### PR TITLE
Remove deprecated methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,16 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.10.0</version>
+  <version>0.11.0</version>
 </dependency>
 ```
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.10.0'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.11.0'
 ```
 If you are using SBT, add this to your dependencies
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.10.0"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.11.0"
 ```
 
 ## google-auth-library-credentials

--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -62,21 +62,7 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
 
   private transient AppIdentityService appIdentityService;
 
-  /**
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public AppEngineCredentials(Collection<String> scopes) {
-    this(scopes, null);
-  }
-
-  /**
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public AppEngineCredentials(Collection<String> scopes, AppIdentityService appIdentityService) {
+  private AppEngineCredentials(Collection<String> scopes, AppIdentityService appIdentityService) {
     this.scopes = scopes == null ? ImmutableSet.<String>of() : ImmutableList.copyOf(scopes);
     this.appIdentityService = appIdentityService != null ? appIdentityService 
         : AppIdentityServiceFactory.getAppIdentityService();

--- a/oauth2_http/java/com/google/auth/oauth2/ClientId.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ClientId.java
@@ -135,11 +135,8 @@ public class ClientId {
    *
    * @param clientId Text identifier of the Client ID.
    * @param clientSecret Secret to associated with the Client ID.
-   * @deprecated Use {@link #of(String, String)} instead. This constructor will either be deleted
-   *             or made private in a later version.
    */
-  @Deprecated
-  public ClientId(String clientId, String clientSecret) {
+  private ClientId(String clientId, String clientSecret) {
     this.clientId = Preconditions.checkNotNull(clientId);
     this.clientSecret = clientSecret;
   }

--- a/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -54,33 +54,20 @@ public class CloudShellCredentials extends GoogleCredentials {
 
   /**
    * The Cloud Shell back authorization channel uses serialized
-   * Javascript Protobufers, preceeded by the message length and a
+   * Javascript Protobuffers, preceded by the message length and a
    * new line character. However, the request message has no content,
    * so a token request consists of an empty JsPb, and its 2 character
-   * lenth prefix.
+   * length prefix.
    */
   protected final static String GET_AUTH_TOKEN_REQUEST = "2\n[]";
 
   private final int authPort;
 
-  /**
-   * @deprecated Use {@link #create(int)} instead. This method will be deleted in a later version.
-   */
-  @Deprecated
-  public static CloudShellCredentials of(int authPort) {
-    return create(authPort);
-  }
-
   public static CloudShellCredentials create(int authPort) {
     return CloudShellCredentials.newBuilder().setAuthPort(authPort).build();
   }
 
-  /**
-   * @deprecated Use {@link #create(int)} instead. This constructor will either be deleted or
-   *             made private in a later version.
-   */
-  @Deprecated
-  public CloudShellCredentials(int authPort) {
+  private CloudShellCredentials(int authPort) {
     this.authPort = authPort;
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -98,39 +98,12 @@ public class ComputeEngineCredentials extends GoogleCredentials implements Servi
   private transient String serviceAccountEmail;
 
   /**
-   * Returns a credentials instance from the given transport factory
-   *
-   * @param transportFactory The Http transport factory
-   * @return the credential instance
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public static ComputeEngineCredentials of(HttpTransportFactory transportFactory) {
-    return ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
-  }
-
-  /**
-   * Create a new ComputeEngineCredentials instance with default behavior.
-   *
-   * @deprecated Use {@link #create()} instead. This constructor will either be deleted or
-   *             made private in a later version.
-   */
-  @Deprecated
-  public ComputeEngineCredentials() {
-    this(null);
-  }
-
-  /**
    * Constructor with overridden transport.
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
    */
-  @Deprecated
-  public ComputeEngineCredentials(HttpTransportFactory transportFactory) {
+  private ComputeEngineCredentials(HttpTransportFactory transportFactory) {
     this.transportFactory = firstNonNull(transportFactory,
         getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
     this.transportFactoryClassName = this.transportFactory.getClass().getName();

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -59,19 +59,6 @@ public class GoogleCredentials extends OAuth2Credentials {
    *
    * @param accessToken the access token
    * @return the credentials instance
-   * @deprecated Use {@link #create(AccessToken)} instead. This method will be deleted in a later
-   *             version.
-   */
-  @Deprecated
-  public static GoogleCredentials of(AccessToken accessToken) {
-    return create(accessToken);
-  }
-
-  /**
-   * Returns the credentials instance from the given access token.
-   *
-   * @param accessToken the access token
-   * @return the credentials instance
    */
   public static GoogleCredentials create(AccessToken accessToken) {
     return GoogleCredentials.newBuilder().setAccessToken(accessToken).build();
@@ -193,7 +180,6 @@ public class GoogleCredentials extends OAuth2Credentials {
    * @deprecated Use {@link #create(AccessToken)} instead. This constructor will either be deleted
    *             or made protected/private in a later version.
    **/
-  @Deprecated
   public GoogleCredentials(AccessToken accessToken) {
     super(accessToken);
   }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -176,10 +176,8 @@ public class GoogleCredentials extends OAuth2Credentials {
   /**
    * Constructor with explicit access token.
    *
-   * @param accessToken Initial or temporary access token.
-   * @deprecated Use {@link #create(AccessToken)} instead. This constructor will either be deleted
-   *             or made protected/private in a later version.
-   **/
+   * @param accessToken initial or temporary access token
+   */
   public GoogleCredentials(AccessToken accessToken) {
     super(accessToken);
   }

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -76,19 +76,6 @@ public class OAuth2Credentials extends Credentials {
    *
    * @param accessToken the access token
    * @return the credentials instance
-   * @deprecated Use {@link #create(AccessToken)} instead. This method will be deleted in a later
-   *             version.
-   */
-  @Deprecated
-  public static OAuth2Credentials of(AccessToken accessToken) {
-    return create(accessToken);
-  }
-
-  /**
-   * Returns the credentials instance from the given access token.
-   *
-   * @param accessToken the access token
-   * @return the credentials instance
    */
   public static OAuth2Credentials create(AccessToken accessToken) {
     return OAuth2Credentials.newBuilder().setAccessToken(accessToken).build();
@@ -104,12 +91,9 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Constructor with explicit access token.
    *
-   * @param accessToken Initial or temporary access token.
-   * @deprecated Use {@link #create(AccessToken)} instead. This constructor will either be deleted
-   *             or made private in a later version.
+   * @param accessToken initial or temporary access token
    **/
-  @Deprecated
-  public OAuth2Credentials(AccessToken accessToken) {
+  protected OAuth2Credentials(AccessToken accessToken) {
     if (accessToken != null) {
       useAccessToken(accessToken);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -103,47 +103,6 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
   private transient HttpTransportFactory transportFactory;
 
   /**
-   * Constructor with minimum identifying information.
-   *
-   * @param clientId Client ID of the service account from the console. May be null.
-   * @param clientEmail Client email address of the service account from the console.
-   * @param privateKey RSA private key object for the service account.
-   * @param privateKeyId Private key identifier for the service account. May be null.
-   * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
-   *        which results in a credential that must have createScoped called before use.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public ServiceAccountCredentials(
-      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
-      Collection<String> scopes) {
-    this(clientId, clientEmail, privateKey, privateKeyId, scopes, null, null, null, null);
-  }
-
-  /**
-   * Constructor with minimum identifying information and custom HTTP transport.
-   *
-   * @param clientId Client ID of the service account from the console. May be null.
-   * @param clientEmail Client email address of the service account from the console.
-   * @param privateKey RSA private key object for the service account.
-   * @param privateKeyId Private key identifier for the service account. May be null.
-   * @param scopes Scope strings for the APIs to be called. May be null or an empty collection,
-   *        which results in a credential that must have createScoped called before use.
-   * @param transportFactory HTTP transport factory, creates the transport used to get access
-   *        tokens.
-   * @param tokenServerUri URI of the end point that provides tokens.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public ServiceAccountCredentials(
-      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId,
-      Collection<String> scopes, HttpTransportFactory transportFactory, URI tokenServerUri) {
-    this(clientId, clientEmail, privateKey, privateKeyId, scopes, transportFactory, tokenServerUri, null, null);
-  }
-
-  /**
    * Constructor with minimum identifying information and custom HTTP transport.
    *
    * @param clientId Client ID of the service account from the console. May be null.

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -97,22 +97,6 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   transient Clock clock = Clock.SYSTEM;
 
   /**
-   * Constructor with minimum identifying information.
-   *
-   * @param clientId Client ID of the service account from the console. May be null.
-   * @param clientEmail Client email address of the service account from the console.
-   * @param privateKey RSA private key object for the service account.
-   * @param privateKeyId Private key identifier for the service account. May be null.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public ServiceAccountJwtAccessCredentials(
-      String clientId, String clientEmail, PrivateKey privateKey, String privateKeyId) {
-    this(clientId, clientEmail, privateKey, privateKeyId, null);
-  }
-
-  /**
    * Constructor with full information.
    *
    * @param clientId Client ID of the service account from the console. May be null.
@@ -120,11 +104,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * @param privateKey RSA private key object for the service account.
    * @param privateKeyId Private key identifier for the service account. May be null.
    * @param defaultAudience Audience to use if not provided by transport. May be null.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
    */
-  @Deprecated
-  public ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,
+  private ServiceAccountJwtAccessCredentials(String clientId, String clientEmail,
       PrivateKey privateKey, String privateKeyId, URI defaultAudience) {
     this.clientId = clientId;
     this.clientEmail = Preconditions.checkNotNull(clientEmail);
@@ -135,7 +116,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   }
 
   /**
-   * Returns service account crentials defined by JSON using the format supported by the Google
+   * Returns service account credentials defined by JSON using the format supported by the Google
    * Developers Console.
    *
    * @param json a map from the JSON representing the credentials.

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -70,51 +70,19 @@ public class UserAuthorizer {
   private final URI userAuthUri;
 
   /**
-   * Constructor with minimal parameters.
-   *
-   * @param clientId Client ID to identify the OAuth2 consent prompt.
-   * @param scopes OAUth2 scopes defining the user consent.
-   * @param tokenStore Implementation of component for long term storage of tokens.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore) {
-    this(clientId, scopes, tokenStore, null, null, null, null);
-  }
-
-  /**
-   * Constructor with common parameters.
-   *
-   * @param clientId Client ID to identify the OAuth2 consent prompt.
-   * @param scopes OAUth2 scopes defining the user consent.
-   * @param tokenStore Implementation of component for long term storage of tokens.
-   * @param callbackUri URI for implementation of the OAuth2 web callback.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore, URI callbackUri) {
-    this(clientId, scopes, tokenStore, callbackUri, null, null, null);
-  }
-
-  /**
    * Constructor with all parameters.
    *
-   * @param clientId Client ID to identify the OAuth2 consent prompt.
-   * @param scopes OAUth2 scopes defining the user consent.
-   * @param tokenStore Implementation of a component for long term storage of tokens.
-   * @param callbackUri URI for implementation of the OAuth2 web callback.
+   * @param clientId Client ID to identify the OAuth2 consent prompt
+   * @param scopes OAuth2 scopes defining the user consent
+   * @param tokenStore Implementation of a component for long term storage of tokens
+   * @param callbackUri URI for implementation of the OAuth2 web callback
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
-   * @param tokenServerUri URI of the end point that provides tokens.
-   * @param userAuthUri URI of the Web UI for user consent.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
+   * @param tokenServerUri URI of the end point that provides tokens
+   * @param userAuthUri URI of the Web UI for user consent
    */
-  @Deprecated
-  public UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
-                        URI callbackUri, HttpTransportFactory transportFactory, URI tokenServerUri, URI userAuthUri) {
+  private UserAuthorizer(ClientId clientId, Collection<String> scopes, TokenStore tokenStore,
+      URI callbackUri, HttpTransportFactory transportFactory, URI tokenServerUri, URI userAuthUri) {
     this.clientId = Preconditions.checkNotNull(clientId);
     this.scopes = ImmutableList.copyOf(Preconditions.checkNotNull(scopes));
     this.callbackUri = (callbackUri == null) ? DEFAULT_CALLBACK_URI : callbackUri;

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -75,37 +75,6 @@ public class UserCredentials extends GoogleCredentials {
   private transient HttpTransportFactory transportFactory;
 
   /**
-   * Constructor with minimum information and default behavior.
-   *
-   * @param clientId Client ID of the credential from the console.
-   * @param clientSecret Client ID of the credential from the console.
-   * @param refreshToken A refresh token resulting from a OAuth2 consent flow.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public UserCredentials(String clientId, String clientSecret, String refreshToken) {
-    this(clientId, clientSecret, refreshToken, null, null, null);
-  }
-
-  /**
-   * Constructor to allow both refresh token and initial access token for 3LO scenarios.
-   *
-   * @param clientId Client ID of the credential from the console.
-   * @param clientSecret Client ID of the credential from the console.
-   * @param refreshToken A refresh token resulting from a OAuth2 consent flow.
-   * @param accessToken Initial or temporary access token.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
-   */
-  @Deprecated
-  public UserCredentials(
-      String clientId, String clientSecret, String refreshToken, AccessToken accessToken) {
-    this(clientId, clientSecret, refreshToken, accessToken, null, null);
-  }
-
-
-  /**
    * Constructor with all parameters allowing custom transport and server URL.
    *
    * @param clientId Client ID of the credential from the console.
@@ -114,13 +83,10 @@ public class UserCredentials extends GoogleCredentials {
    * @param accessToken Initial or temporary access token.
    * @param transportFactory HTTP transport factory, creates the transport used to get access
    *        tokens.
-   * @param tokenServerUri URI of the end point that provides tokens.
-   * @deprecated Use {@link #newBuilder()} instead. This constructor will either be deleted or made
-   *             private in a later version.
+   * @param tokenServerUri URI of the end point that provides tokens
    */
-  @Deprecated
-  public UserCredentials(String clientId, String clientSecret, String refreshToken,
-                         AccessToken accessToken, HttpTransportFactory transportFactory, URI tokenServerUri) {
+  private UserCredentials(String clientId, String clientSecret, String refreshToken,
+      AccessToken accessToken, HttpTransportFactory transportFactory, URI tokenServerUri) {
     super(accessToken);
     this.clientId = Preconditions.checkNotNull(clientId);
     this.clientSecret = Preconditions.checkNotNull(clientSecret);

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>com.google.appengine</groupId>
+        <artifactId>appengine</artifactId>
+        <version>1.9.64</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-oauth2-http</artifactId>
         <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine</artifactId>
-        <version>1.9.64</version>
+        <version>1.9.71</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Immediately following the last release is the best time to rip out all the deprecated methods. 