### PR TITLE
Add support for Google Extensible Service Proxy

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/EspFriendlyCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/EspFriendlyCredentials.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.google.auth.oauth2;
+
+import com.google.api.client.util.Preconditions;
+import java.util.Objects;
+
+/**
+ * Abstract base class for ESP-friendly credentials.
+ *
+ * Cloud Endpoints' Extensible Service Proxy (ESP), requires JWTs instead of
+ * access tokens.  Subclasses provide the required JWT from the "id_token" of
+ * their refreshed token.
+ */
+public abstract class EspFriendlyCredentials extends GoogleCredentials {
+  protected static final String ACCESS_TOKEN_TYPE = "access_token";
+  protected static final String ID_TOKEN_TYPE = "id_token";
+  protected final String tokenType;
+
+  protected EspFriendlyCredentials(String tokenType) {
+    Preconditions.checkNotNull(tokenType);
+    this.tokenType = tokenType;
+  }
+
+  protected EspFriendlyCredentials(AccessToken accessToken, String tokenType) {
+    super(accessToken);
+    Preconditions.checkNotNull(tokenType);
+    this.tokenType = tokenType;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof EspFriendlyCredentials)) return false;
+    if (!super.equals(o)) return false;
+    EspFriendlyCredentials that = (EspFriendlyCredentials) o;
+    return Objects.equals(tokenType, that.tokenType);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tokenType);
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -128,6 +128,15 @@ public class GoogleCredentials extends OAuth2Credentials {
   }
 
   /**
+   * Returns a copy of credentials that can be used to connect to
+   * Cloud Endpoints' Extensible Service Proxy (ESP), which
+   * requires a JWT instead of an access token.
+   */
+  public static GoogleCredentials forEsp(GoogleCredentials credentials) {
+    return credentials.forEsp();
+  }
+
+  /**
    * Returns credentials defined by a JSON file stream.
    *
    * <p>The stream can contain a Service Account key file in JSON format from the Google Developers
@@ -228,6 +237,16 @@ public class GoogleCredentials extends OAuth2Credentials {
    * otherwise, returns the same instance.
    */
   public GoogleCredentials createDelegated(String user) {
+    return this;
+  }
+
+  /**
+   * If the credentials are to be used to connect to Cloud Endpoints'
+   * Extensible Service Proxy (ESP), creates a copy of the identity so
+   * that it uses the id_token field of a refreshed token which is a JWT;
+   * otherwise, returns the same instance.
+   */
+  public GoogleCredentials forEsp() {
     return this;
   }
 

