### PR TITLE
Release google-auth-library-java v0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.12.0</version>
+  <version>0.13.0</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})
@@ -44,7 +44,7 @@ If you are using Gradle, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.12.0'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.13.0'
 ```
 [//]: # ({x-version-update-end})
 
@@ -52,7 +52,7 @@ If you are using SBT, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.12.0"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.13.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.12.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.13.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.12.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.13.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.12.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.13.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-parent</artifactId>
-  <version>0.12.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+  <version>0.13.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
   <description>Client libraries providing authentication and

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,7 @@
 # Format:
 # module:released-version:current-version
 
-google-auth-library-parent:0.12.0:0.12.1-SNAPSHOT
-google-auth-library-appengine:0.12.0:0.12.1-SNAPSHOT
-google-auth-library-credentials:0.12.0:0.12.1-SNAPSHOT
-google-auth-library-oauth2-http:0.12.0:0.12.1-SNAPSHOT
+google-auth-library-parent:0.13.0:0.13.0
+google-auth-library-appengine:0.13.0:0.13.0
+google-auth-library-credentials:0.13.0:0.13.0
+google-auth-library-oauth2-http:0.13.0:0.13.0


### PR DESCRIPTION
This pull request was generated using releasetool.

01-17-2019 12:40 PST

### Implementation Changes
- Use OutputStream directly instead of PrintWriter ([#220](https://github.com/google/google-auth-library-java/pull/220))
- Improve log output when detecting GCE ([#214](https://github.com/google/google-auth-library-java/pull/214))

### New Features
- Overload GoogleCredentials.createScoped with variadic arguments ([#218](https://github.com/google/google-auth-library-java/pull/218))

### Dependencies
- Update google-http-client version, guava, and maven surefire plugin ([#221](https://github.com/google/google-auth-library-java/pull/221))

### Internal / Testing Changes
- Enable autorelease ([#222](https://github.com/google/google-auth-library-java/pull/222))
- Tests: Enable a test that was missing the test annotation ([#219](https://github.com/google/google-auth-library-java/pull/219))
- Add kokoro job for publishing javadoc to GCS ([#217](https://github.com/google/google-auth-library-java/pull/217))
- Bump next snapshot ([#216](https://github.com/google/google-auth-library-java/pull/216))