### PR TITLE
Release google-auth-library-java v0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.15.0</version>
+  <version>0.16.0</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})
@@ -44,7 +44,7 @@ If you are using Gradle, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.15.0'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.16.0'
 ```
 [//]: # ({x-version-update-end})
 
@@ -52,7 +52,7 @@ If you are using SBT, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.15.0"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.16.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.15.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.16.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bom/README.md
+++ b/bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-libary-bom</artifactId>
-      <version>0.15.0</version>
+      <version>0.16.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-bom</artifactId>
-  <version>0.15.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-bom:current} -->
+  <version>0.16.0</version><!-- {x-version-update:google-auth-library-bom:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java BOM</name>
   <description>

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.15.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.16.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.15.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.16.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-parent</artifactId>
-  <version>0.15.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+  <version>0.16.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
   <description>Client libraries providing authentication and

--- a/versions.txt
+++ b/versions.txt
@@ -1,8 +1,9 @@
 # Format:
 # module:released-version:current-version
 
-google-auth-library:0.15.0:0.15.1-SNAPSHOT
-google-auth-library-parent:0.15.0:0.15.1-SNAPSHOT
-google-auth-library-appengine:0.15.0:0.15.1-SNAPSHOT
-google-auth-library-credentials:0.15.0:0.15.1-SNAPSHOT
-google-auth-library-oauth2-http:0.15.0:0.15.1-SNAPSHOT
+google-auth-library:0.16.0:0.16.0
+google-auth-library-bom:0.16.0:0.16.0
+google-auth-library-parent:0.16.0:0.16.0
+google-auth-library-appengine:0.16.0:0.16.0
+google-auth-library-credentials:0.16.0:0.16.0
+google-auth-library-oauth2-http:0.16.0:0.16.0


### PR DESCRIPTION
This pull request was generated using releasetool.

06-04-2019 09:41 PDT

### New Features
- Add google-auth-library-bom artifact ([#256](https://github.com/google/google-auth-library-java/pull/256))

### Dependencies
- Update dependency com.google.http-client:google-http-client to v1.30.0 ([#261](https://github.com/google/google-auth-library-java/pull/261))
- Update dependency com.google.http-client:google-http-client to v1.29.2 ([#259](https://github.com/google/google-auth-library-java/pull/259))
- Update dependency org.sonatype.plugins:nexus-staging-maven-plugin to v1.6.8 ([#257](https://github.com/google/google-auth-library-java/pull/257))
- Update to latest app engine SDK version ([#258](https://github.com/google/google-auth-library-java/pull/258))
- Update dependency org.apache.maven.plugins:maven-source-plugin to v3.1.0 ([#254](https://github.com/google/google-auth-library-java/pull/254))
- Update dependency org.jacoco:jacoco-maven-plugin to v0.8.4 ([#255](https://github.com/google/google-auth-library-java/pull/255))
- Update dependency org.apache.maven.plugins:maven-jar-plugin to v3.1.2 ([#252](https://github.com/google/google-auth-library-java/pull/252))
- Update dependency org.apache.maven.plugins:maven-source-plugin to v2.4 ([#253](https://github.com/google/google-auth-library-java/pull/253))

### Documentation
- Javadoc publish kokoro job uses docpublisher ([#243](https://github.com/google/google-auth-library-java/pull/243))

### Internal / Testing Changes
- Add renovate.json ([#245](https://github.com/google/google-auth-library-java/pull/245))
- Bump next snapshot ([#240](https://github.com/google/google-auth-library-java/pull/240))