--- a/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
+++ b/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
@@ -63,10 +63,11 @@ public class HttpCredentialsAdapterTest {
   @Test
   public void initialize_populatesOAuth2Credentials() throws IOException {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    final String idToken = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
     final String expectedAuthorization = InternalAuthHttpConstants.BEARER_PREFIX + accessToken;
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, accessToken, idToken);
 
     OAuth2Credentials credentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
@@ -91,16 +92,20 @@ public class HttpCredentialsAdapterTest {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
     final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
 
+    final String idToken = "1/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
+    final String idToken2 = "2/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
+
     MockTokenServerTransportFactory tokenServerTransportFactory =
         new MockTokenServerTransportFactory();
     tokenServerTransportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    tokenServerTransportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken);
+    tokenServerTransportFactory.transport.addRefreshTokens(REFRESH_TOKEN, accessToken, idToken);
 
     OAuth2Credentials credentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
         .setClientSecret(CLIENT_SECRET)
         .setRefreshToken(REFRESH_TOKEN)
         .setHttpTransportFactory(tokenServerTransportFactory)
+//        .forEsp()
         .build();
 
     credentials.refresh();
@@ -114,7 +119,7 @@ public class HttpCredentialsAdapterTest {
 
     // now switch out the access token so that the original one is invalid,
     //   requiring a refresh of the access token
-    tokenServerTransportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+    tokenServerTransportFactory.transport.addRefreshTokens(REFRESH_TOKEN, accessToken2, idToken2);
 
     HttpResponse response = request.execute();
 
@@ -126,11 +131,12 @@ public class HttpCredentialsAdapterTest {
   @Test
   public void initialize_noURI() throws IOException {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    final String idToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
     final String expectedAuthorization = InternalAuthHttpConstants.BEARER_PREFIX + accessToken;
     MockTokenServerTransportFactory tokenServerTransportFactory =
         new MockTokenServerTransportFactory();
     tokenServerTransportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    tokenServerTransportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken);
+    tokenServerTransportFactory.transport.addRefreshTokens(REFRESH_TOKEN, accessToken, idToken);
 
     OAuth2Credentials credentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -73,6 +73,7 @@ public class DefaultCredentialsProviderTest {
   private static final String USER_CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";
   private static final String REFRESH_TOKEN = "1/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final String ID_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
   private static final String SA_CLIENT_EMAIL =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
   private static final String SA_CLIENT_ID =
@@ -289,7 +290,7 @@ public class DefaultCredentialsProviderTest {
   @Test
   public void getDefaultCredentials_envServiceAccount_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     InputStream serviceAccountStream = ServiceAccountCredentialsTest
         .writeServiceAccountStream(
             SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
@@ -305,6 +306,12 @@ public class DefaultCredentialsProviderTest {
     defaultCredentials = defaultCredentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = defaultCredentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+
+    GoogleCredentials defaultCredentialsForEsp = defaultCredentials.forEsp();
+
+    defaultCredentialsForEsp = defaultCredentialsForEsp.createScoped(SCOPES);
+    metadata = defaultCredentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN);
   }
 
   @Test
@@ -408,8 +415,10 @@ public class DefaultCredentialsProviderTest {
   public void getDefaultCredentials_envAndWellKnownFile_envPrecedence() throws IOException {
     final String refreshTokenEnv = "2/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
     final String accessTokenEnv = "2/MkSJoj1xsli0AccessToken_NKPY2";
+    final String idTokenEnv = "2/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
     final String refreshTokenWkf = "3/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
     final String accessTokenWkf = "3/MkSJoj1xsli0AccessToken_NKPY2";
+    final String idTokenWkf = "3/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
 
     InputStream envStream =
@@ -431,10 +440,10 @@ public class DefaultCredentialsProviderTest {
 
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(USER_CLIENT_ID, USER_CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(refreshTokenWkf, accessTokenWkf);
-    transportFactory.transport.addRefreshToken(refreshTokenEnv, accessTokenEnv);
+    transportFactory.transport.addRefreshTokens(refreshTokenWkf, accessTokenWkf, idTokenWkf);
+    transportFactory.transport.addRefreshTokens(refreshTokenEnv, accessTokenEnv, idTokenEnv);
 
-    testUserProvidesToken(testProvider, transportFactory, accessTokenEnv);
+    testUserProvidesToken(testProvider, transportFactory, accessTokenEnv, idTokenEnv);
   }
 
   private static File getTempDirectory() {
@@ -445,17 +454,25 @@ public class DefaultCredentialsProviderTest {
       String clientSecret, String refreshToken) throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(clientId, clientSecret);
-    transportFactory.transport.addRefreshToken(refreshToken, ACCESS_TOKEN);
-    testUserProvidesToken(testProvider, transportFactory, ACCESS_TOKEN);
+    transportFactory.transport.addRefreshTokens(refreshToken, ACCESS_TOKEN, ID_TOKEN);
+    testUserProvidesToken(testProvider, transportFactory, ACCESS_TOKEN, ID_TOKEN);
   }
 
   private void testUserProvidesToken(TestDefaultCredentialsProvider testProvider,
-      HttpTransportFactory transportFactory, String accessToken) throws IOException {
+      HttpTransportFactory transportFactory,
+      String accessToken, String idToken) throws IOException {
     GoogleCredentials defaultCredentials = testProvider.getDefaultCredentials(transportFactory);
 
     assertNotNull(defaultCredentials);
     Map<String, List<String>> metadata = defaultCredentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, accessToken);
+
+    GoogleCredentials defaultCredentialsForEsp =
+        testProvider.getDefaultCredentials(transportFactory).forEsp();
+
+    assertNotNull(defaultCredentialsForEsp);
+    metadata = defaultCredentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, idToken);
   }
 
   public static class MockAppEngineCredentials extends GoogleCredentials {

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -147,12 +147,22 @@ public class GoogleCredentialsTest {
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+  }
 
-    GoogleCredentials credentialsForEsp = credentials.forEsp();
+  @Test
+  public void fromStream_serviceAccount_providesToken_forEsp() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
+    InputStream serviceAccountStream = ServiceAccountCredentialsTest
+        .writeServiceAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
-    assertNotNull(credentialsForEsp);
-    credentialsForEsp = credentialsForEsp.createScoped(SCOPES);
-    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    GoogleCredentials credentials =
+        GoogleCredentials.fromStream(serviceAccountStream, transportFactory).forEsp();
+
+    assertNotNull(credentials);
+    credentials = credentials.createScoped(SCOPES);
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ID_TOKEN);
   }
 
@@ -201,10 +211,21 @@ public class GoogleCredentialsTest {
     assertNotNull(credentials);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+  }
 
-    GoogleCredentials credentialsForEsp = credentials.forEsp();
+  @Test
+  public void fromStream_user_providesToken_forEsp() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addClient(USER_CLIENT_ID, USER_CLIENT_SECRET);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN, ID_TOKEN);
+    InputStream userStream =
+        UserCredentialsTest.writeUserStream(USER_CLIENT_ID, USER_CLIENT_SECRET, REFRESH_TOKEN);
 
-    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    GoogleCredentials credentials =
+        GoogleCredentials.fromStream(userStream, transportFactory).forEsp();
+
+    assertNotNull(credentials);
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ID_TOKEN);
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -45,7 +45,6 @@ import com.google.auth.TestUtils;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayDeque;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,8 +57,8 @@ public class MockTokenServerTransport extends MockHttpTransport {
   static final JsonFactory JSON_FACTORY = new JacksonFactory();
   int buildRequestCount;
   final Map<String, String> clients = new HashMap<String, String>();
-  final Map<String, String> refreshTokens = new HashMap<String, String>();
-  final Map<String, String> serviceAccounts = new HashMap<String, String>();
+  final Map<String, RefreshedTokens> refreshTokens = new HashMap<String, RefreshedTokens>();
+  final Map<String, RefreshedTokens> serviceAccounts = new HashMap<String, RefreshedTokens>();
   final Map<String, String> codes = new HashMap<String, String>();
   URI tokenServerUri = OAuth2Utils.TOKEN_SERVER_URI;
   private IOException error;
@@ -79,23 +78,27 @@ public class MockTokenServerTransport extends MockHttpTransport {
 
   public void addAuthorizationCode(String code, String refreshToken, String accessToken) {
     codes.put(code, refreshToken);
-    refreshTokens.put(refreshToken, accessToken);
+    refreshTokens.put(refreshToken, new RefreshedTokens(accessToken));
   }
 
   public void addClient(String clientId, String clientSecret) {
     clients.put(clientId, clientSecret);
   }
 
-  public void addRefreshToken(String refreshToken, String accessTokenToReturn) {
-    refreshTokens.put(refreshToken, accessTokenToReturn);
+  public void addRefreshAccessToken(String refreshToken, String accessTokenToReturn) {
+    refreshTokens.put(refreshToken, new RefreshedTokens(accessTokenToReturn));
   }
 
-  public void addServiceAccount(String email, String accessToken) {
-    serviceAccounts.put(email, accessToken);
+  public void addRefreshTokens(String refreshToken, String accessTokenToReturn, String idTokenToReturn) {
+    refreshTokens.put(refreshToken, new RefreshedTokens(accessTokenToReturn, idTokenToReturn));
+  }
+
+  public void addServiceAccount(String email, String accessToken, String idToken) {
+    serviceAccounts.put(email, new RefreshedTokens(accessToken, idToken));
   }
 
   public String getAccessToken(String refreshToken) {
-    return refreshTokens.get(refreshToken);
+    return refreshTokens.get(refreshToken).accessToken;
   }
 
   public void setError(IOException error) {
@@ -142,6 +145,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
           String content = this.getContentAsString();
           Map<String, String> query = TestUtils.parseQuery(content);
           String accessToken;
+          String idToken = null;
           String refreshToken = null;
 
           String foundId = query.get("client_id");
@@ -167,7 +171,8 @@ public class MockTokenServerTransport extends MockHttpTransport {
             if (!refreshTokens.containsKey(refreshToken)) {
               throw new IOException("Refresh Token not found.");
             }
-            accessToken = refreshTokens.get(refreshToken);
+            accessToken = refreshTokens.get(refreshToken).accessToken;
+            idToken = refreshTokens.get(refreshToken).idToken;
           } else if (query.containsKey("grant_type")) {
             String grantType = query.get("grant_type");
             if (!EXPECTED_GRANT_TYPE.equals(grantType)) {
@@ -179,7 +184,8 @@ public class MockTokenServerTransport extends MockHttpTransport {
             if (!serviceAccounts.containsKey(foundEmail)) {
               throw new IOException("Service Account Email not found as issuer.");
             }
-            accessToken = serviceAccounts.get(foundEmail);
+            accessToken = serviceAccounts.get(foundEmail).accessToken;
+            idToken = serviceAccounts.get(foundEmail).idToken;
             String foundScopes = (String) signature.getPayload().get("scope");
             if (foundScopes == null || foundScopes.length() == 0) {
               throw new IOException("Scopes not found.");
@@ -192,6 +198,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
           GenericJson refreshContents = new GenericJson();
           refreshContents.setFactory(JSON_FACTORY);
           refreshContents.put("access_token", accessToken);
+          refreshContents.put("id_token", idToken);
           refreshContents.put("expires_in", expiresInSeconds);
           refreshContents.put("token_type", "Bearer");
           if (refreshToken != null) {
@@ -221,5 +228,22 @@ public class MockTokenServerTransport extends MockHttpTransport {
       };
     }
     return super.buildRequest(method, url);
+  }
+
+  private static class RefreshedTokens {
+    static final String IGNORED = null;
+
+    private String accessToken;
+    private String idToken;
+
+    public RefreshedTokens(String accessToken) {
+      this.accessToken = accessToken;
+      this.idToken = IGNORED;
+    }
+
+    public RefreshedTokens(String accessToken, String idToken) {
+      this.accessToken = accessToken;
+      this.idToken = idToken;
+    }
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
@@ -66,6 +66,10 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
   private static final String CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";
   private static final String REFRESH_TOKEN = "1/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
   private static final String ACCESS_TOKEN = "aashpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
+  private static final String ACCESS_TOKEN_1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final String ACCESS_TOKEN_2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final String ID_TOKEN_1 = "1/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
+  private static final String ID_TOKEN_2 = "2/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
 
   @Test
@@ -108,11 +112,9 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
   @Test
   public void addChangeListener_notifiesOnRefresh() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
     OAuth2Credentials userCredentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
         .setClientSecret(CLIENT_SECRET)
@@ -128,28 +130,51 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
     // Get a first token
     metadata = userCredentials.getRequestMetadata(CALL_URI);
-    TestUtils.assertContainsBearerToken(metadata, accessToken1);
-    assertEquals(accessToken1, listener.accessToken.getTokenValue());
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_1);
+    assertEquals(ACCESS_TOKEN_1, listener.accessToken.getTokenValue());
     assertEquals(1, listener.callCount);
 
     // Change server to a different token and refresh
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
     // Refresh to force getting next token
     userCredentials.refresh();
 
     metadata = userCredentials.getRequestMetadata(CALL_URI);
-    TestUtils.assertContainsBearerToken(metadata, accessToken2);
-    assertEquals(accessToken2, listener.accessToken.getTokenValue());
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_2);
+    assertEquals(ACCESS_TOKEN_2, listener.accessToken.getTokenValue());
+    assertEquals(2, listener.callCount);
+
+    OAuth2Credentials userCredentialsForEsp = ((UserCredentials) userCredentials).forEsp();
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
+
+    // Use a fixed clock so tokens don't expire
+    userCredentialsForEsp.clock = new TestClock();
+    listener = new TestChangeListener();
+    userCredentialsForEsp.addChangeListener(listener);
+    assertEquals(0, listener.callCount);
+
+    // Get a first token
+    metadata = userCredentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_1);
+    assertEquals(ID_TOKEN_1, listener.accessToken.getTokenValue());
+    assertEquals(1, listener.callCount);
+
+    // Change server to a different token and refresh
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
+    // Refresh to force getting next token
+    userCredentialsForEsp.refresh();
+
+    metadata = userCredentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_2);
+    assertEquals(ID_TOKEN_2, listener.accessToken.getTokenValue());
     assertEquals(2, listener.callCount);
   }
 
   @Test
   public void removeChangeListener_unregisters_observer() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
     OAuth2Credentials userCredentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
         .setClientSecret(CLIENT_SECRET)
@@ -167,25 +192,48 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     assertEquals(1, listener.callCount);
 
     // Change server to a different token and refresh
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
     // Refresh to force getting next token
     userCredentials.refresh();
     assertEquals(2, listener.callCount);
 
     // Remove the listener and refresh the credential again
     userCredentials.removeChangeListener(listener);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
     userCredentials.refresh();
+    assertEquals(2, listener.callCount);
+
+    OAuth2Credentials userCredentialsForEsp = ((UserCredentials) userCredentials).forEsp();
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
+
+    // Use a fixed clock so tokens don't expire
+    userCredentialsForEsp.clock = new TestClock();
+    listener = new TestChangeListener();
+    userCredentialsForEsp.addChangeListener(listener);
+    assertEquals(0, listener.callCount);
+
+    // Get a first token
+    userCredentialsForEsp.getRequestMetadata(CALL_URI);
+    assertEquals(1, listener.callCount);
+
+    // Change server to a different token and refresh
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
+    // Refresh to force getting next token
+    userCredentialsForEsp.refresh();
+    assertEquals(2, listener.callCount);
+
+    // Remove the listener and refresh the credential again
+    userCredentialsForEsp.removeChangeListener(listener);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
+    userCredentialsForEsp.refresh();
     assertEquals(2, listener.callCount);
   }
 
   @Test
   public void getRequestMetadata_blocking_cachesExpiringToken() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
     TestClock clock = new TestClock();
     OAuth2Credentials credentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
@@ -198,11 +246,11 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     // Verify getting the first token
     assertEquals(0, transportFactory.transport.buildRequestCount);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
-    TestUtils.assertContainsBearerToken(metadata, accessToken1);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_1);
     assertEquals(1, transportFactory.transport.buildRequestCount--);
 
     // Change server to a different token
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
 
     // Make transport fail when used next time.
     IOException error = new IOException("error");
@@ -211,7 +259,7 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     // Advance 5 minutes and verify original token
     clock.addToCurrentTime(5 * 60 * 1000);
     metadata = credentials.getRequestMetadata(CALL_URI);
-    TestUtils.assertContainsBearerToken(metadata, accessToken1);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_1);
 
     // Advance 60 minutes and verify revised token
     clock.addToCurrentTime(60 * 60 * 1000);
@@ -228,17 +276,55 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     // Reset the error and try again
     transportFactory.transport.setError(null);
     metadata = credentials.getRequestMetadata(CALL_URI);
-    TestUtils.assertContainsBearerToken(metadata, accessToken2);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_2);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+
+    OAuth2Credentials credentialsForEsp = ((UserCredentials) credentials).forEsp();
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
+    credentialsForEsp.clock = clock = new TestClock();
+
+    // Verify getting the first token
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_1);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+
+    // Change server to a different token
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
+
+    // Make transport fail when used next time.
+    error = new IOException("error");
+    transportFactory.transport.setError(error);
+
+    // Advance 5 minutes and verify original token
+    clock.addToCurrentTime(5 * 60 * 1000);
+    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_1);
+
+    // Advance 60 minutes and verify revised token
+    clock.addToCurrentTime(60 * 60 * 1000);
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+
+    try {
+      credentialsForEsp.getRequestMetadata(CALL_URI);
+      fail("Should throw");
+    } catch (IOException e) {
+      assertSame(error, e);
+      assertEquals(1, transportFactory.transport.buildRequestCount--);
+    }
+
+    // Reset the error and try again
+    transportFactory.transport.setError(null);
+    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_2);
     assertEquals(1, transportFactory.transport.buildRequestCount--);
   }
 
   @Test
   public void getRequestMetadata_async() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
     TestClock clock = new TestClock();
     OAuth2Credentials credentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
