### PR TITLE
add App Engine API to pom.xml with test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine</artifactId>
+        <version>1.9.64</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-oauth2-http</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
I'm not totally clear on why this dependency isn't already in the pom.xml (maybe with scope provided?) but in any case this will make the tests pass and moots #187 

fix #187 
