### PR TITLE
Update dependencies versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ capable of signing byte arrays using the credentials associated to a Google Serv
 ## google-auth-library-appengine
 
 This artifact depends on the App Engine SDK (`appengine-api-1.0-sdk`) and should be used only by
-applications running on App Engine. The `AppEngineCredentials` class allows to authorize your App
+applications running on App Engine. The `AppEngineCredentials` class allows you to authorize your App
 Engine application given an instance of [AppIdentityService](https://cloud.google.com/appengine/docs/java/javadoc/com/google/appengine/api/appidentity/AppIdentityService).
 
 You can install the App Engine SDK from Maven Central:
 
 ```bash
-$ mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.65
+$ mvn dependency:get -Dartifact=com.google.appengine:appengine-api-1.0-sdk:1.9.71
 ```
 
 You can find [all available versions][appengine-sdk-versions] on Maven Central.

--- a/pom.xml
+++ b/pom.xml
@@ -44,10 +44,10 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.google.http.version>1.28.0</project.google.http.version>
+    <project.google.http.version>1.27.0</project.google.http.version>
     <project.junit.version>4.12</project.junit.version>
-    <project.guava.version>26.0-android</project.guava.version>
-    <project.appengine.version>1.9.64</project.appengine.version>
+    <project.guava.version>27.1-android</project.guava.version>
+    <project.appengine.version>1.9.71</project.appengine.version>
   </properties>
 
   <dependencyManagement>
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>com.google.appengine</groupId>
         <artifactId>appengine</artifactId>
-        <version>1.9.71</version>
+        <version>${project.appengine.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This moves Guava and AppEngine API SDK forward. 
It resolves a minor inconsistency in the version definition for the AppEngine API SDK.
It also moves the google-http-java-client *backwards* to 1.27.0 because 1.28.0 made an incompatible change that breaks google-cloud-java (which depends on 1.27.0) and using 1.28.0 here risks runtime problems down the line. 
