### PR TITLE
Defer Credential building in HttpCredentialsAdapter until request time

### DIFF
--- a/oauth2_http/java/com/google/auth/http/HttpCredentialsAdapter.java
+++ b/oauth2_http/java/com/google/auth/http/HttpCredentialsAdapter.java
@@ -110,9 +110,7 @@ public class HttpCredentialsAdapter
         }
         for (Map.Entry<String, List<String>> entry : credentialHeaders.entrySet()) {
           String headerName = entry.getKey();
-          List<String> requestValues = new ArrayList<>();
-          requestValues.addAll(entry.getValue());
-          requestHeaders.put(headerName, requestValues);
+          requestHeaders.put(headerName, new ArrayList<>(entry.getValue()));
         }
       }
     });

--- a/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
+++ b/oauth2_http/javatests/com/google/auth/http/HttpCredentialsAdapterTest.java
@@ -83,7 +83,7 @@ public class HttpCredentialsAdapterTest {
 
     HttpHeaders requestHeaders = request.getHeaders();
     String authorizationHeader = requestHeaders.getAuthorization();
-    assertEquals(authorizationHeader, expectedAuthorization);
+    assertEquals(expectedAuthorization, authorizationHeader);
   }
 
   @Test
@@ -148,6 +148,6 @@ public class HttpCredentialsAdapterTest {
 
     HttpHeaders requestHeaders = request.getHeaders();
     String authorizationHeader = requestHeaders.getAuthorization();
-    assertEquals(authorizationHeader, expectedAuthorization);
+    assertEquals(expectedAuthorization, authorizationHeader);
   }
 }


### PR DESCRIPTION
Fixes #119

Note that this is a slight behavioral change that delays fetching the request metadata (fetch credentials) until right before the request is executing using a `HttpExecuteInterceptor`. If the user has already configured an interceptor, we run theirs before fetching credentials.