@@ -258,11 +344,11 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
     assertEquals(1, executor.runTasksExhaustively());
     assertNotNull(callback.metadata);
-    TestUtils.assertContainsBearerToken(callback.metadata, accessToken1);
+    TestUtils.assertContainsBearerToken(callback.metadata, ACCESS_TOKEN_1);
     assertEquals(1, transportFactory.transport.buildRequestCount--);
 
     // Change server to a different token
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
 
     // Make transport fail when used next time.
     IOException error = new IOException("error");
@@ -275,7 +361,7 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     credentials.getRequestMetadata(CALL_URI, executor, callback);
     assertNotNull(callback.metadata);
     assertEquals(0, executor.numTasks());
-    TestUtils.assertContainsBearerToken(callback.metadata, accessToken1);
+    TestUtils.assertContainsBearerToken(callback.metadata, ACCESS_TOKEN_1);
 
     // Advance 60 minutes and verify revised token, which uses the executor.
     callback.reset();
@@ -297,16 +383,71 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
     assertEquals(1, executor.runTasksExhaustively());
     assertNotNull(callback.metadata);
-    TestUtils.assertContainsBearerToken(callback.metadata, accessToken2);
+    TestUtils.assertContainsBearerToken(callback.metadata, ACCESS_TOKEN_2);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+
+    OAuth2Credentials credentialsForEsp = ((UserCredentials) credentials).forEsp();
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
+    credentialsForEsp.clock = clock = new TestClock();
+    executor = new MockExecutor();
+    callback = new MockRequestMetadataCallback();
+
+    // Verify getting the first token, which uses the transport and calls the callback in the
+    // executor.
+    credentialsForEsp.getRequestMetadata(CALL_URI, executor, callback);
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+    assertNull(callback.metadata);
+
+    assertEquals(1, executor.runTasksExhaustively());
+    assertNotNull(callback.metadata);
+    TestUtils.assertContainsBearerToken(callback.metadata, ID_TOKEN_1);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+
+    // Change server to a different token
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
+
+    // Make transport fail when used next time.
+    error = new IOException("error");
+    transportFactory.transport.setError(error);
+
+    // Advance 5 minutes and verify original token. Callback is called inline.
+    callback.reset();
+    clock.addToCurrentTime(5 * 60 * 1000);
+    assertNull(callback.metadata);
+    credentialsForEsp.getRequestMetadata(CALL_URI, executor, callback);
+    assertNotNull(callback.metadata);
+    assertEquals(0, executor.numTasks());
+    TestUtils.assertContainsBearerToken(callback.metadata, ID_TOKEN_1);
+
+    // Advance 60 minutes and verify revised token, which uses the executor.
+    callback.reset();
+    clock.addToCurrentTime(60 * 60 * 1000);
+    credentialsForEsp.getRequestMetadata(CALL_URI, executor, callback);
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+    assertNull(callback.exception);
+
+    assertEquals(1, executor.runTasksExhaustively());
+    assertSame(error, callback.exception);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+
+    // Reset the error and try again
+    transportFactory.transport.setError(null);
+    callback.reset();
+    credentialsForEsp.getRequestMetadata(CALL_URI, executor, callback);
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+    assertNull(callback.metadata);
+
+    assertEquals(1, executor.runTasksExhaustively());
+    assertNotNull(callback.metadata);
+    TestUtils.assertContainsBearerToken(callback.metadata, ID_TOKEN_2);
     assertEquals(1, transportFactory.transport.buildRequestCount--);
   }
 
   @Test
   public void getRequestMetadata_async_refreshRace() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
     TestClock clock = new TestClock();
     OAuth2Credentials credentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
