### PR TITLE
Release google-auth-library-java v0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.16.0</version>
+  <version>0.16.1</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})
@@ -44,7 +44,7 @@ If you are using Gradle, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.16.0'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.16.1'
 ```
 [//]: # ({x-version-update-end})
 
@@ -52,7 +52,7 @@ If you are using SBT, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.16.0"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.16.1"
 ```
 [//]: # ({x-version-update-end})
 

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.16.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.16.1</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bom/README.md
+++ b/bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-libary-bom</artifactId>
-      <version>0.16.0</version>
+      <version>0.16.1</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-bom</artifactId>
-  <version>0.16.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-bom:current} -->
+  <version>0.16.1</version><!-- {x-version-update:google-auth-library-bom:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java BOM</name>
   <description>

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.16.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.16.1</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.16.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.16.1</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-parent</artifactId>
-  <version>0.16.1-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+  <version>0.16.1</version><!-- {x-version-update:google-auth-library-parent:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
   <description>Client libraries providing authentication and

--- a/versions.txt
+++ b/versions.txt
@@ -1,9 +1,9 @@
 # Format:
 # module:released-version:current-version
 
-google-auth-library:0.16.0:0.16.1-SNAPSHOT
-google-auth-library-bom:0.16.0:0.16.1-SNAPSHOT
-google-auth-library-parent:0.16.0:0.16.1-SNAPSHOT
-google-auth-library-appengine:0.16.0:0.16.1-SNAPSHOT
-google-auth-library-credentials:0.16.0:0.16.1-SNAPSHOT
-google-auth-library-oauth2-http:0.16.0:0.16.1-SNAPSHOT
+google-auth-library:0.16.1:0.16.1
+google-auth-library-bom:0.16.1:0.16.1
+google-auth-library-parent:0.16.1:0.16.1
+google-auth-library-appengine:0.16.1:0.16.1
+google-auth-library-credentials:0.16.1:0.16.1
+google-auth-library-oauth2-http:0.16.1:0.16.1


### PR DESCRIPTION
This pull request was generated using releasetool.

06-06-2019 13:10 PDT

### Dependencies
- Update dependency com.google.http-client:google-http-client to v1.30.1 ([#265](https://github.com/google/google-auth-library-java/pull/265))

### Internal / Testing Changes
- Add credentials for autorelease ([#267](https://github.com/google/google-auth-library-java/pull/267))
- Add developers section to google-auth-library-bom pom.xml
- Bump next snapshot ([#264](https://github.com/google/google-auth-library-java/pull/264))