### PR TITLE
Add Signer for impersonatied credentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -180,7 +180,7 @@ public class ImpersonatedCredentials extends GoogleCredentials implements Servic
    * @param toSign bytes to sign
    * @return signed bytes
    * @throws SigningException if the attempt to sign the provided bytes failed
-   * @see <a href="https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/signBlob>Blob Signing</a>
+   * @see <a href="https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/signBlob">Blob Signing</a>
    */
   @Override
   public byte[] sign(byte[] toSign) {

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Google Inc. All rights reserved.
+ * Copyright 2019, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -163,6 +163,12 @@ public class ImpersonatedCredentials extends GoogleCredentials implements Servic
         .build();
   }
 
+  /**
+   * Returns the email field of the serviceAccount that is being impersonated.
+   *
+   * @return email address of the impesonated service account.
+   */
+  @Override
   public String getAccount() {
       return this.targetPrincipal;
   }
@@ -189,7 +195,6 @@ public class ImpersonatedCredentials extends GoogleCredentials implements Servic
   }
 
   private String getSignature(String bytes) throws IOException {
-
     String signBlobUrl = String.format(IAM_SIGN_ENDPOINT, getAccount());
     GenericUrl genericUrl = new GenericUrl(signBlobUrl);
 

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Google Inc. All rights reserved.
+ * Copyright 2018, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-java/issues/5043

Adds `Signer` capability to `ImpersonatedCredentials`.  This will allow impersonated credentials to make signedURLs and basically, just sign bytes as the `target_credential`

sample usage

```java
          
ServiceAccountCredentials sourceCredentials = ServiceAccountCredentials
          .fromStream(new FileInputStream("svc_account.json"));
sourceCredentials = (ServiceAccountCredentials) sourceCredentials
 .createScoped(Arrays.asList("https://www.googleapis.com/auth/iam"));

ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
          "impersonated-account@project.iam.gserviceaccount.com", null,
          Arrays.asList("https://www.googleapis.com/auth/devstorage.read_only"), 300);

Storage storage_service = StorageOptions.newBuilder()
.setCredentials(targetCredentials)
.build()
.getService();

String BUCKET_NAME1= "bucket-name";
String BLOB_NAME1 = "object-name.txt";

BlobInfo BLOB_INFO1 = BlobInfo.newBuilder(BUCKET_NAME1, BLOB_NAME1).build();

URL url =
storage_service.signUrl(
  BLOB_INFO1,
  140,
  TimeUnit.MINUTES,
     Storage.SignUrlOption.httpMethod(HttpMethod.GET), 
     Storage.SignUrlOption.withV4Signature());
System.out.println(url);

```