@@ -327,7 +468,28 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     assertEquals(1, executor.numTasks());
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertEquals(1, transportFactory.transport.buildRequestCount--);
-    TestUtils.assertContainsBearerToken(metadata, accessToken1);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_1);
+
+    // When the task is run, the cached data is used.
+    assertEquals(1, executor.runTasksExhaustively());
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+    assertSame(metadata, callback.metadata);
+
+    OAuth2Credentials credentialsForEsp = ((UserCredentials) credentials).forEsp();
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
+    executor = new MockExecutor();
+    callback = new MockRequestMetadataCallback();
+
+    // Getting the first token, which uses the transport and calls the callback in the executor.
+    credentialsForEsp.getRequestMetadata(CALL_URI, executor, callback);
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+    assertNull(callback.metadata);
+
+    // Asynchronous task is scheduled, but beaten by another blocking get call.
+    assertEquals(1, executor.numTasks());
+    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_1);
 
     // When the task is run, the cached data is used.
     assertEquals(1, executor.runTasksExhaustively());
@@ -348,11 +510,9 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
   @Test
   public void refresh_refreshesToken() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken1);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
     OAuth2Credentials userCredentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
         .setClientSecret(CLIENT_SECRET)
@@ -364,20 +524,42 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
 
     // Get a first token
     Map<String, List<String>> metadata = userCredentials.getRequestMetadata(CALL_URI);
