### PR TITLE
Autorelease will also auto publish

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -25,4 +25,3 @@ mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 mvn test -B
 
 bash $KOKORO_GFILE_DIR/codecov.sh
-#bash .kokoro/codecov.sh

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -30,7 +30,6 @@ AUTORELEASE="false"
 if [[ -n "${AUTORELEASE_PR}" ]]
 then
   AUTORELEASE="true"
-  echo "should autorelease"
 fi
 
 mvn clean install deploy -B \

--- a/.kokoro/release/stage.sh
+++ b/.kokoro/release/stage.sh
@@ -26,9 +26,17 @@ pushd $(dirname "$0")/../../
 setup_environment_secrets
 create_settings_xml_file "settings.xml"
 
-mvn clean install deploy \
+AUTORELEASE="false"
+if [[ -n "${AUTORELEASE_PR}" ]]
+then
+  AUTORELEASE="true"
+  echo "should autorelease"
+fi
+
+mvn clean install deploy -B \
   --settings ${MAVEN_SETTINGS_FILE} \
   -DperformRelease=true \
   -Dgpg.executable=gpg \
   -Dgpg.passphrase=${GPG_PASSPHRASE} \
-  -Dgpg.homedir=${GPG_HOMEDIR}
+  -Dgpg.homedir=${GPG_HOMEDIR} \
+  -Ddeploy.autorelease=${AUTORELEASE}

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <project.junit.version>4.12</project.junit.version>
     <project.guava.version>27.1-android</project.guava.version>
     <project.appengine.version>1.9.74</project.appengine.version>
+    <deploy.autorelease>false</deploy.autorelease>
   </properties>
 
   <dependencyManagement>
@@ -129,7 +130,7 @@
           <configuration>
             <serverId>ossrh</serverId>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            <autoReleaseAfterClose>${deploy.autorelease}</autoReleaseAfterClose>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
After autorelease pushes to Sonatype, the release will automatically be promoted.

You can do the same behavior locally by setting `-Ddeploy.autorelease=true` when running `mvn deploy`