### PR TITLE
Option to suppress end user credentials warning.

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -212,9 +212,9 @@ class DefaultCredentialsProvider {
   }
 
   private void warnAboutProblematicCredentials(GoogleCredentials credentials) {
-    if (!Boolean.parseBoolean(getEnv(SUPPRESS_GCLOUD_CREDS_WARNING_ENV_VAR))
-        && credentials instanceof UserCredentials
-        && ((UserCredentials) credentials).getClientId().equals(CLOUDSDK_CLIENT_ID)) {
+    if (credentials instanceof UserCredentials
+        && ((UserCredentials) credentials).getClientId().equals(CLOUDSDK_CLIENT_ID)
+        && !Boolean.parseBoolean(getEnv(SUPPRESS_GCLOUD_CREDS_WARNING_ENV_VAR))) {
       LOGGER.log(Level.WARNING, CLOUDSDK_CREDENTIALS_WARNING);
     }
   }

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -87,6 +87,7 @@ class DefaultCredentialsProvider {
       + "SDK, you might receive a \"quota exceeded\" or \"API not enabled\" error. For "
       + "more information about service accounts, see "
       + "https://cloud.google.com/docs/authentication/.";
+  public static final String SUPPRESS_GCLOUD_CREDS_WARNING_ENV_VAR = "SUPPRESS_GCLOUD_CREDS_WARNING";
 
   // These variables should only be accessed inside a synchronized block
   private GoogleCredentials cachedCredentials = null;
@@ -211,8 +212,9 @@ class DefaultCredentialsProvider {
   }
 
   private void warnAboutProblematicCredentials(GoogleCredentials credentials) {
-    if (credentials instanceof UserCredentials &&
-        ((UserCredentials)credentials).getClientId().equals(CLOUDSDK_CLIENT_ID)) {
+    if (!Boolean.parseBoolean(getEnv(SUPPRESS_GCLOUD_CREDS_WARNING_ENV_VAR))
+        && credentials instanceof UserCredentials
+        && ((UserCredentials) credentials).getClientId().equals(CLOUDSDK_CLIENT_ID)) {
       LOGGER.log(Level.WARNING, CLOUDSDK_CREDENTIALS_WARNING);
     }
   }


### PR DESCRIPTION
Defining a new environment variable SUPPRESS_GCLOUD_CREDS_WARNING.
Setting this to true suppresses the end user credentials warning.

Fixes #193