-    TestUtils.assertContainsBearerToken(metadata, accessToken1);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_1);
     assertEquals(1, transportFactory.transport.buildRequestCount--);
 
     // Change server to a different token
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessToken2);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
 
     // Confirm token being cached
-    TestUtils.assertContainsBearerToken(metadata, accessToken1);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_1);
     assertEquals(0, transportFactory.transport.buildRequestCount);
 
     // Refresh to force getting next token
     userCredentials.refresh();
     metadata = userCredentials.getRequestMetadata(CALL_URI);
-    TestUtils.assertContainsBearerToken(metadata, accessToken2);
+    TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN_2);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+
+
+    OAuth2Credentials userCredentialsForEsp = ((UserCredentials) userCredentials).forEsp();
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_1, ID_TOKEN_1);
+
+    // Get a first token
+    metadata = userCredentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_1);
+    assertEquals(1, transportFactory.transport.buildRequestCount--);
+
+    // Change server to a different token
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN_2, ID_TOKEN_2);
+
+    // Confirm token being cached
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_1);
+    assertEquals(0, transportFactory.transport.buildRequestCount);
+
+    // Refresh to force getting next token
+    userCredentialsForEsp.refresh();
+    metadata = userCredentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN_2);
     assertEquals(1, transportFactory.transport.buildRequestCount--);
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -98,6 +98,11 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
       + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
       + "==\n-----END PRIVATE KEY-----\n";
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final String ID_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
+  private static final String ACCESS_TOKEN_1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final String ACCESS_TOKEN_2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final String ID_TOKEN_1 = "1/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
+  private static final String ID_TOKEN_2 = "2/eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
   private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
   private static final String SERVICE_ACCOUNT_USER = "user@example.com";
   private static final String PROJECT_ID = "project-id";
