### PR TITLE
Add ImpersonatedCredentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ following are searched (in order) to find the Application Default Credentials:
 
 To get Credentials from a Service Account JSON key use `GoogleCredentials.fromStream(InputStream)`
 or `GoogleCredentials.fromStream(InputStream, HttpTransportFactory)`. Note that the credentials must
-be refreshed before the access token is available. 
+be refreshed before the access token is available.
 
 ```java
 GoogleCredentials credentials = GoogleCredentials.fromStream(new FileInputStream("/path/to/credentials.json"));
@@ -113,6 +113,31 @@ credentials.refreshIfExpired();
 AccessToken token = credentials.getAccessToken();
 // OR
 AccessToken token = credentials.refreshAccessToken();
+```
+
+### ImpersonatedCredentials
+
+Allows a credentials issued to a user or service account to
+impersonate another.  The source project using ImpersonaedCredentials must enable the
+"IAMCredentials" API.  Also, the target service account must grant the orginating principal
+the "Service Account Token Creator" IAM role.
+
+```java
+String credPath = "/path/to/svc_account.json";
+ServiceAccountCredentials sourceCredentials = ServiceAccountCredentials
+     .fromStream(new FileInputStream(credPath));
+sourceCredentials = (ServiceAccountCredentials) sourceCredentials
+    .createScoped(Arrays.asList("https://www.googleapis.com/auth/iam"));
+
+ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+    "impersonated-account@project.iam.gserviceaccount.com", null,
+    Arrays.asList("https://www.googleapis.com/auth/devstorage.read_only"), 300);
+
+Storage storage_service = StorageOptions.newBuilder().setProjectId("project-id")
+    .setCredentials(targetCredentials).build().getService();
+
+for (Bucket b : storage_service.list().iterateAll())
+    System.out.println(b); 
 ```
 
 ## CI Status

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2018, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpContent;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.http.json.JsonHttpContent;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.util.GenericData;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * ImpersonatedCredentials allowing credentials issued to a user or
+ * service account to impersonate another.
+ * <br/>
+ * The source project using ImpersonatedCredentials must enable the
+ * "IAMCredentials" API.<br/>
+ * Also, the target service account must grant the orginating principal the
+ * "Service Account Token Creator" IAM role.
+ * <br/>
+ * Usage:<br/>
+ * <pre>
+ * String credPath = "/path/to/svc_account.json";
+ * ServiceAccountCredentials sourceCredentials = ServiceAccountCredentials
+ *     .fromStream(new FileInputStream(credPath));
+ * sourceCredentials = (ServiceAccountCredentials) sourceCredentials
+ *     .createScoped(Arrays.asList("https://www.googleapis.com/auth/iam"));
+ * 
+ * ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+ *     "impersonated-account@project.iam.gserviceaccount.com", null,
+ *     Arrays.asList("https://www.googleapis.com/auth/devstorage.read_only"), 300);
+ *
+ * Storage storage_service = StorageOptions.newBuilder().setProjectId("project-id")
+ *    .setCredentials(targetCredentials).build().getService();
+ *
+ * for (Bucket b : storage_service.list().iterateAll())
+ *     System.out.println(b); 
+ * </pre>
+ */
+public class ImpersonatedCredentials extends GoogleCredentials {
+
+  private static final long serialVersionUID = -2133257318957488431L;
+  private static final String RFC3339 = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+  private static final int ONE_HOUR_IN_SECONDS = 3600;
+  private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+  private static final String ERROR_PREFIX = "Error processng IamCredentials generateAccessToken response. ";
+  private static final String IAM_ENDPOINT = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken";
+
+  private static final String SCOPE_EMPTY_ERROR = "Scopes cannot be null";
+  private static final String LIFETIME_EXCEEDED_ERROR = "lifetime must be less than or equal to 3600";
+  
+  private GoogleCredentials sourceCredentials;
+  private String targetPrincipal;
+  private List<String> delegates;
+  private List<String> scopes;
+  private int lifetime;
+  private final String transportFactoryClassName;
+
+  private transient HttpTransportFactory transportFactory;
+
+  /**
+   * @param sourceCredentials The source credential used as to acquire the
+   * impersonated credentials
+   * @param targetPrincipal   The service account to impersonate.
+   * @param delegates         The chained list of delegates required to grant
+   * the final access_token.  <br/>If set, the sequence of identities must
+   * have "Service Account Token Creator" capability granted to the
+   * prceeding identity.  <br/>For example, if set to
+   * [serviceAccountB, serviceAccountC], the sourceCredential
+   * must have the Token Creator role on serviceAccountB. serviceAccountB must
+   * have the Token Creator on serviceAccountC.  <br/>Finally, C must have
+   * Token Creator on target_principal. If left unset, sourceCredential
+   * must have that role on targetPrincipal.
+   * @param scopes            Scopes to request during the authorization grant.
+   * @param lifetime          Number of seconds the delegated credential should
+   * be valid for (upto 3600).
+   * @param transportFactory  HTTP transport factory, creates the transport used
+   *                          to get access tokens.
+   */  
+  public static ImpersonatedCredentials create(GoogleCredentials sourceCredentials, String targetPrincipal,
+      List<String> delegates, List<String> scopes, int lifetime, HttpTransportFactory transportFactory) {
+    return ImpersonatedCredentials.newBuilder().setSourceCredentials(sourceCredentials)
+        .setTargetPrincipal(targetPrincipal).setDelegates(delegates).setScopes(scopes).setLifetime(lifetime)
+        .setHttpTransportFactory(transportFactory).build();
+  }
+
+  /**
+   * @param sourceCredentials The source credential used as to acquire the
+   * impersonated credentials
+   * @param targetPrincipal   The service account to impersonate.
+   * @param delegates         The chained list of delegates required to grant
+   * the final access_token.  <br/>If set, the sequence of identities must
+   * have "Service Account Token Creator" capability granted to the
+   * prceeding identity.  <br/>For example, if set to
+   * [serviceAccountB, serviceAccountC], the sourceCredential
+   * must have the Token Creator role on serviceAccountB. serviceAccountB must
+   * have the Token Creator on serviceAccountC.  <br/>Finally, C must have
+   * Token Creator on target_principal. If left unset, sourceCredential
+   * must have that role on targetPrincipal.
+   * @param scopes            Scopes to request during the authorization grant.
+   * @param lifetime          Number of seconds the delegated credential should
+   * be valid for (upto 3600).
+   */  
+  public static ImpersonatedCredentials create(GoogleCredentials sourceCredentials, String targetPrincipal,
+      List<String> delegates, List<String> scopes, int lifetime) {
+    return ImpersonatedCredentials.newBuilder().setSourceCredentials(sourceCredentials)
+        .setTargetPrincipal(targetPrincipal).setDelegates(delegates).setScopes(scopes).setLifetime(lifetime).build();
+  }
+
+  /**
+   * @param sourceCredentials = Source Credentials.
+   * @param targetPrincipal   = targetPrincipal;
+   * @param delegates         = delegates;
+   * @param scopes            = scopes;
+   * @param lifetime          = lifetime;
+   * @param transportFactory  = HTTP transport factory, creates the transport used
+   *                          to get access tokens.
+   * @deprecated Use {@link #create(ImpersonatedCredentials)} instead. This constructor
+   *             will either be deleted or made private in a later version.
+   */
+  @Deprecated
+  ImpersonatedCredentials(GoogleCredentials sourceCredentials, String targetPrincipal, List<String> delegates,
+      List<String> scopes, int lifetime, HttpTransportFactory transportFactory) {
+    this.sourceCredentials = sourceCredentials;
+    this.targetPrincipal = targetPrincipal;
+    this.delegates = delegates;
+    this.scopes = scopes;
+    this.lifetime = lifetime;
+    this.transportFactory = firstNonNull(transportFactory,
+        getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
+    this.transportFactoryClassName = this.transportFactory.getClass().getName();
+    if (this.delegates == null) {
+      this.delegates = new ArrayList<String>();
+    }
+    if (this.scopes == null) {
+      throw new IllegalStateException(SCOPE_EMPTY_ERROR);
+    }
+    if (this.lifetime > ONE_HOUR_IN_SECONDS) {
+      throw new IllegalStateException(LIFETIME_EXCEEDED_ERROR);
+    }
+  }
+
+  /**
+   * @param sourceCredentials = Source Credentials.
+   * @param targetPrincipal   = targetPrincipal;
+   * @param scopes            = scopes;
+   * @param lifetime          = lifetime;
+   * @param transportFactory  = HTTP transport factory, creates the transport used
+   *                          to get access tokens.
+   * @deprecated Use {@link #create(ImpersonatedCredentials)} instead. This constructor
+   *             will either be deleted or made private in a later version.
+   */  
+  @Deprecated
+  ImpersonatedCredentials(GoogleCredentials sourceCredentials, String targetPrincipal, List<String> scopes,
+      int lifetime, HttpTransportFactory transportFactory) {
+    this(sourceCredentials, targetPrincipal, new ArrayList<String>(), scopes, lifetime, transportFactory);
+  }
+
+  /**
+   * @param sourceCredentials = Source Credentials.
+   * @param targetPrincipal   = targetPrincipal;
+   * @param delegates         = delegates;
+   * @param scopes            = scopes;
+   * @param lifetime          = lifetime;
+   * @deprecated Use {@link #create(ImpersonatedCredentials)} instead. This constructor
+   *             will either be deleted or made private in a later version.
+   */  
+  @Deprecated
+  ImpersonatedCredentials(GoogleCredentials sourceCredentials, String targetPrincipal, List<String> scopes,
+      int lifetime) {
+    this(sourceCredentials, targetPrincipal, new ArrayList<String>(), scopes, lifetime, null);
+  }
+
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    if (this.sourceCredentials.getAccessToken() == null) {
+      this.sourceCredentials = this.sourceCredentials.createScoped(Arrays.asList(CLOUD_PLATFORM_SCOPE));
+      this.sourceCredentials.refresh();
+    }
+    if (this.sourceCredentials.getAccessToken().getExpirationTime().before(new Date())) {
+      this.sourceCredentials.refresh();
+    }
+
+    HttpTransport httpTransport = this.transportFactory.create();
+    JsonObjectParser parser = new JsonObjectParser(OAuth2Utils.JSON_FACTORY);
+
+    HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(sourceCredentials);
+    HttpRequestFactory requestFactory = httpTransport.createRequestFactory();
+
+    String endpointUrl = String.format(IAM_ENDPOINT, this.targetPrincipal);
+    GenericUrl url = new GenericUrl(endpointUrl);
+
+    Map<String, Object> body = ImmutableMap.<String, Object>of("delegates", this.delegates, "scope", this.scopes,
+        "lifetime", this.lifetime + "s");
+
+    HttpContent requestContent = new JsonHttpContent(parser.getJsonFactory(), body);
+    HttpRequest request = requestFactory.buildPostRequest(url, requestContent);
+    adapter.initialize(request);
+    request.setParser(parser);
+
+    HttpResponse response = request.execute();
+    int statusCode = response.getStatusCode();
+
+    if (statusCode == HttpStatusCodes.STATUS_CODE_UNAUTHORIZED) {
+      GenericData responseError = response.parseAs(GenericData.class);
+      throw new IOException(responseError.toString());
+    }
+
+    if (statusCode == HttpStatusCodes.STATUS_CODE_BAD_REQUEST) {
+      GenericData responseError = response.parseAs(GenericData.class);
+      throw new IOException(responseError.toString());
+    }
+
+    if (statusCode >= 400 && statusCode < HttpStatusCodes.STATUS_CODE_SERVER_ERROR) {
+      GenericData responseError = response.parseAs(GenericData.class);
+      throw new IOException(responseError.toString());
+    }
+
+    if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
+      throw new IOException(response.parseAsString());
+    }
+
+    GenericData responseData = response.parseAs(GenericData.class);
+    response.disconnect();
+
+    String accessToken = OAuth2Utils.validateString(responseData, "accessToken", ERROR_PREFIX);
+    String expireTime = OAuth2Utils.validateString(responseData, "expireTime", ERROR_PREFIX);
+
+    DateFormat format = new SimpleDateFormat(RFC3339);
+    Date date;
+    try {
+      date = format.parse(expireTime);
+    } catch (ParseException pe) {
+      throw new IOException(ERROR_PREFIX + pe.getMessage());
+    }
+    return new AccessToken(accessToken, date);
+  }
+
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceCredentials, targetPrincipal, delegates, scopes, lifetime);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("sourceCredentials", sourceCredentials)
+        .add("targetPrincipal", targetPrincipal)
+        .add("delegates", delegates)
+        .add("scopes", scopes)
+        .add("lifetime", lifetime)
+        .add("transportFactoryClassName", transportFactoryClassName).toString();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof ImpersonatedCredentials)) {
+      return false;
+    }
+    ImpersonatedCredentials other = (ImpersonatedCredentials) obj;
+    return Objects.equals(this.sourceCredentials, other.sourceCredentials)
+        && Objects.equals(this.targetPrincipal, other.targetPrincipal)
+        && Objects.equals(this.delegates, other.delegates)
+        && Objects.equals(this.scopes, other.scopes)
+        && Objects.equals(this.lifetime, other.lifetime)
+        && Objects.equals(this.transportFactoryClassName, other.transportFactoryClassName);
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this.sourceCredentials, this.targetPrincipal);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder extends GoogleCredentials.Builder {
+
+    private GoogleCredentials sourceCredentials;
+    private String targetPrincipal;
+    private List<String> delegates;
+    private List<String> scopes;
+    private int lifetime;
+    private HttpTransportFactory transportFactory;
+
+    protected Builder() {
+    }
+
+    protected Builder(GoogleCredentials sourceCredentials, String targetPrincipal) {
+      this.sourceCredentials = sourceCredentials;
+      this.targetPrincipal = targetPrincipal;
+    }
+
+    public Builder setSourceCredentials(GoogleCredentials sourceCredentials) {
+      this.sourceCredentials = sourceCredentials;
+      return this;
+    }
+
+    public GoogleCredentials getSourceCredentials() {
+      return this.sourceCredentials;
+    }
+
+    public Builder setTargetPrincipal(String targetPrincipal) {
+      this.targetPrincipal = targetPrincipal;
+      return this;
+    }
+
+    public String getTargetPrincipal() {
+      return this.targetPrincipal;
+    }
+
+    public Builder setDelegates(List<String> delegates) {
+      this.delegates = delegates;
+      return this;
+    }
+
+    public List<String> getDelegates() {
+      return this.delegates;
+    }
+
+    public Builder setScopes(List<String> scopes) {
+      this.scopes = scopes;
+      return this;
+    }
+
+    public List<String> getScopes() {
+      return this.scopes;
+    }
+
+    public Builder setLifetime(int lifetime) {
+      this.lifetime = lifetime;
+      return this;
+    }
+
+    public int getLifetime() {
+      return this.lifetime;
+    }
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+    }
+
+    public HttpTransportFactory getHttpTransportFactory() {
+      return transportFactory;
+    }
+
+    public ImpersonatedCredentials build() {
+      return new ImpersonatedCredentials(this.sourceCredentials, this.targetPrincipal, this.delegates, this.scopes,
+          this.lifetime, this.transportFactory);
+    }
+
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.security.PrivateKey;
+import java.util.Arrays;
+import java.util.List;
+
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.Clock;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.GoogleCredentialsTest.MockTokenServerTransportFactory;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.util.Date;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+
+/**
+ * Test case for {@link ImpersonatedCredentials}.
+ */
+@RunWith(JUnit4.class)
+public class ImpersonatedCredentialsTest extends BaseSerializationTest {
+
+  private static final String SA_CLIENT_EMAIL = "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
+  private static final String SA_PRIVATE_KEY_ID = "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
+  static final String SA_PRIVATE_KEY_PKCS8 = "-----BEGIN PRIVATE KEY-----\n"
+      + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
+      + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
+      + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
+      + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
+      + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
+      + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
+      + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
+      + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
+      + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
+      + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
+      + "==\n-----END PRIVATE KEY-----\n";
+
+  private static final String PROJECT_ID = "project-id";
+  private static final String IMPERSONATED_CLIENT_EMAIL = "impersonated-account@iam.gserviceaccount.com";
+  private static final List<String> SCOPES = Arrays.asList("https://www.googleapis.com/auth/devstorage.read_only");
+  private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
+  private static final int VALID_LIFETIME = 300;
+  private static final int INVALID_LIFETIME = 3800;
+
+  private static final String RFC3339 = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+
+  static class MockIAMCredentialsServiceTransportFactory implements HttpTransportFactory {
+
+    MockIAMCredentialsServiceTransport transport = new MockIAMCredentialsServiceTransport();
+
+    @Override
+    public HttpTransport create() {
+      return transport;
+    }
+  }
+
+  private GoogleCredentials getSourceCredentials() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    ServiceAccountCredentials sourceCredentials = ServiceAccountCredentials.newBuilder()
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setScopes(SCOPES)
+        .setProjectId(PROJECT_ID)
+        .setHttpTransportFactory(transportFactory).build();
+    transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+
+    return sourceCredentials;
+  }
+
+  @Test()
+  public void refreshAccessToken_unauthorized() throws IOException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    String expectedMessage = "The caller does not have permission";
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setTokenResponseErrorCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+    mtransportFactory.transport.setTokenResponseErrorContent(
+        generateErrorJson(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED,
+            expectedMessage, "global", "forbidden"));
+    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+
+    try {
+      targetCredentials.refreshAccessToken().getTokenValue();
+      fail(String.format("Should throw exception with message containing '%s'", expectedMessage));
+    } catch (HttpResponseException expected) {
+      assertTrue(expected.getMessage().contains(expectedMessage));
+    }
+  }
+
+  @Test()
+  public void refreshAccessToken_malformedTarget() throws IOException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    String invalidTargetEmail = "foo";
+    String expectedMessage = "Request contains an invalid argument";
+    mtransportFactory.transport.setTargetPrincipal(invalidTargetEmail);
+    mtransportFactory.transport.setTokenResponseErrorCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    mtransportFactory.transport.setTokenResponseErrorContent(
+        generateErrorJson(HttpStatusCodes.STATUS_CODE_BAD_REQUEST,
+            expectedMessage, "global", "badRequest"));
+    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+        invalidTargetEmail, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+
+    try {
+      targetCredentials.refreshAccessToken().getTokenValue();
+      fail(String.format("Should throw exception with message containing '%s'", expectedMessage));
+    } catch (HttpResponseException expected) {
+      assertTrue(expected.getMessage().contains(expectedMessage));
+    }
+  }
+
+  @Test()
+  public void credential_with_invalid_lifetime() throws IOException, IllegalStateException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    try {
+      ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+          IMPERSONATED_CLIENT_EMAIL, null, SCOPES, INVALID_LIFETIME);
+      targetCredentials.refreshAccessToken().getTokenValue();
+      fail(String.format("Should throw exception with message containing '%s'",
+          "lifetime must be less than or equal to 3600"));
+    } catch (IllegalStateException expected) {
+      assertTrue(expected.getMessage().contains("lifetime must be less than or equal to 3600"));
+    }
+
+  }
+
+  @Test()
+  public void credential_with_invalid_scope() throws IOException, IllegalStateException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    try {
+      ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+          IMPERSONATED_CLIENT_EMAIL, null, null, VALID_LIFETIME);
+      targetCredentials.refreshAccessToken().getTokenValue();
+      fail(String.format("Should throw exception with message containing '%s'",
+          "Scopes cannot be null"));
+    } catch (IllegalStateException expected) {
+      assertTrue(expected.getMessage().contains("Scopes cannot be null"));
+    }
+
+  }
+
+  @Test()
+  public void refreshAccessToken_success() throws IOException, IllegalStateException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
+    mtransportFactory.transport.setexpireTime(getDefaultExpireTime());
+    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+
+    assertEquals(ACCESS_TOKEN, targetCredentials.refreshAccessToken().getTokenValue());
+  }
+
+  @Test()
+  public void refreshAccessToken_delegates_success() throws IOException, IllegalStateException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
+    mtransportFactory.transport.setexpireTime(getDefaultExpireTime());
+    List<String> delegates = Arrays.asList("delegate-account@iam.gserviceaccount.com");
+    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+        IMPERSONATED_CLIENT_EMAIL, delegates, SCOPES, VALID_LIFETIME, mtransportFactory);
+
+    assertEquals(ACCESS_TOKEN, targetCredentials.refreshAccessToken().getTokenValue());
+  }
+
+  @Test()
+  public void refreshAccessToken_invalidDate() throws IOException, IllegalStateException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    String expectedMessage = "Unparseable date";
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setAccessToken("foo");
+    mtransportFactory.transport.setexpireTime("1973-09-29T15:01:23");
+    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+
+    try {
+      targetCredentials.refreshAccessToken().getTokenValue();
+      fail(String.format("Should throw exception with message containing '%s'", expectedMessage));
+    } catch (IOException expected) {
+      assertTrue(expected.getMessage().contains(expectedMessage));
+    }
+  }
+
+  @Test
+  public void hashCode_equals() throws IOException {
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
+    mtransportFactory.transport.setexpireTime(getDefaultExpireTime());
+    ImpersonatedCredentials credentials = ImpersonatedCredentials.create(sourceCredentials,
+        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+
+    ImpersonatedCredentials otherCredentials = ImpersonatedCredentials.create(sourceCredentials,
+        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+
+    assertEquals(credentials.hashCode(), otherCredentials.hashCode());
+  }
+
+  @Test
+  public void serialize() throws IOException, ClassNotFoundException {
+
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
+    mtransportFactory.transport.setexpireTime(getDefaultExpireTime());
+
+    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
+        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    GoogleCredentials deserializedCredentials = serializeAndDeserialize(targetCredentials);
+    assertEquals(targetCredentials, deserializedCredentials);
+    assertEquals(targetCredentials.hashCode(), deserializedCredentials.hashCode());
+    assertEquals(targetCredentials.toString(), deserializedCredentials.toString());
+    assertSame(deserializedCredentials.clock, Clock.SYSTEM);
+  }
+
+  private String getDefaultExpireTime() {
+    Date currentDate = new Date();
+    Calendar c = Calendar.getInstance();
+    c.setTime(currentDate);
+    c.add(Calendar.SECOND, VALID_LIFETIME);    
+    return new SimpleDateFormat(RFC3339).format(c.getTime());
+  }
+
+  private String generateErrorJson(int errorCode, String errorMessage, String errorDomain,
+      String errorReason) throws IOException {
+
+    JsonFactory factory = new JacksonFactory();
+    ByteArrayOutputStream bout = new ByteArrayOutputStream();
+    JsonGenerator generator = factory.createJsonGenerator(bout, Charset.defaultCharset());
+    generator.enablePrettyPrint();
+
+    generator.writeStartObject();
+    generator.writeFieldName("error");
+
+    generator.writeStartObject();
+    generator.writeFieldName("code");
+    generator.writeNumber(errorCode);
+    generator.writeFieldName("message");
+    generator.writeString(errorMessage);
+
+    generator.writeFieldName("errors");
+    generator.writeStartArray();
+    generator.writeStartObject();
+    generator.writeFieldName("message");
+    generator.writeString(errorMessage);
+    generator.writeFieldName("domain");
+    generator.writeString(errorDomain);
+    generator.writeFieldName("reason");
+    generator.writeString(errorReason);
+    generator.writeEndObject();
+    generator.writeEndArray();
+
+    generator.writeFieldName("status");
+    generator.writeString("PERMISSION_DENIED");
+
+    generator.writeEndObject();
+    generator.writeEndObject();
+    generator.close();
+    return bout.toString();
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -133,7 +133,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     try {
       targetCredentials.refreshAccessToken().getTokenValue();
       fail(String.format("Should throw exception with message containing '%s'", expectedMessage));
-    } catch (HttpResponseException expected) {
+    } catch (IOException expected) {
       assertTrue(expected.getMessage().contains(expectedMessage));
     }
   }
@@ -157,7 +157,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     try {
       targetCredentials.refreshAccessToken().getTokenValue();
       fail(String.format("Should throw exception with message containing '%s'", expectedMessage));
-    } catch (HttpResponseException expected) {
+    } catch (IOException expected) {
       assertTrue(expected.getMessage().contains(expectedMessage));
     }
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import java.io.IOException;
+
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.Json;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+
+/**
+ * Transport that simulates the IAMCredentials server for access tokens.
+ */
+public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
+
+  private static final String IAM_ENDPOINT = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken";
+
+  private Integer tokenResponseErrorCode;
+  private String tokenResponseErrorContent;
+  private String targetPrincipal;
+
+  private String accessToken;
+  private String expireTime;
+
+  public MockIAMCredentialsServiceTransport() {
+  }
+
+  public void setTokenResponseErrorCode(Integer tokenResponseErrorCode) {
+    this.tokenResponseErrorCode = tokenResponseErrorCode;
+  }
+
+  public void setTokenResponseErrorContent(String tokenResponseErrorContent) {
+    this.tokenResponseErrorContent = tokenResponseErrorContent;
+  }
+
+  public void setTargetPrincipal(String targetPrincipal) {
+    this.targetPrincipal = targetPrincipal;
+  }
+
+  public void setAccessToken(String accessToken) {
+    this.accessToken = accessToken;
+  }
+
+  public void setexpireTime(String expireTime) {
+    this.expireTime = expireTime;
+  }
+
+  @Override
+  public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+
+    String formattedUrl = String.format(IAM_ENDPOINT, this.targetPrincipal);
+    if (url.equals(formattedUrl)) {
+      return new MockLowLevelHttpRequest(url) {
+        @Override
+        public LowLevelHttpResponse execute() throws IOException {
+
+          if (tokenResponseErrorCode != null) {
+            return new MockLowLevelHttpResponse()
+                .setStatusCode(tokenResponseErrorCode)
+                .setContentType(Json.MEDIA_TYPE)
+                .setContent(tokenResponseErrorContent);
+          }
+
+          // Create the JSON response
+          GenericJson refreshContents = new GenericJson();
+          refreshContents.setFactory(OAuth2Utils.JSON_FACTORY);
+          refreshContents.put("accessToken", accessToken);
+          refreshContents.put("expireTime", expireTime);
+          String refreshText = refreshContents.toPrettyString();
+          return new MockLowLevelHttpResponse()
+              .setContentType(Json.MEDIA_TYPE)
+              .setContent(refreshText);
+        }
+      };
+    }
+    return super.buildRequest(method, url);
+  }
+
+}


