### PR TITLE
Javadoc publish kokoro job uses docpublisher

### DIFF
--- a/.kokoro/release/publish_javadoc.cfg
+++ b/.kokoro/release/publish_javadoc.cfg
@@ -1,16 +1,19 @@
 # Format: //devtools/kokoro/config/proto/build.proto
-
 env_vars: {
-  key: "TRAMPOLINE_BUILD_FILE"
-  value: "github/google-auth-library-java/.kokoro/release/publish_javadoc.sh"
+    key: "STAGING_BUCKET"
+    value: "docs-staging"
 }
 
 env_vars: {
-  key: "LINK_LATEST"
-  value: "true"
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/google-http-java-client/.kokoro/release/publish_javadoc.sh"
 }
 
-env_vars: {
-  key: "BUCKET"
-  value: "gcloud-javadoc-testing"
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
 }

--- a/.kokoro/release/publish_javadoc.cfg
+++ b/.kokoro/release/publish_javadoc.cfg
@@ -6,7 +6,7 @@ env_vars: {
 
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-http-java-client/.kokoro/release/publish_javadoc.sh"
+    value: "github/google-auth-library-java/.kokoro/release/publish_javadoc.sh"
 }
 
 before_action {

--- a/.kokoro/release/publish_javadoc.cfg
+++ b/.kokoro/release/publish_javadoc.cfg
@@ -1,12 +1,12 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 env_vars: {
-    key: "STAGING_BUCKET"
-    value: "docs-staging"
+  key: "STAGING_BUCKET"
+  value: "docs-staging"
 }
 
 env_vars: {
-    key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/google-auth-library-java/.kokoro/release/publish_javadoc.sh"
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/google-auth-library-java/.kokoro/release/publish_javadoc.sh"
 }
 
 before_action {

--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -1,65 +1,56 @@
 #!/bin/bash
-# Copyright 2018, Google Inc. All rights reserved.
+# Copyright 2019 Google Inc.
 #
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-#    * Redistributions of source code must retain the above copyright
-# notice, this list of conditions and the following disclaimer.
-#    * Redistributions in binary form must reproduce the above
-# copyright notice, this list of conditions and the following disclaimer
-# in the documentation and/or other materials provided with the
-# distribution.
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
-#    * Neither the name of Google Inc. nor the names of its
-# contributors may be used to endorse or promote products derived from
-# this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-set -e
+set -eo pipefail
 
-if [[ -z "${BUCKET}" ]]; then
-    echo "Must set BUCKET environment variable"
-    exit 1
+if [[ -z "${CREDENTIALS}" ]]; then
+  CREDENTIALS=${KOKORO_KEYSTORE_DIR}/73713_docuploader_service_account
 fi
 
+if [[ -z "${STAGING_BUCKET}" ]]; then
+  echo "Need to set STAGING_BUCKET environment variable"
+  exit 1
+fi
+
+# work from the git root directory
 pushd $(dirname "$0")/../../
 
-# Pull the library version from project properties
-VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev '(^\[|\w+:)')
+# install docuploader package
+python3 -m pip install gcp-docuploader
 
-case "${VERSION}" in
-    *-SNAPSHOT)
-        echo "Cannot publish javadoc for -SNAPSHOT versions"
-        exit 1
-        ;;
-    "")
-        echo "Could not obtain version number from maven-help-plugin."
-        exit 1
-        ;;
-esac
+# compile all packages
+mvn clean install -B -DskipTests=true
 
-# Generate the javadoc from scratch
-mvn clean install javadoc:aggregate -DskipTests=true -B
+NAME=google-auth-library
+VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
-# Sync the current version to gCS
-gsutil -m rsync -d target/site gs://${BUCKET}/java/google-auth-library-java/${VERSION}
+# build the docs
+mvn site
+mvn site:stage -DtopSiteURL=https://googleapis.dev/java/${NAME}/${VERSION}
 
-if [[ "${LINK_LATEST}" == "true" ]]; then
-    # Sync the current content to latest
-    gsutil -m rsync gs://${BUCKET}/java/google-auth-library-java/${VERSION} gs://${BUCKET}/java/google-auth-library-java/latest
-fi
+pushd target/staging/site/${NAME}/apidocs
+
+# create metadata
+python3 -m docuploader create-metadata \
+  --name ${NAME} \
+  --version ${VERSION} \
+  --language java
+
+# upload docs
+python3 -m docuploader upload . \
+  --credentials ${CREDENTIALS} \
+  --staging-bucket ${STAGING_BUCKET}
 
 popd

--- a/.kokoro/release/publish_javadoc.sh
+++ b/.kokoro/release/publish_javadoc.sh
@@ -37,10 +37,9 @@ NAME=google-auth-library
 VERSION=$(grep ${NAME}: versions.txt | cut -d: -f3)
 
 # build the docs
-mvn site
-mvn site:stage -DtopSiteURL=https://googleapis.dev/java/${NAME}/${VERSION}
+mvn site -B
 
-pushd target/staging/site/${NAME}/apidocs
+pushd target/site/apidocs
 
 # create metadata
 python3 -m docuploader create-metadata \

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -76,5 +76,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.9.1</version>
+          <version>3.1.0</version>
           <executions>
             <execution>
               <id>attach-javadocs</id>
