### PR TITLE
Add google-auth-library-bom artifact

### DIFF
--- a/bom/README.md
+++ b/bom/README.md
@@ -1,0 +1,28 @@
+# Google Auth Library Bill of Materials
+
+The `google-auth-library-bom` is a pom that can be used to import consistent versions of
+`google-auth-library` components plus its dependencies.
+
+To use it in Maven, add the following to your `pom.xml`:
+
+[//]: # ({x-version-update-start:google-auth-library-bom:released})
+```xml
+<dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-libary-bom</artifactId>
+      <version>0.15.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+  </dependencies>
+</dependencyManagement>
+```
+[//]: # ({x-version-update-end})
+
+## License
+
+Apache 2.0 - See [LICENSE] for more information.
+
+[LICENSE]: https://github.com/googleapis/google-auth-library-java/blob/master/LICENSE

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.google.auth</groupId>
+  <artifactId>google-auth-library-bom</artifactId>
+  <version>0.15.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-bom:current} -->
+  <packaging>pom</packaging>
+  <name>Google Auth Library for Java BOM</name>
+  <description>
+    BOM for Google Auth Library for Java
+  </description>
+  <url>https://github.com/googleapis/google-auth-library-java</url>
+
+  <licenses>
+    <license>
+      <name>Apache-2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <organization>
+    <name>Google</name>
+    <url>http://www.google.com/</url>
+  </organization>
+
+  <scm>
+    <connection>scm:git:https://github.com/googleapis/google-auth-library-java.git</connection>
+    <developerConnection>scm:git:https://github.com/googleapis/google-auth-library-java.git</developerConnection>
+    <url>https://github.com/googleapis/google-auth-library-java</url>
+  </scm>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-credentials</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-http</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-oauth2-appengine</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.5</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>false</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
     <module>credentials</module>
     <module>oauth2_http</module>
     <module>appengine</module>
+    <module>bom</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
We should be publishing a BOM for dependency management.
This bom should be imported by google-cloud-java and the com.google.cloud:libraries-bom