@@ -193,7 +198,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_enablesAccessTokens() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     GoogleCredentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
         SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null, transportFactory, null);
 
@@ -229,7 +234,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void fromJSON_getProjectId() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     GenericJson json = writeServiceAccountJson(
         SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
 
@@ -240,7 +245,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void fromJSON_getProjectIdNull() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     GenericJson json = writeServiceAccountJson(
         SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
 
@@ -251,7 +256,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void fromJSON_hasAccessToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     GenericJson json = writeServiceAccountJson(
         SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
 
@@ -260,25 +265,35 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+
+    GoogleCredentials credentialsForEsp = credentials.forEsp();
+
+    credentialsForEsp = credentialsForEsp.createScoped(SCOPES);
+    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN);
   }
 
   @Test
   public void getRequestMetadata_hasAccessToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
         SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory, null);
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+
+    OAuth2Credentials credentialsForEsp = ((ServiceAccountCredentials) credentials).forEsp();
+    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN);
   }
 
   @Test
   public void getRequestMetadata_customTokenServer_hasAccessToken() throws IOException {
     final URI TOKEN_SERVER = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     transportFactory.transport.setTokenServerUri(TOKEN_SERVER);
     OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
         SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
@@ -287,12 +302,14 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
+
+    OAuth2Credentials credentialsForEsp = ((ServiceAccountCredentials) credentials).forEsp();
+    metadata = credentialsForEsp.getRequestMetadata(CALL_URI);
+    TestUtils.assertContainsBearerToken(metadata, ID_TOKEN);
   }
 
   @Test
   public void refreshAccessToken_refreshesToken() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
@@ -305,17 +322,25 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             transportFactory,
             null);
 
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken1);
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_1);
 
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken2);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
     credentials.refresh();
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken2);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_2);
+
+    ServiceAccountCredentials credentialsForEsp = (ServiceAccountCredentials) credentials.forEsp();
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_1);
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
+    credentialsForEsp.refresh();
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_2);
   }
 
   @Test
   public void refreshAccessToken_tokenExpiry() throws IOException {
-    final String tokenString = "1/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
@@ -329,22 +354,36 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             null);
     credentials.clock = new FixedClock(0L);
 
-    transport.addServiceAccount(SA_CLIENT_EMAIL, tokenString);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     AccessToken accessToken = credentials.refreshAccessToken();
-    assertEquals(tokenString, accessToken.getTokenValue());
+    assertEquals(ACCESS_TOKEN, accessToken.getTokenValue());
     assertEquals(3600 * 1000L, accessToken.getExpirationTimeMillis().longValue());
 
     // Test for large expires_in values (should not overflow).
     transport.setExpiresInSeconds(3600 * 1000);
     accessToken = credentials.refreshAccessToken();
-    assertEquals(tokenString, accessToken.getTokenValue());
+    assertEquals(ACCESS_TOKEN, accessToken.getTokenValue());
+    assertEquals(3600 * 1000 * 1000L, accessToken.getExpirationTimeMillis().longValue());
+
+    ServiceAccountCredentials credentialsForEsp = (ServiceAccountCredentials) credentials.forEsp();
+    // reset time
+    credentialsForEsp.clock = new FixedClock(0L);
+    transport.setExpiresInSeconds(3600);
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
+    accessToken = credentialsForEsp.refreshAccessToken();
+    assertEquals(ID_TOKEN, accessToken.getTokenValue());
+    assertEquals(3600 * 1000L, accessToken.getExpirationTimeMillis().longValue());
+
+    // Test for large expires_in values (should not overflow).
+    transport.setExpiresInSeconds(3600 * 1000);
+    accessToken = credentialsForEsp.refreshAccessToken();
+    assertEquals(ID_TOKEN, accessToken.getTokenValue());
     assertEquals(3600 * 1000 * 1000L, accessToken.getExpirationTimeMillis().longValue());
   }
 
   @Test
   public void refreshAccessToken_retriesIOException() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