### PR DESCRIPTION
Addresses https://github.com/googleapis/google-auth-library-java/issues/210

Allow for `ImpersonatedCredentials` in core auth library set.  Instructions to repro or to run system tests:

```
# Create source identity:
# gcloud iam service-accounts create source-serviceaccount --display-name="Source Identity"
# gcloud iam service-accounts keys  create svc-src.json --iam-account=source-serviceaccount@mineral-minutia-820.iam.gserviceaccount.com


# Create target identity
# gcloud iam service-accounts create target-serviceaccount --display-name="Target Identity"

# Allow source to impersonate target
# gcloud iam service-accounts add-iam-policy-binding target-serviceaccount@mineral-minutia-820.iam.gserviceaccount.com --member='serviceAccount:source-serviceaccount@mineral-minutia-820.iam.gserviceaccount.com' --role='roles/iam.serviceAccountTokenCreator'

# Add resource ACL to target
# gcloud projects add-iam-policy-binding mineral-minutia-820 --member='serviceAccount:target-serviceaccount@mineral-minutia-820.iam.gserviceaccount.com' --role='roles/storage.admin'

# Test the app below

# now create a GCE instance of the same source identity.
# comment out the service account section and uncomment the ComputeCredential section (as ADC)
# gcloud compute instances create impersonate-test --service-account=source-serviceaccount@mineral-minutia-820.iam.gserviceaccount.com --scopes=https://www.googleapis.com/auth/iam
# Upload the source below to GCE and rerun the test
```

output of unittests ran:
```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 s - in com.google.auth.oauth2.ImpersonatedCredentialsTest
``