### PR TITLE
Log warnings and deprecate AppEngineCredentials.getApplicationDefault

### DIFF
--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -35,6 +35,7 @@ import com.google.appengine.api.appidentity.AppIdentityService;
 import com.google.appengine.api.appidentity.AppIdentityService.GetAccessTokenResult;
 import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
 import com.google.auth.ServiceAccountSigner;
+import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.MoreObjects;
@@ -46,14 +47,20 @@ import java.io.ObjectInputStream;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Objects;
+import java.util.logging.Logger;
 
 /**
- * OAuth2 credentials representing the built-in service account for Google App ENgine.
+ * OAuth2 credentials representing the built-in service account for Google App Engine. You should
+ * only use this class if you are running on AppEngine and are using urlfetch.
  *
  * <p>Fetches access tokens from the App Identity service.
  */
 public class AppEngineCredentials extends GoogleCredentials implements ServiceAccountSigner {
 
+  private static final Logger LOGGER = Logger.getLogger(AppEngineCredentials.class.getName());
+  private static final String APPLICATION_DEFAULT_CREDENTIALS_WARNING = "You are attempting to "
+      + "fetch Application Default Credentials from com.google.auth.appengine.AppEngineCredentials."
+      + " This method will not return a com.google.auth.appengine.AppEngineCredentials instance.";
   private static final long serialVersionUID = -2627708355455064660L;
 
   private final String appIdentityServiceClassName;
@@ -61,6 +68,29 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
   private final boolean scopesRequired;
 
   private transient AppIdentityService appIdentityService;
+
+  /**
+   * {@inheritDoc}
+   * @deprecated AppEngineCredentials should be instantiated via its Builder. See
+   * https://github.com/googleapis/google-auth-library-java#google-auth-library-appengine
+   */
+  @Deprecated
+  public static GoogleCredentials getApplicationDefault() throws IOException {
+    LOGGER.warning(APPLICATION_DEFAULT_CREDENTIALS_WARNING);
+    return GoogleCredentials.getApplicationDefault();
+  }
+
+  /**
+   * {@inheritDoc}
+   * @deprecated AppEngineCredentials should be instantiated via its Builder. See
+   * https://github.com/googleapis/google-auth-library-java#google-auth-library-appengine
+   */
+  @Deprecated
+  public static GoogleCredentials getApplicationDefault(HttpTransportFactory transportFactory)
+      throws IOException {
+    LOGGER.warning(APPLICATION_DEFAULT_CREDENTIALS_WARNING);
+    return GoogleCredentials.getApplicationDefault(transportFactory);
+  }
 
   private AppEngineCredentials(Collection<String> scopes, AppIdentityService appIdentityService) {
     this.scopes = scopes == null ? ImmutableSet.<String>of() : ImmutableList.copyOf(scopes);

--- a/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
+++ b/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
@@ -39,11 +39,16 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.api.client.http.HttpTransport;
 import com.google.auth.Credentials;
+import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.BaseSerializationTest;
 import com.google.auth.oauth2.GoogleCredentials;
 
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -250,5 +255,52 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
       }
     }
     assertTrue("Bearer token not found", found);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void warnsDefaultCredentials() throws IOException {
+    Logger logger = Logger.getLogger(AppEngineCredentials.class.getName());
+    LogHandler handler = new LogHandler();
+    logger.addHandler(handler);
+
+    Credentials unused = AppEngineCredentials.getApplicationDefault();
+
+    LogRecord message = handler.getRecord();
+    assertTrue(message.getMessage().contains("You are attempting to"));
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void warnsDefaultCredentialsWithTransport() throws IOException {
+    Logger logger = Logger.getLogger(AppEngineCredentials.class.getName());
+    LogHandler handler = new LogHandler();
+    logger.addHandler(handler);
+
+    Credentials unused = AppEngineCredentials.getApplicationDefault(
+        new HttpTransportFactory() {
+          @Override
+          public HttpTransport create() {
+            return null;
+          }
+        });
+
+    LogRecord message = handler.getRecord();
+    assertTrue(message.getMessage().contains("You are attempting to"));
+  }
+
+  private class LogHandler extends Handler {
+    LogRecord lastRecord;
+
+    public void publish(LogRecord record) {
+      lastRecord = record;
+    }
+
+    public LogRecord getRecord() {
+      return lastRecord;
+    }
+
+    public void close() {}
+    public void flush() {}
   }
 }

--- a/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
+++ b/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
@@ -259,12 +259,16 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
 
   @Test
   @SuppressWarnings("deprecation")
-  public void warnsDefaultCredentials() throws IOException {
+  public void warnsDefaultCredentials() {
     Logger logger = Logger.getLogger(AppEngineCredentials.class.getName());
     LogHandler handler = new LogHandler();
     logger.addHandler(handler);
 
-    Credentials unused = AppEngineCredentials.getApplicationDefault();
+    try {
+      Credentials unused = AppEngineCredentials.getApplicationDefault();
+    } catch (IOException ex) {
+      // ignore - this may just fail for not being in a supported environment
+    }
 
     LogRecord message = handler.getRecord();
     assertTrue(message.getMessage().contains("You are attempting to"));
@@ -272,18 +276,22 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
 
   @Test
   @SuppressWarnings("deprecation")
-  public void warnsDefaultCredentialsWithTransport() throws IOException {
+  public void warnsDefaultCredentialsWithTransport() {
     Logger logger = Logger.getLogger(AppEngineCredentials.class.getName());
     LogHandler handler = new LogHandler();
     logger.addHandler(handler);
 
-    Credentials unused = AppEngineCredentials.getApplicationDefault(
-        new HttpTransportFactory() {
-          @Override
-          public HttpTransport create() {
-            return null;
-          }
-        });
+    try {
+      Credentials unused = AppEngineCredentials.getApplicationDefault(
+          new HttpTransportFactory() {
+            @Override
+            public HttpTransport create() {
+              return null;
+            }
+          });
+    } catch (IOException ex) {
+      // ignore - this may just fail for not being in a supported environment
+    }
 
     LogRecord message = handler.getRecord();
     assertTrue(message.getMessage().contains("You are attempting to"));


### PR DESCRIPTION
Currently, you can call `getApplicationDefault()` on a subclass of `GoogleCredentials` which will try to detect your execution environment. This does not make sense for the subclasses as you are not guaranteed to get back an instance of that class (especially for `com.google.auth.appengine.AppEngineCredentials` which will never be returned).

This PR marks `getApplicationDefault()` and `getApplicationDefault(HttpTransportFactory)` as deprecated to signal to users that they should not be using this method. It does turn around and call `GoogleCredentials.getApplicationDefault()` to preserve the current behavior, but it also logs a warning.

This should help alleviate some confusion around `com.google.auth.appengine.AppEngineCredentials` like in #272 