@@ -357,19 +396,27 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             transportFactory,
             null);
 
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken1);
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_1);
 
     transport.addResponseErrorSequence(new IOException());
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken2);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
     credentials.refresh();
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken2);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_2);
+
+    ServiceAccountCredentials credentialsForEsp = (ServiceAccountCredentials) credentials.forEsp();
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_1);
+
+    transport.addResponseErrorSequence(new IOException());
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
+    credentialsForEsp.refresh();
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_2);
   }
 
   @Test
   public void refreshAccessToken_retriesForbiddenError() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
@@ -382,19 +429,27 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             transportFactory,
             null);
 
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken1);
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_1);
 
     transport.addResponseSequence(new MockLowLevelHttpResponse().setStatusCode(403));
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken2);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
     credentials.refresh();
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken2);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_2);
+
+    ServiceAccountCredentials credentialsForEsp = (ServiceAccountCredentials) credentials.forEsp();
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_1);
+
+    transport.addResponseSequence(new MockLowLevelHttpResponse().setStatusCode(403));
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
+    credentialsForEsp.refresh();
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_2);
   }
 
   @Test
   public void refreshAccessToken_retriesServerError() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
@@ -407,19 +462,27 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             transportFactory,
             null);
 
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken1);
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_1);
 
     transport.addResponseSequence(new MockLowLevelHttpResponse().setStatusCode(500));
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken2);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
     credentials.refresh();
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken2);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_2);
+
+    ServiceAccountCredentials credentialsForEsp = (ServiceAccountCredentials) credentials.forEsp();
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_1);
+
+    transport.addResponseSequence(new MockLowLevelHttpResponse().setStatusCode(500));
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
+    credentialsForEsp.refresh();
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_2);
   }
 
   @Test
   public void refreshAccessToken_failsNotFoundError() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
-    final String accessToken2 = "2/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
@@ -432,13 +495,27 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             transportFactory,
             null);
 
-    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken1);
-    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), ACCESS_TOKEN_1);
 
     try {
       transport.addResponseSequence(new MockLowLevelHttpResponse().setStatusCode(404));
-      transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken2);
+      transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
       credentials.refresh();
+      fail("Should not retry on Not Found");
+    } catch (IOException expected) {
+      // Expected
+    }
+
+    ServiceAccountCredentials credentialsForEsp = (ServiceAccountCredentials) credentials.forEsp();
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_1, ID_TOKEN_1);
+    TestUtils.assertContainsBearerToken(credentialsForEsp.getRequestMetadata(CALL_URI), ID_TOKEN_1);
+
+    try {
+      transport.addResponseSequence(new MockLowLevelHttpResponse().setStatusCode(404));
+      transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN_2, ID_TOKEN_2);
+      credentialsForEsp.refresh();
       fail("Should not retry on Not Found");
     } catch (IOException expected) {
       // Expected
@@ -585,11 +662,13 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
         tokenServer, SERVICE_ACCOUNT_USER);
     String expectedToString = String.format(
         "ServiceAccountCredentials{clientId=%s, clientEmail=%s, privateKeyId=%s, "
-            + "transportFactoryClassName=%s, tokenServerUri=%s, scopes=%s, serviceAccountUser=%s}",
+            + "transportFactoryClassName=%s, tokenType=%s, tokenServerUri=%s, "
+            + "scopes=%s, serviceAccountUser=%s}",
         SA_CLIENT_ID,
         SA_CLIENT_EMAIL,
         SA_PRIVATE_KEY_ID,
         MockTokenServerTransportFactory.class.getName(),
+        "access_token",
         tokenServer,
         SCOPES,
         SERVICE_ACCOUNT_USER);