@@ -168,6 +168,11 @@
           <configuration>
             <reportNameSuffix>sponge_log</reportNameSuffix>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.7.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <site>
       <id>googleapis.dev</id>
       <name>Google self-hosted documentation site</name>
-      <url>https://googleapis.dev/java/google-auth-library/${project.version}/</url>
+      <url>https://googleapis.dev/java/google-auth-library/${project.version}</url>
     </site>
   </distributionManagement>
 
@@ -177,11 +177,6 @@
             <reportNameSuffix>sponge_log</reportNameSuffix>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <version>3.7.1</version>
-        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -202,46 +197,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <doclint>none</doclint>
-          <source>7</source>
-        </configuration>
-        <executions>
-          <execution>
-            <id>aggregate</id>
-            <goals>
-              <goal>aggregate</goal>
-            </goals>
-            <phase>site</phase>
-            <configuration>
-              <links>
-                <link>http://download.oracle.com/javase/7/docs/api/</link>
-                <link>http://cloud.google.com/appengine/docs/java/javadoc</link>
-              </links>
-              <doctitle>Google Auth Library for Java ${project.version}</doctitle>
-              <overview>${basedir}/overview.html</overview>
-              <groups>
-                <group>
-                  <title>google-auth-library-credentials</title>
-                  <packages>com.google.auth*</packages>
-                </group>
-                <group>
-                  <title>google-auth-library-oauth2-http</title>
-                  <packages>com.google.auth.http*:com.google.auth.oauth2*</packages>
-                </group>
-                <group>
-                  <title>google-auth-library-appengine</title>
-                  <packages>com.google.auth.appengine*</packages>
-                </group>
-              </groups>
-              <windowtitle>google-auth-library ${project.version}</windowtitle>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -267,6 +222,14 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+        <configuration>
+          <skipDeploy>true</skipDeploy>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.2</version>
@@ -288,6 +251,51 @@
     </plugins>
   </build>
 
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.0</version>
+        <reportSets>
+          <reportSet>
+            <id>html</id>
+            <reports>
+              <report>aggregate</report>
+              <report>javadoc</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+        <configuration>
+          <doclint>none</doclint>
+          <source>7</source>
+          <outputDirectory>${project.build.directory}/javadoc</outputDirectory>
+          <doctitle>Google Auth Library for Java ${project.version}</doctitle>
+          <overview>${basedir}/overview.html</overview>
+          <groups>
+            <group>
+              <title>google-auth-library-credentials</title>
+              <packages>com.google.auth*</packages>
+            </group>
+            <group>
+              <title>google-auth-library-oauth2-http</title>
+              <packages>com.google.auth.http*:com.google.auth.oauth2*</packages>
+            </group>
+            <group>
+              <title>google-auth-library-appengine</title>
+              <packages>com.google.auth.appengine*</packages>
+            </group>
+          </groups>
+          <links>
+            <link>http://download.oracle.com/javase/7/docs/api/</link>
+            <link>http://cloud.google.com/appengine/docs/java/javadoc</link>
+          </links>
+          <windowtitle>google-auth-library ${project.version}</windowtitle>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
+
   <profiles>
     <profile>
       <id>release-sign-artifacts</id>
@@ -299,6 +307,32 @@
       </activation>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,14 @@
     authorization to enable calling Google APIs.</description>
   <url>https://github.com/googleapis/google-auth-library-java</url>
 
+  <distributionManagement>
+    <site>
+      <id>googleapis.dev</id>
+      <name>Google self-hosted documentation site</name>
+      <url>https://googleapis.dev/java/google-auth-library/${project.version}/</url>
+    </site>
+  </distributionManagement>
+
   <licenses>
     <license>
       <name>BSD New license</name>
@@ -198,6 +206,42 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <doclint>none</doclint>
+          <source>7</source>
+        </configuration>
+        <executions>
+          <execution>
+            <id>aggregate</id>
+            <goals>
+              <goal>aggregate</goal>
+            </goals>
+            <phase>site</phase>
+            <configuration>
+              <links>
+                <link>http://download.oracle.com/javase/7/docs/api/</link>
+                <link>http://cloud.google.com/appengine/docs/java/javadoc</link>
+              </links>
+              <doctitle>Google Auth Library for Java ${project.version}</doctitle>
+              <overview>${basedir}/overview.html</overview>
+              <groups>
+                <group>
+                  <title>google-auth-library-credentials</title>
+                  <packages>com.google.auth*</packages>
+                </group>
+                <group>
+                  <title>google-auth-library-oauth2-http</title>
+                  <packages>com.google.auth.http*:com.google.auth.oauth2*</packages>
+                </group>
+                <group>
+                  <title>google-auth-library-appengine</title>
+                  <packages>com.google.auth.appengine*</packages>
+                </group>
+              </groups>
+              <windowtitle>google-auth-library ${project.version}</windowtitle>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,7 @@
 # Format:
 # module:released-version:current-version
 
+google-auth-library:0.15.0:0.15.1-SNAPSHOT
 google-auth-library-parent:0.15.0:0.15.1-SNAPSHOT
 google-auth-library-appengine:0.15.0:0.15.1-SNAPSHOT
 google-auth-library-credentials:0.15.0:0.15.1-SNAPSHOT


### PR DESCRIPTION
We now will use `gcp-docpublisher` to push built javadoc to our documentation staging area.