### PR TITLE
createScoped: fix endless recursion

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -36,6 +36,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.Preconditions;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -219,7 +220,7 @@ public class GoogleCredentials extends OAuth2Credentials {
    * @return GoogleCredentials with requested scopes.
    */
   public GoogleCredentials createScoped(String... scopes) {
-    return createScoped(scopes);
+    return createScoped(ImmutableList.copyOf(scopes));
   }
 
   /**

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -31,6 +31,7 @@
 
 package com.google.auth.oauth2;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -39,6 +40,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.collect.ImmutableList;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +55,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Test case for {@link GoogleCredentials}.
@@ -217,6 +220,25 @@ public class GoogleCredentialsTest {
         UserCredentialsTest.writeUserStream(USER_CLIENT_ID, USER_CLIENT_SECRET, null);
 
     testFromStreamException(userStream, "refresh_token");
+  }
+
+  @Test
+  public void createScoped_overloadCallsImplementation() {
+    final AtomicReference<Collection<String>> called = new AtomicReference<>();
+    final GoogleCredentials expectedScopedCredentials = new GoogleCredentials();
+
+    GoogleCredentials credentials = new GoogleCredentials() {
+      @Override
+      public GoogleCredentials createScoped(Collection<String> scopes) {
+        called.set(scopes);
+        return expectedScopedCredentials;
+      }
+    };
+
+    GoogleCredentials scopedCredentials = credentials.createScoped("foo", "bar");
+
+    assertEquals(expectedScopedCredentials, scopedCredentials);
+    assertEquals(ImmutableList.of("foo", "bar"), called.get());
   }
 
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {


### PR DESCRIPTION
Call `createScoped` implementation instead of endlessly recursing.