@@ -650,7 +729,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   @Test
   public void fromStream_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN, ID_TOKEN);
     InputStream serviceAccountStream = writeServiceAccountStream(
         SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -224,7 +224,7 @@ public class UserAuthorizerTest {
         new AccessToken(accessTokenValue1, new Date(EXPIRATION_TIME));
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessTokenValue2);
+    transportFactory.transport.addRefreshAccessToken(REFRESH_TOKEN, accessTokenValue2);
     TokenStore tokenStore = new MemoryTokensStorage();
     UserAuthorizer authorizer = UserAuthorizer.newBuilder()
         .setClientId(CLIENT_ID)
@@ -313,7 +313,7 @@ public class UserAuthorizerTest {
     assertEquals(accessTokenValue1, credentials1.getAccessToken().getTokenValue());
 
     // Refresh the token to get update from token server
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessTokenValue2);
+    transportFactory.transport.addRefreshAccessToken(REFRESH_TOKEN, accessTokenValue2);
     credentials1.refresh();
     assertEquals(REFRESH_TOKEN, credentials1.getRefreshToken());
     assertEquals(accessTokenValue2, credentials1.getAccessToken().getTokenValue());
@@ -353,7 +353,7 @@ public class UserAuthorizerTest {
     TokenStore tokenStore = new MemoryTokensStorage();
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN_VALUE);
+    transportFactory.transport.addRefreshAccessToken(REFRESH_TOKEN, ACCESS_TOKEN_VALUE);
     UserCredentials initialCredentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID_VALUE)
         .setClientSecret(CLIENT_SECRET)

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -72,6 +72,7 @@ public class UserCredentialsTest extends BaseSerializationTest {
   private static final String CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";
   private static final String REFRESH_TOKEN = "1/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final String ID_TOKEN = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjU0MjViYjg0NjE2ZWJmOTczYWU4MGJjNjJhYzY4OGQyYTcyNzE1YWQifQ.eyJhenAiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI4ODIwMzQ1NDEwMzctYjM5a3B2OWU4M2d2MmVzNnAyY243bG5lb3E0aHVqMDAuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDY5NTgzMjUxNzYwMTY0MzYyOTYiLCJoZCI6Im5pYW50aWNsYWJzLmNvbSIsImVtYWlsIjoiYWNhYnJlcmFAbmlhbnRpY2xhYnMuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImF0X2hhc2giOiJzMGVzY1VZc0RMb09UUlptRkRKS0FnIiwibm9uY2UiOiJOMC41MDA5MzE4NDMxMDYzNTYxMTUyNDMyNjU0Nzg2MyIsImV4cCI6MTUyNDMzMDE0OCwiaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwianRpIjoiYTU4Y2JlYjBlNWJkMmUxZDRlY2M3MmQ3MjljOGRlZjViNzdiNDYyMCIsImlhdCI6MTUyNDMyNjU0OCwibmFtZSI6IkFsYW4gQ2FicmVyYSIsInBpY3R1cmUiOiJodHRwczovL2xoMy5nb29nbGV1c2VyY29udGVudC5jb20vLTRjTjQ0cUEteUNrL0FBQUFBQUFBQUFJL0FBQUFBQUFBQUFjL2p0UUtQcVpDWGRjL3M5Ni1jL3Bob3RvLmpwZyIsImdpdmVuX25hbWUiOiJBbGFuIiwiZmFtaWx5X25hbWUiOiJDYWJyZXJhIiwibG9jYWxlIjoiZW4ifQ.Ro3ru4YuhPIQqDLIQiGp81Pha1hMVxFfeaeIIrEgZbp9-UG8I6cZEqlhLpOeLCJP3bQk5r9sHAZLUY_eoG-i_OBicX5g3Kos643ZMXgBPxLHRQcwAJfhlpwzLS-dxrYCqUOMw2JQUDji0KSIzTDREbO7r_54agvEn4WWYTxuj2jyBxm66GkiigNzCIfp1n3BQ5O94yGU77DUjA2o6SXaPVh82IwrNDXpp8wnRXtY_jzCMS5k8pAs8f62EqFUSZfJO6MwV7QG7SZ460ORWNV3zJiuaWx2UhStis6cjVxxaB6LiR5pDa4QvKLmyysXc6EeZ12h8EOgcP4C_EDSWmUmnA";
   private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
 
@@ -117,7 +118,7 @@ public class UserCredentialsTest extends BaseSerializationTest {
   public void fromJson_hasAccessToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN, ID_TOKEN);
     GenericJson json = writeUserJson(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
 
     GoogleCredentials credentials = UserCredentials.fromJson(json, transportFactory);
@@ -167,7 +168,7 @@ public class UserCredentialsTest extends BaseSerializationTest {
   public void getRequestMetadata_fromRefreshToken_hasAccessToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN, ID_TOKEN);
     UserCredentials userCredentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
         .setClientSecret(CLIENT_SECRET)
@@ -185,7 +186,7 @@ public class UserCredentialsTest extends BaseSerializationTest {
     final URI TOKEN_SERVER = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN, ID_TOKEN);
     transportFactory.transport.setTokenServerUri(TOKEN_SERVER);
     UserCredentials userCredentials = UserCredentials.newBuilder()
         .setClientId(CLIENT_ID)
@@ -393,12 +394,13 @@ public class UserCredentialsTest extends BaseSerializationTest {
         .build();
 
     String expectedToString = String.format(
-        "UserCredentials{requestMetadata=%s, temporaryAccess=%s, clientId=%s, refreshToken=%s, "
-            + "tokenServerUri=%s, transportFactoryClassName=%s}",
+        "UserCredentials{requestMetadata=%s, temporaryAccess=%s, clientId=%s, "
+            + "tokenType=%s, refreshToken=%s, tokenServerUri=%s, transportFactoryClassName=%s}",
         ImmutableMap.of(AuthHttpConstants.AUTHORIZATION,
             ImmutableList.of(OAuth2Utils.BEARER_PREFIX + accessToken.getTokenValue())),
         accessToken.toString(),
         CLIENT_ID,
+        "access_token",
         REFRESH_TOKEN,
         tokenServer,
         MockTokenServerTransportFactory.class.getName());
@@ -475,7 +477,7 @@ public class UserCredentialsTest extends BaseSerializationTest {
   public void fromStream_user_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
-    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+    transportFactory.transport.addRefreshTokens(REFRESH_TOKEN, ACCESS_TOKEN, ID_TOKEN);
     InputStream userStream = writeUserStream(CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN);
 
     UserCredentials credentials = UserCredentials.fromStream(userStream, transportFactory);


### PR DESCRIPTION
Cloud Endpoints' Extensible Service Proxy only takes JWTs, not access tokens.  This
change provides the ability to trasform UserCredentials and ServiceAccountCredentals
such that they provide JWTs as bearer tokens.

[CCLA](https://cla.developers.google.com/about/google-corporate) is in the works.  I thought I'd get the ball rolling with the review.