### PR TITLE
feat: adds JwtCredentials with custom claims

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019, Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+/**
+ * Value class representing the set of fields used as the payload of a JWT token.
+ *
+ * <p>To create and customize claims, use the builder:
+ *
+ * <pre><code>
+ * Claims claims = Claims.newBuilder()
+ *     .setAudience("https://example.com/some-audience")
+ *     .setIssuer("some-issuer@example.com")
+ *     .setSubject("some-subject@example.com")
+ *     .build();
+ * </code></pre>
+ */
+@AutoValue
+public abstract class JwtClaims implements Serializable {
+  private static final long serialVersionUID = 4974444151019426702L;
+
+  @Nullable
+  abstract String getAudience();
+
+  @Nullable
+  abstract String getIssuer();
+
+  @Nullable
+  abstract String getSubject();
+
+  static Builder newBuilder() {
+    return new AutoValue_JwtClaims.Builder();
+  }
+
+  /**
+   * Returns a new Claims instance with overridden fields.
+   *
+   * <p>Any non-null field will overwrite the value from the original claims instance.
+   *
+   * @param other claims to override
+   * @return new claims
+   */
+  public JwtClaims merge(JwtClaims other) {
+    return newBuilder()
+        .setAudience(other.getAudience() == null ? getAudience() : other.getAudience())
+        .setIssuer(other.getIssuer() == null ? getIssuer() : other.getIssuer())
+        .setSubject(other.getSubject() == null ? getSubject() : other.getSubject())
+        .build();
+  }
+
+  /**
+   * Returns whether or not this set of claims is complete.
+   *
+   * <p>Audience, issuer, and subject are required to be set in order to use the claim set for a
+   * JWT token. An incomplete Claims instance is useful for overriding claims when using {@link
+   * ServiceAccountJwtAccessCredentials#jwtWithClaims(JwtClaims)} or {@link
+   * JwtCredentials#jwtWithClaims(JwtClaims)}.
+   *
+   * @return
+   */
+  public boolean isComplete() {
+    return getAudience() != null && getIssuer() != null && getSubject() != null;
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setAudience(String audience);
+
+    abstract Builder setIssuer(String issuer);
+
+    abstract Builder setSubject(String subject);
+
+    abstract JwtClaims build();
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
@@ -84,8 +84,8 @@ public abstract class JwtClaims implements Serializable {
   /**
    * Returns whether or not this set of claims is complete.
    *
-   * <p>Audience, issuer, and subject are required to be set in order to use the claim set for a
-   * JWT token. An incomplete Claims instance is useful for overriding claims when using {@link
+   * <p>Audience, issuer, and subject are required to be set in order to use the claim set for a JWT
+   * token. An incomplete Claims instance is useful for overriding claims when using {@link
    * ServiceAccountJwtAccessCredentials#jwtWithClaims(JwtClaims)} or {@link
    * JwtCredentials#jwtWithClaims(JwtClaims)}.
    *

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -86,7 +86,8 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   transient Clock clock;
 
   private transient String jwt;
-  private transient Long expiry;
+  // The date (represented as seconds since the epoch) that the generated JWT expires
+  private transient Long expiryInSeconds;
 
   JwtCredentials(Builder builder) {
     this.privateKey = Preconditions.checkNotNull(builder.getPrivateKey());
@@ -118,8 +119,8 @@ public class JwtCredentials extends Credentials implements JwtProvider {
       payload.setIssuer(claims.getIssuer());
       payload.setSubject(claims.getSubject());
       payload.setIssuedAtTimeSeconds(currentTime / 1000);
-      expiry = currentTime / 1000 + lifeSpanSeconds;
-      payload.setExpirationTimeSeconds(expiry);
+      expiryInSeconds = currentTime / 1000 + lifeSpanSeconds;
+      payload.setExpirationTimeSeconds(expiryInSeconds);
 
       JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
 
@@ -133,7 +134,8 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   }
 
   private boolean shouldRefresh() {
-    return expiry == null || getClock().currentTimeMillis() / 1000 > expiry - CLOCK_SKEW;
+    return expiryInSeconds == null ||
+        getClock().currentTimeMillis() / 1000 > expiryInSeconds - CLOCK_SKEW;
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -31,7 +31,6 @@
 
 package com.google.auth.oauth2;
 
-import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebToken;
 import com.google.api.client.util.Clock;
@@ -72,8 +71,8 @@ import javax.annotation.Nullable;
  */
 public class JwtCredentials extends Credentials implements JwtProvider {
   private static final String JWT_ACCESS_PREFIX = OAuth2Utils.BEARER_PREFIX;
-  private static final String JWT_INCOMPLETE_ERROR_MESSAGE = "JWT claims must contain audience, "
-      + "issuer, and subject.";
+  private static final String JWT_INCOMPLETE_ERROR_MESSAGE =
+      "JWT claims must contain audience, " + "issuer, and subject.";
   private static final long CLOCK_SKEW = TimeUnit.MINUTES.toSeconds(5);
 
   // byte[] is serializable, so the lock variable can be final
@@ -82,8 +81,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   private final String privateKeyId;
   private final Claims claims;
   private final Long lifeSpanSeconds;
-  @VisibleForTesting
-  transient Clock clock;
+  @VisibleForTesting transient Clock clock;
 
   private transient String jwt;
   // The date (represented as seconds since the epoch) that the generated JWT expires
@@ -102,9 +100,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     return new Builder();
   }
 
-  /**
-   * Refresh the token by discarding the cached token and metadata and rebuilding a new one.
-   */
+  /** Refresh the token by discarding the cached token and metadata and rebuilding a new one. */
   @Override
   public void refresh() throws IOException {
     JsonWebSignature.Header header = new JsonWebSignature.Header();
@@ -125,18 +121,19 @@ public class JwtCredentials extends Credentials implements JwtProvider {
       this.expiryInSeconds = payload.getExpirationTimeSeconds();
 
       try {
-        this.jwt = JsonWebSignature.signUsingRsaSha256(privateKey, OAuth2Utils.JSON_FACTORY, header,
-            payload);
+        this.jwt =
+            JsonWebSignature.signUsingRsaSha256(
+                privateKey, OAuth2Utils.JSON_FACTORY, header, payload);
       } catch (GeneralSecurityException e) {
-        throw new IOException("Error signing service account JWT access header with private key.",
-            e);
+        throw new IOException(
+            "Error signing service account JWT access header with private key.", e);
       }
     }
   }
 
   private boolean shouldRefresh() {
-    return expiryInSeconds == null ||
-        getClock().currentTimeMillis() / 1000 > expiryInSeconds - CLOCK_SKEW;
+    return expiryInSeconds == null
+        || getClock().currentTimeMillis() / 1000 > expiryInSeconds - CLOCK_SKEW;
   }
 
   /**
@@ -313,9 +310,9 @@ public class JwtCredentials extends Credentials implements JwtProvider {
      * Returns whether or not this set of claims is complete.
      *
      * <p>Audience, issuer, and subject are required to be set in order to use the claim set for a
-     * JWT token. An incomplete Claims instance is useful for overriding claims when using
-     * {@link ServiceAccountJwtAccessCredentials#jwtWithClaims(Claims)} or
-     * {@link JwtCredentials#jwtWithClaims(Claims)}.
+     * JWT token. An incomplete Claims instance is useful for overriding claims when using {@link
+     * ServiceAccountJwtAccessCredentials#jwtWithClaims(Claims)} or {@link
+     * JwtCredentials#jwtWithClaims(Claims)}.
      *
      * @return
      */
@@ -326,8 +323,11 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     @AutoValue.Builder
     abstract static class Builder {
       abstract Builder setAudience(String audience);
+
       abstract Builder setIssuer(String issuer);
+
       abstract Builder setSubject(String subject);
+
       abstract Claims build();
     }
   }

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Google Inc. All rights reserved.
+ * Copyright 2019, Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google Inc. nor the names of its
+ *    * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -213,7 +213,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     protected Builder() {}
 
     public Builder setPrivateKey(PrivateKey privateKey) {
-      this.privateKey = privateKey;
+      this.privateKey = Preconditions.checkNotNull(privateKey);
       return this;
     }
 
@@ -222,7 +222,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
 
     public Builder setPrivateKeyId(String privateKeyId) {
-      this.privateKeyId = privateKeyId;
+      this.privateKeyId = Preconditions.checkNotNull(privateKeyId);
       return this;
     }
 
@@ -231,7 +231,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
 
     public Builder setClaims(Claims claims) {
-      this.claims = claims;
+      this.claims = Preconditions.checkNotNull(claims);
       return this;
     }
 
@@ -240,7 +240,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
 
     public Builder setLifeSpanSeconds(Long lifeSpanSeconds) {
-      this.lifeSpanSeconds = lifeSpanSeconds;
+      this.lifeSpanSeconds = Preconditions.checkNotNull(lifeSpanSeconds);
       return this;
     }
 
@@ -249,7 +249,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
 
     Builder setClock(Clock clock) {
-      this.clock = clock;
+      this.clock = Preconditions.checkNotNull(clock);
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -56,6 +56,7 @@ public class JwtCredentials extends Credentials {
   private static final String JWT_ACCESS_PREFIX = OAuth2Utils.BEARER_PREFIX;
   private static final String JWT_INCOMPLETE_ERROR_MESSAGE = "JWT claims must contain audience, "
       + "issuer, and subject.";
+  private static final long CLOCK_SKEW = TimeUnit.MINUTES.toSeconds(5);
 
   // byte[] is serializable, so the lock variable can be final
   private final Object lock = new byte[0];
@@ -111,7 +112,7 @@ public class JwtCredentials extends Credentials {
   }
 
   private boolean shouldRefresh() {
-    return expiry == null || getClock().currentTimeMillis() / 1000 > expiry;
+    return expiry == null || getClock().currentTimeMillis() / 1000 > expiry - CLOCK_SKEW;
   }
 
   public JwtCredentials withClaims(Claims newClaims) {

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -72,7 +72,7 @@ import javax.annotation.Nullable;
  * </code>
  * </pre>
  */
-public class JwtCredentials extends Credentials {
+public class JwtCredentials extends Credentials implements JwtProvider {
   private static final String JWT_ACCESS_PREFIX = OAuth2Utils.BEARER_PREFIX;
   private static final String JWT_INCOMPLETE_ERROR_MESSAGE = "JWT claims must contain audience, "
       + "issuer, and subject.";
@@ -145,7 +145,8 @@ public class JwtCredentials extends Credentials {
    *        values.
    * @return new credentials
    */
-  public JwtCredentials withClaims(Claims newClaims) {
+  @Override
+  public JwtCredentials jwtWithClaims(Claims newClaims) {
     return JwtCredentials.newBuilder()
         .setPrivateKey(privateKey)
         .setPrivateKeyId(privateKeyId)

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -314,8 +314,8 @@ public class JwtCredentials extends Credentials implements JwtProvider {
      *
      * <p>Audience, issuer, and subject are required to be set in order to use the claim set for a
      * JWT token. An incomplete Claims instance is useful for overriding claims when using
-     * {@link ServiceAccountJwtAccessCredentials#withClaims(Claims)} or
-     * {@link JwtCredentials#withClaims(Claims)}.
+     * {@link ServiceAccountJwtAccessCredentials#jwtWithClaims(Claims)} or
+     * {@link JwtCredentials#jwtWithClaims(Claims)}.
      *
      * @return
      */

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -263,8 +263,6 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
   }
 
-
-
   /**
    * Value class representing the set of fields used as the payload of a JWT token.
    *

--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -57,8 +57,7 @@ import javax.annotation.Nullable;
  *
  * <p>Uses a JSON Web Token (JWT) directly in the request metadata to provide authorization.
  *
- * <pre>
- * <code>
+ * <pre><code>
  * JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
  *     .setAudience("https://example.com/some-audience")
  *     .setIssuer("some-issuer@example.com")
@@ -69,8 +68,7 @@ import javax.annotation.Nullable;
  *     .setPrivateKeyId("private-key-id")
  *     .setClaims(claims)
  *     .build();
- * </code>
- * </pre>
+ * </code></pre>
  */
 public class JwtCredentials extends Credentials implements JwtProvider {
   private static final String JWT_ACCESS_PREFIX = OAuth2Utils.BEARER_PREFIX;
@@ -141,8 +139,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   /**
    * Returns a copy of these credentials with modified claims.
    *
-   * @param newClaims New claims. Any unspecified claim fields will default to the the current
-   *        values.
+   * @param newClaims New claims. Any unspecified claim fields default to the the current values.
    * @return new credentials
    */
   @Override
@@ -263,23 +260,25 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
   }
 
+
+
   /**
    * Value class representing the set of fields used as the payload of a JWT token.
    *
    * <p>To create and customize claims, use the builder:
    *
-   * <pre>
-   * <code>
+   * <pre><code>
    * Claims claims = Claims.newBuilder()
    *     .setAudience("https://example.com/some-audience")
    *     .setIssuer("some-issuer@example.com")
    *     .setSubject("some-subject@example.com")
    *     .build();
-   * </code>
-   * </pre>
+   * </code></pre>
    */
   @AutoValue
   public abstract static class Claims implements Serializable {
+    private static final long serialVersionUID = 4974444151019426702L;
+
     @Nullable
     abstract String getAudience();
 

--- a/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
@@ -40,7 +40,7 @@ public interface JwtProvider {
   /**
    * Returns a new JwtCredentials instance with modified claims.
    *
-   * @param newClaims New claims. Any unspecified claim fields will default to the the current
+   * @param newClaims new claims. Any unspecified claim fields will default to the the current
    *     values.
    * @return new credentials
    */

--- a/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Google Inc. All rights reserved.
+ * Copyright 2019, Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google Inc. nor the names of its
+ *    * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *

--- a/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
@@ -44,5 +44,5 @@ public interface JwtProvider {
    *     values.
    * @return new credentials
    */
-  JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims);
+  JwtCredentials jwtWithClaims(JwtClaims newClaims);
 }

--- a/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Interface for creating custom JWT tokens
+ */
+@Beta
+public interface JwtProvider {
+
+  /**
+   * Returns a new JwtCredentials instance with modified claims.
+   *
+   * @param newClaims New claims. Any unspecified claim fields will default to the the current
+   *        values.
+   * @return new credentials
+   */
+  JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims);
+}

--- a/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtProvider.java
@@ -33,9 +33,7 @@ package com.google.auth.oauth2;
 
 import com.google.common.annotations.Beta;
 
-/**
- * Interface for creating custom JWT tokens
- */
+/** Interface for creating custom JWT tokens */
 @Beta
 public interface JwtProvider {
 
@@ -43,7 +41,7 @@ public interface JwtProvider {
    * Returns a new JwtCredentials instance with modified claims.
    *
    * @param newClaims New claims. Any unspecified claim fields will default to the the current
-   *        values.
+   *     values.
    * @return new credentials
    */
   JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims);

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -530,14 +530,13 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * Returns a new JwtCredentials instance with modified claims.
    *
    * @param newClaims New claims. Any unspecified claim fields will default to the the current
-   *        values.
+   *     values.
    * @return new credentials
    */
   @Override
   public JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims) {
-    JwtCredentials.Claims.Builder claimsBuilder = JwtCredentials.Claims.newBuilder()
-        .setIssuer(clientEmail)
-        .setSubject(clientEmail);
+    JwtCredentials.Claims.Builder claimsBuilder =
+        JwtCredentials.Claims.newBuilder().setIssuer(clientEmail).setSubject(clientEmail);
     return JwtCredentials.newBuilder()
         .setPrivateKey(privateKey)
         .setPrivateKeyId(privateKeyId)

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -84,7 +84,8 @@ import java.util.Objects;
  *
  * <p>By default uses a JSON Web Token (JWT) to fetch access tokens.
  */
-public class ServiceAccountCredentials extends GoogleCredentials implements ServiceAccountSigner {
+public class ServiceAccountCredentials extends GoogleCredentials
+    implements JwtProvider, ServiceAccountSigner {
 
   private static final long serialVersionUID = 7807543542681217978L;
   private static final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
@@ -441,6 +442,26 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
     } catch (NoSuchAlgorithmException | InvalidKeyException | SignatureException ex) {
       throw new SigningException("Failed to sign the provided bytes", ex);
     }
+  }
+
+  /**
+   * Returns a new JwtCredentials instance with modified claims.
+   *
+   * @param newClaims New claims. Any unspecified claim fields will default to the the current
+   *        values.
+   * @return new credentials
+   */
+  @Override
+  public JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims) {
+    JwtCredentials.Claims.Builder claimsBuilder = JwtCredentials.Claims.newBuilder()
+        .setIssuer(clientEmail)
+        .setSubject(clientEmail);
+    return JwtCredentials.newBuilder()
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(privateKeyId)
+        .setClaims(claimsBuilder.build().merge(newClaims))
+        .setClock(clock)
+        .build();
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -534,13 +534,13 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @return new credentials
    */
   @Override
-  public JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims) {
-    JwtCredentials.Claims.Builder claimsBuilder =
-        JwtCredentials.Claims.newBuilder().setIssuer(clientEmail).setSubject(clientEmail);
+  public JwtCredentials jwtWithClaims(JwtClaims newClaims) {
+    JwtClaims.Builder claimsBuilder =
+        JwtClaims.newBuilder().setIssuer(clientEmail).setSubject(clientEmail);
     return JwtCredentials.newBuilder()
         .setPrivateKey(privateKey)
         .setPrivateKeyId(privateKeyId)
-        .setClaims(claimsBuilder.build().merge(newClaims))
+        .setJwtClaims(claimsBuilder.build().merge(newClaims))
         .setClock(clock)
         .build();
   }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -529,7 +529,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
   /**
    * Returns a new JwtCredentials instance with modified claims.
    *
-   * @param newClaims New claims. Any unspecified claim fields will default to the the current
+   * @param newClaims new claims. Any unspecified claim fields will default to the the current
    *     values.
    * @return new credentials
    */

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -86,7 +86,6 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   private final URI defaultAudience;
   private transient LoadingCache<JwtCredentials.Claims, JwtCredentials> credentialsCache;
 
-
   // Until we expose this to the users it can remain transient and non-serializable
   @VisibleForTesting
   transient Clock clock = Clock.SYSTEM;

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -281,14 +281,13 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    * Returns a new JwtCredentials instance with modified claims.
    *
    * @param newClaims New claims. Any unspecified claim fields will default to the the current
-   *        values.
+   *     values.
    * @return new credentials
    */
   @Override
   public JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims) {
-    JwtCredentials.Claims.Builder claimsBuilder = JwtCredentials.Claims.newBuilder()
-        .setIssuer(clientEmail)
-        .setSubject(clientEmail);
+    JwtCredentials.Claims.Builder claimsBuilder =
+        JwtCredentials.Claims.newBuilder().setIssuer(clientEmail).setSubject(clientEmail);
     if (defaultAudience != null) {
       claimsBuilder.setAudience(defaultAudience.toString());
     }
@@ -338,11 +337,12 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     }
 
     try {
-      JwtCredentials.Claims defaultClaims = JwtCredentials.Claims.newBuilder()
-          .setAudience(uri.toString())
-          .setIssuer(clientEmail)
-          .setSubject(clientEmail)
-          .build();
+      JwtCredentials.Claims defaultClaims =
+          JwtCredentials.Claims.newBuilder()
+              .setAudience(uri.toString())
+              .setIssuer(clientEmail)
+              .setSubject(clientEmail)
+              .build();
       JwtCredentials credentials = credentialsCache.get(defaultClaims);
       return credentials.getRequestMetadata(uri);
     } catch (ExecutionException e) {
@@ -359,9 +359,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     }
   }
 
-  /**
-   * Discard any cached data
-   */
+  /** Discard any cached data */
   @Override
   public void refresh() {
     credentialsCache.invalidateAll();

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -280,7 +280,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   /**
    * Returns a new JwtCredentials instance with modified claims.
    *
-   * @param newClaims New claims. Any unspecified claim fields will default to the the current
+   * @param newClaims new claims. Any unspecified claim fields will default to the the current
    *     values.
    * @return new credentials
    */

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -78,6 +78,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   static final String JWT_ACCESS_PREFIX = OAuth2Utils.BEARER_PREFIX;
   @VisibleForTesting
   static final long LIFE_SPAN_SECS = TimeUnit.HOURS.toSeconds(1);
+  private static final long CLOCK_SKEW = TimeUnit.MINUTES.toSeconds(5);
 
   private final String clientId;
   private final String clientEmail;
@@ -239,7 +240,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   private LoadingCache<JwtCredentials.Claims, JwtCredentials> createCache() {
     return CacheBuilder.newBuilder()
         .maximumSize(100)
-        .expireAfterWrite(LIFE_SPAN_SECS - 300, TimeUnit.SECONDS)
+        .expireAfterWrite(LIFE_SPAN_SECS - CLOCK_SKEW, TimeUnit.SECONDS)
         .ticker(
             new Ticker() {
               @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -265,7 +265,14 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
         );
   }
 
-  public JwtCredentials withClaims(JwtCredentials.Claims claims) {
+  /**
+   * Returns a new JwtCredentials instance with modified claims.
+   *
+   * @param newClaims New claims. Any unspecified claim fields will default to the the current
+   *        values.
+   * @return new credentials
+   */
+  public JwtCredentials withClaims(JwtCredentials.Claims newClaims) {
     JwtCredentials.Claims.Builder claimsBuilder = JwtCredentials.Claims.newBuilder()
         .setIssuer(clientEmail)
         .setSubject(clientEmail);
@@ -275,7 +282,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     return JwtCredentials.newBuilder()
         .setPrivateKey(privateKey)
         .setPrivateKeyId(privateKeyId)
-        .setClaims(claimsBuilder.build().merge(claims))
+        .setClaims(claimsBuilder.build().merge(newClaims))
         .setLifeSpanSeconds(LIFE_SPAN_SECS)
         .setClock(clock)
         .build();

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -72,7 +72,7 @@ import java.util.concurrent.TimeUnit;
  * <p>Uses a JSON Web Token (JWT) directly in the request metadata to provide authorization.
  */
 public class ServiceAccountJwtAccessCredentials extends Credentials
-    implements ServiceAccountSigner {
+    implements JwtProvider, ServiceAccountSigner {
 
   private static final long serialVersionUID = -7274955171379494197L;
   static final String JWT_ACCESS_PREFIX = OAuth2Utils.BEARER_PREFIX;
@@ -272,7 +272,8 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    *        values.
    * @return new credentials
    */
-  public JwtCredentials withClaims(JwtCredentials.Claims newClaims) {
+  @Override
+  public JwtCredentials jwtWithClaims(JwtCredentials.Claims newClaims) {
     JwtCredentials.Claims.Builder claimsBuilder = JwtCredentials.Claims.newBuilder()
         .setIssuer(clientEmail)
         .setSubject(clientEmail);

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -265,12 +265,19 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   }
 
   public JwtCredentials withClaims(JwtCredentials.Claims claims) {
-    try {
-      return credentialsCache.get(claims);
-    } catch (ExecutionException e) {
-      // Should never happen
-      throw new IllegalStateException("generateJwtAccess threw an unexpected checked exception", e.getCause());
+    JwtCredentials.Claims.Builder claimsBuilder = JwtCredentials.Claims.newBuilder()
+        .setIssuer(clientEmail)
+        .setSubject(clientEmail);
+    if (defaultAudience != null) {
+      claimsBuilder.setAudience(defaultAudience.toString());
     }
+    return JwtCredentials.newBuilder()
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(privateKeyId)
+        .setClaims(claimsBuilder.build().merge(claims))
+        .setLifeSpanSeconds(LIFE_SPAN_SECS)
+        .setClock(clock)
+        .build();
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -253,11 +253,12 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
             new CacheLoader<JwtCredentials.Claims, JwtCredentials>() {
               @Override
               public JwtCredentials load(JwtCredentials.Claims claims) throws Exception {
-                System.out.println("creating credentials");
                 return JwtCredentials.newBuilder()
                     .setPrivateKey(privateKey)
                     .setPrivateKeyId(privateKeyId)
                     .setClaims(claims)
+                    .setLifeSpanSeconds(LIFE_SPAN_SECS)
+                    .setClock(clock)
                     .build();
               }
             }

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -43,27 +43,26 @@ import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.util.Clock;
 import com.google.auth.http.AuthHttpConstants;
 import java.io.IOException;
-import java.net.URI;
 import java.security.PrivateKey;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
 public class JwtCredentialsTest extends BaseSerializationTest {
-  private static final String PRIVATE_KEY_ID =
-      "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
-  private static final String PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n"
-      + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
-      + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
-      + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
-      + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
-      + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
-      + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
-      + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
-      + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
-      + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
-      + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
-      + "==\n-----END PRIVATE KEY-----\n";
+  private static final String PRIVATE_KEY_ID = "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
+  private static final String PRIVATE_KEY =
+      "-----BEGIN PRIVATE KEY-----\n"
+          + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
+          + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
+          + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
+          + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
+          + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
+          + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
+          + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
+          + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
+          + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
+          + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
+          + "==\n-----END PRIVATE KEY-----\n";
   private static final String JWT_ACCESS_PREFIX =
       ServiceAccountJwtAccessCredentials.JWT_ACCESS_PREFIX;
   private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
@@ -78,16 +77,18 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
-    JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
-        .setAudience("some-audience")
-        .setIssuer("some-issuer")
-        .setSubject("some-subject")
-        .build();
-    JwtCredentials credentials = JwtCredentials.newBuilder()
-        .setClaims(claims)
-        .setPrivateKey(getPrivateKey())
-        .setPrivateKeyId(PRIVATE_KEY_ID)
-        .build();
+    JwtCredentials.Claims claims =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("some-audience")
+            .setIssuer("some-issuer")
+            .setSubject("some-subject")
+            .build();
+    JwtCredentials credentials =
+        JwtCredentials.newBuilder()
+            .setClaims(claims)
+            .setPrivateKey(getPrivateKey())
+            .setPrivateKeyId(PRIVATE_KEY_ID)
+            .build();
 
     JwtCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
@@ -99,15 +100,13 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   @Test
   public void builder_requiresPrivateKey() {
     try {
-      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
-          .setAudience("some-audience")
-          .setIssuer("some-issuer")
-          .setSubject("some-subject")
-          .build();
-      JwtCredentials.newBuilder()
-          .setClaims(claims)
-          .setPrivateKeyId(PRIVATE_KEY_ID)
-          .build();
+      JwtCredentials.Claims claims =
+          JwtCredentials.Claims.newBuilder()
+              .setAudience("some-audience")
+              .setIssuer("some-issuer")
+              .setSubject("some-subject")
+              .build();
+      JwtCredentials.newBuilder().setClaims(claims).setPrivateKeyId(PRIVATE_KEY_ID).build();
       fail("Should throw exception");
     } catch (NullPointerException ex) {
       // expected
@@ -117,15 +116,13 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   @Test
   public void builder_requiresPrivateKeyId() {
     try {
-      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
-          .setAudience("some-audience")
-          .setIssuer("some-issuer")
-          .setSubject("some-subject")
-          .build();
-      JwtCredentials.newBuilder()
-          .setClaims(claims)
-          .setPrivateKey(getPrivateKey())
-          .build();
+      JwtCredentials.Claims claims =
+          JwtCredentials.Claims.newBuilder()
+              .setAudience("some-audience")
+              .setIssuer("some-issuer")
+              .setSubject("some-subject")
+              .build();
+      JwtCredentials.newBuilder().setClaims(claims).setPrivateKey(getPrivateKey()).build();
       fail("Should throw exception");
     } catch (NullPointerException ex) {
       // expected
@@ -148,8 +145,7 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   @Test
   public void builder_requiresCompleteClaims() {
     try {
-      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
-          .build();
+      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder().build();
       JwtCredentials.newBuilder()
           .setClaims(claims)
           .setPrivateKeyId(PRIVATE_KEY_ID)
@@ -160,18 +156,21 @@ public class JwtCredentialsTest extends BaseSerializationTest {
       // expected
     }
   }
+
   @Test
   public void claims_merge_overwritesFields() {
-    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder()
-        .setAudience("audience-1")
-        .setIssuer("issuer-1")
-        .setSubject("subject-1")
-        .build();
-    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder()
-        .setAudience("audience-2")
-        .setIssuer("issuer-2")
-        .setSubject("subject-2")
-        .build();
+    JwtCredentials.Claims claims1 =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("audience-1")
+            .setIssuer("issuer-1")
+            .setSubject("subject-1")
+            .build();
+    JwtCredentials.Claims claims2 =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("audience-2")
+            .setIssuer("issuer-2")
+            .setSubject("subject-2")
+            .build();
     JwtCredentials.Claims merged = claims1.merge(claims2);
 
     assertEquals("audience-2", merged.getAudience());
@@ -181,14 +180,14 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void claims_merge_defaultValues() {
-    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder()
-        .setAudience("audience-1")
-        .setIssuer("issuer-1")
-        .setSubject("subject-1")
-        .build();
-    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder()
-        .setAudience("audience-2")
-        .build();
+    JwtCredentials.Claims claims1 =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("audience-1")
+            .setIssuer("issuer-1")
+            .setSubject("subject-1")
+            .build();
+    JwtCredentials.Claims claims2 =
+        JwtCredentials.Claims.newBuilder().setAudience("audience-2").build();
     JwtCredentials.Claims merged = claims1.merge(claims2);
 
     assertEquals("audience-2", merged.getAudience());
@@ -209,79 +208,93 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void claims_equals() {
-    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder()
-        .setAudience("audience-1")
-        .setIssuer("issuer-1")
-        .setSubject("subject-1")
-        .build();
-    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder()
-        .setAudience("audience-1")
-        .setIssuer("issuer-1")
-        .setSubject("subject-1")
-        .build();
+    JwtCredentials.Claims claims1 =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("audience-1")
+            .setIssuer("issuer-1")
+            .setSubject("subject-1")
+            .build();
+    JwtCredentials.Claims claims2 =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("audience-1")
+            .setIssuer("issuer-1")
+            .setSubject("subject-1")
+            .build();
 
     assertEquals(claims1, claims2);
   }
 
   @Test
   public void jwtWithClaims_overwritesClaims() throws IOException {
-    JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
-        .setAudience("some-audience")
-        .setIssuer("some-issuer")
-        .setSubject("some-subject")
-        .build();
-    JwtCredentials credentials = JwtCredentials.newBuilder()
-        .setClaims(claims)
-        .setPrivateKey(getPrivateKey())
-        .setPrivateKeyId(PRIVATE_KEY_ID)
-        .build();
-    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder()
-        .setAudience("some-audience2")
-        .setIssuer("some-issuer2")
-        .setSubject("some-subject2")
-        .build();
+    JwtCredentials.Claims claims =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("some-audience")
+            .setIssuer("some-issuer")
+            .setSubject("some-subject")
+            .build();
+    JwtCredentials credentials =
+        JwtCredentials.newBuilder()
+            .setClaims(claims)
+            .setPrivateKey(getPrivateKey())
+            .setPrivateKeyId(PRIVATE_KEY_ID)
+            .build();
+    JwtCredentials.Claims claims2 =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("some-audience2")
+            .setIssuer("some-issuer2")
+            .setSubject("some-subject2")
+            .build();
     JwtCredentials credentials2 = credentials.jwtWithClaims(claims2);
     Map<String, List<String>> metadata = credentials2.getRequestMetadata();
-    verifyJwtAccess(metadata, "some-audience2","some-issuer2", "some-subject2", PRIVATE_KEY_ID);
+    verifyJwtAccess(metadata, "some-audience2", "some-issuer2", "some-subject2", PRIVATE_KEY_ID);
   }
 
   @Test
   public void jwtWithClaims_defaultsClaims() throws IOException {
-    JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
-        .setAudience("some-audience")
-        .setIssuer("some-issuer")
-        .setSubject("some-subject")
-        .build();
-    JwtCredentials credentials = JwtCredentials.newBuilder()
-        .setClaims(claims)
-        .setPrivateKey(getPrivateKey())
-        .setPrivateKeyId(PRIVATE_KEY_ID)
-        .build();
+    JwtCredentials.Claims claims =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("some-audience")
+            .setIssuer("some-issuer")
+            .setSubject("some-subject")
+            .build();
+    JwtCredentials credentials =
+        JwtCredentials.newBuilder()
+            .setClaims(claims)
+            .setPrivateKey(getPrivateKey())
+            .setPrivateKeyId(PRIVATE_KEY_ID)
+            .build();
     JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder().build();
     JwtCredentials credentials2 = credentials.jwtWithClaims(claims2);
     Map<String, List<String>> metadata = credentials2.getRequestMetadata();
-    verifyJwtAccess(metadata, "some-audience","some-issuer", "some-subject", PRIVATE_KEY_ID);
+    verifyJwtAccess(metadata, "some-audience", "some-issuer", "some-subject", PRIVATE_KEY_ID);
   }
 
   @Test
   public void getRequestMetadata_hasJwtAccess() throws IOException {
-    JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
-        .setAudience("some-audience")
-        .setIssuer("some-issuer")
-        .setSubject("some-subject")
-        .build();
-    JwtCredentials credentials = JwtCredentials.newBuilder()
-        .setClaims(claims)
-        .setPrivateKey(getPrivateKey())
-        .setPrivateKeyId(PRIVATE_KEY_ID)
-        .build();
+    JwtCredentials.Claims claims =
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("some-audience")
+            .setIssuer("some-issuer")
+            .setSubject("some-subject")
+            .build();
+    JwtCredentials credentials =
+        JwtCredentials.newBuilder()
+            .setClaims(claims)
+            .setPrivateKey(getPrivateKey())
+            .setPrivateKeyId(PRIVATE_KEY_ID)
+            .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata();
-    verifyJwtAccess(metadata, "some-audience","some-issuer", "some-subject", PRIVATE_KEY_ID);
+    verifyJwtAccess(metadata, "some-audience", "some-issuer", "some-subject", PRIVATE_KEY_ID);
   }
 
-  private void verifyJwtAccess(Map<String, List<String>> metadata, String expectedAudience,
-      String expectedIssuer, String expectedSubject, String expectedKeyId) throws IOException {
+  private void verifyJwtAccess(
+      Map<String, List<String>> metadata,
+      String expectedAudience,
+      String expectedIssuer,
+      String expectedSubject,
+      String expectedKeyId)
+      throws IOException {
     assertNotNull(metadata);
     List<String> authorizations = metadata.get(AuthHttpConstants.AUTHORIZATION);
     assertNotNull("Authorization headers not found", authorizations);

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Google Inc. All rights reserved.
+ * Copyright 2019, Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google Inc. nor the names of its
+ *    * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2019, Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -224,7 +224,7 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void withClaims_overwritesClaims() throws IOException {
+  public void jwtWithClaims_overwritesClaims() throws IOException {
     JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
         .setAudience("some-audience")
         .setIssuer("some-issuer")
@@ -240,13 +240,13 @@ public class JwtCredentialsTest extends BaseSerializationTest {
         .setIssuer("some-issuer2")
         .setSubject("some-subject2")
         .build();
-    JwtCredentials credentials2 = credentials.withClaims(claims2);
+    JwtCredentials credentials2 = credentials.jwtWithClaims(claims2);
     Map<String, List<String>> metadata = credentials2.getRequestMetadata();
     verifyJwtAccess(metadata, "some-audience2","some-issuer2", "some-subject2", PRIVATE_KEY_ID);
   }
 
   @Test
-  public void withClaims_defaultsClaims() throws IOException {
+  public void jwtWithClaims_defaultsClaims() throws IOException {
     JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
         .setAudience("some-audience")
         .setIssuer("some-issuer")
@@ -258,7 +258,7 @@ public class JwtCredentialsTest extends BaseSerializationTest {
         .setPrivateKeyId(PRIVATE_KEY_ID)
         .build();
     JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder().build();
-    JwtCredentials credentials2 = credentials.withClaims(claims2);
+    JwtCredentials credentials2 = credentials.jwtWithClaims(claims2);
     Map<String, List<String>> metadata = credentials2.getRequestMetadata();
     verifyJwtAccess(metadata, "some-audience","some-issuer", "some-subject", PRIVATE_KEY_ID);
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import com.google.api.client.util.Clock;
+import java.io.IOException;
+import java.security.PrivateKey;
+import org.junit.Test;
+
+public class JwtCredentialsTest extends BaseSerializationTest {
+  private static final String PRIVATE_KEY_ID =
+      "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
+  private static final String PRIVATE_KEY = "-----BEGIN PRIVATE KEY-----\n"
+      + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
+      + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
+      + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
+      + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
+      + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
+      + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
+      + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
+      + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
+      + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
+      + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
+      + "==\n-----END PRIVATE KEY-----\n";
+  static PrivateKey getPrivateKey() {
+    try {
+      return ServiceAccountCredentials.privateKeyFromPkcs8(PRIVATE_KEY);
+    } catch (IOException ex) {
+      return null;
+    }
+  }
+
+  @Test
+  public void serialize() throws IOException, ClassNotFoundException {
+    JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
+        .setAudience("some-audience")
+        .setIssuer("some-issuer")
+        .setSubject("some-subject")
+        .build();
+    JwtCredentials credentials = JwtCredentials.newBuilder()
+        .setClaims(claims)
+        .setPrivateKey(getPrivateKey())
+        .setPrivateKeyId(PRIVATE_KEY_ID)
+        .build();
+
+    JwtCredentials deserializedCredentials = serializeAndDeserialize(credentials);
+    assertEquals(credentials, deserializedCredentials);
+    assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
+    assertEquals(credentials.toString(), deserializedCredentials.toString());
+    assertSame(deserializedCredentials.getClock(), Clock.SYSTEM);
+  }
+
+  @Test
+  public void builder_requiresPrivateKey() {
+    try {
+      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
+          .setAudience("some-audience")
+          .setIssuer("some-issuer")
+          .setSubject("some-subject")
+          .build();
+      JwtCredentials.newBuilder()
+          .setClaims(claims)
+          .setPrivateKeyId(PRIVATE_KEY_ID)
+          .build();
+      fail("Should throw exception");
+    } catch (NullPointerException ex) {
+      // expected
+    }
+  }
+
+  @Test
+  public void builder_requiresPrivateKeyId() {
+    try {
+      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
+          .setAudience("some-audience")
+          .setIssuer("some-issuer")
+          .setSubject("some-subject")
+          .build();
+      JwtCredentials.newBuilder()
+          .setClaims(claims)
+          .setPrivateKey(getPrivateKey())
+          .build();
+      fail("Should throw exception");
+    } catch (NullPointerException ex) {
+      // expected
+    }
+  }
+
+  @Test
+  public void builder_requiresClaims() {
+    try {
+      JwtCredentials.newBuilder()
+          .setPrivateKeyId(PRIVATE_KEY_ID)
+          .setPrivateKey(getPrivateKey())
+          .build();
+      fail("Should throw exception");
+    } catch (NullPointerException ex) {
+      // expected
+    }
+  }
+
+  @Test
+  public void builder_requiresCompleteClaims() {
+    try {
+      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder()
+          .build();
+      JwtCredentials.newBuilder()
+          .setClaims(claims)
+          .setPrivateKeyId(PRIVATE_KEY_ID)
+          .setPrivateKey(getPrivateKey())
+          .build();
+      fail("Should throw exception");
+    } catch (IllegalStateException ex) {
+      // expected
+    }
+  }
+  @Test
+  public void claims_merge_overwritesFields() {
+    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder()
+        .setAudience("audience-1")
+        .setIssuer("issuer-1")
+        .setSubject("subject-1")
+        .build();
+    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder()
+        .setAudience("audience-2")
+        .setIssuer("issuer-2")
+        .setSubject("subject-2")
+        .build();
+    JwtCredentials.Claims merged = claims1.merge(claims2);
+
+    assertEquals("audience-2", merged.getAudience());
+    assertEquals("issuer-2", merged.getIssuer());
+    assertEquals("subject-2", merged.getSubject());
+  }
+
+  @Test
+  public void claims_merge_defaultValues() {
+    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder()
+        .setAudience("audience-1")
+        .setIssuer("issuer-1")
+        .setSubject("subject-1")
+        .build();
+    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder()
+        .setAudience("audience-2")
+        .build();
+    JwtCredentials.Claims merged = claims1.merge(claims2);
+
+    assertEquals("audience-2", merged.getAudience());
+    assertEquals("issuer-1", merged.getIssuer());
+    assertEquals("subject-1", merged.getSubject());
+  }
+
+  @Test
+  public void claims_merge_null() {
+    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder().build();
+    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder().build();
+    JwtCredentials.Claims merged = claims1.merge(claims2);
+
+    assertNull(merged.getAudience());
+    assertNull(merged.getIssuer());
+    assertNull(merged.getSubject());
+  }
+
+  @Test
+  public void claims_equals() {
+    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder()
+        .setAudience("audience-1")
+        .setIssuer("issuer-1")
+        .setSubject("subject-1")
+        .build();
+    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder()
+        .setAudience("audience-1")
+        .setIssuer("issuer-1")
+        .setSubject("subject-1")
+        .build();
+
+    assertEquals(claims1, claims2);
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -186,8 +186,7 @@ public class JwtCredentialsTest extends BaseSerializationTest {
             .setIssuer("issuer-1")
             .setSubject("subject-1")
             .build();
-    JwtClaims claims2 =
-        JwtClaims.newBuilder().setAudience("audience-2").build();
+    JwtClaims claims2 = JwtClaims.newBuilder().setAudience("audience-2").build();
     JwtClaims merged = claims1.merge(claims2);
 
     assertEquals("audience-2", merged.getAudience());

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -77,15 +77,15 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
-    JwtCredentials.Claims claims =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims =
+        JwtClaims.newBuilder()
             .setAudience("some-audience")
             .setIssuer("some-issuer")
             .setSubject("some-subject")
             .build();
     JwtCredentials credentials =
         JwtCredentials.newBuilder()
-            .setClaims(claims)
+            .setJwtClaims(claims)
             .setPrivateKey(getPrivateKey())
             .setPrivateKeyId(PRIVATE_KEY_ID)
             .build();
@@ -100,13 +100,13 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   @Test
   public void builder_requiresPrivateKey() {
     try {
-      JwtCredentials.Claims claims =
-          JwtCredentials.Claims.newBuilder()
+      JwtClaims claims =
+          JwtClaims.newBuilder()
               .setAudience("some-audience")
               .setIssuer("some-issuer")
               .setSubject("some-subject")
               .build();
-      JwtCredentials.newBuilder().setClaims(claims).setPrivateKeyId(PRIVATE_KEY_ID).build();
+      JwtCredentials.newBuilder().setJwtClaims(claims).setPrivateKeyId(PRIVATE_KEY_ID).build();
       fail("Should throw exception");
     } catch (NullPointerException ex) {
       // expected
@@ -116,13 +116,13 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   @Test
   public void builder_requiresPrivateKeyId() {
     try {
-      JwtCredentials.Claims claims =
-          JwtCredentials.Claims.newBuilder()
+      JwtClaims claims =
+          JwtClaims.newBuilder()
               .setAudience("some-audience")
               .setIssuer("some-issuer")
               .setSubject("some-subject")
               .build();
-      JwtCredentials.newBuilder().setClaims(claims).setPrivateKey(getPrivateKey()).build();
+      JwtCredentials.newBuilder().setJwtClaims(claims).setPrivateKey(getPrivateKey()).build();
       fail("Should throw exception");
     } catch (NullPointerException ex) {
       // expected
@@ -145,9 +145,9 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   @Test
   public void builder_requiresCompleteClaims() {
     try {
-      JwtCredentials.Claims claims = JwtCredentials.Claims.newBuilder().build();
+      JwtClaims claims = JwtClaims.newBuilder().build();
       JwtCredentials.newBuilder()
-          .setClaims(claims)
+          .setJwtClaims(claims)
           .setPrivateKeyId(PRIVATE_KEY_ID)
           .setPrivateKey(getPrivateKey())
           .build();
@@ -159,19 +159,19 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void claims_merge_overwritesFields() {
-    JwtCredentials.Claims claims1 =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims1 =
+        JwtClaims.newBuilder()
             .setAudience("audience-1")
             .setIssuer("issuer-1")
             .setSubject("subject-1")
             .build();
-    JwtCredentials.Claims claims2 =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims2 =
+        JwtClaims.newBuilder()
             .setAudience("audience-2")
             .setIssuer("issuer-2")
             .setSubject("subject-2")
             .build();
-    JwtCredentials.Claims merged = claims1.merge(claims2);
+    JwtClaims merged = claims1.merge(claims2);
 
     assertEquals("audience-2", merged.getAudience());
     assertEquals("issuer-2", merged.getIssuer());
@@ -180,15 +180,15 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void claims_merge_defaultValues() {
-    JwtCredentials.Claims claims1 =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims1 =
+        JwtClaims.newBuilder()
             .setAudience("audience-1")
             .setIssuer("issuer-1")
             .setSubject("subject-1")
             .build();
-    JwtCredentials.Claims claims2 =
-        JwtCredentials.Claims.newBuilder().setAudience("audience-2").build();
-    JwtCredentials.Claims merged = claims1.merge(claims2);
+    JwtClaims claims2 =
+        JwtClaims.newBuilder().setAudience("audience-2").build();
+    JwtClaims merged = claims1.merge(claims2);
 
     assertEquals("audience-2", merged.getAudience());
     assertEquals("issuer-1", merged.getIssuer());
@@ -197,9 +197,9 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void claims_merge_null() {
-    JwtCredentials.Claims claims1 = JwtCredentials.Claims.newBuilder().build();
-    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder().build();
-    JwtCredentials.Claims merged = claims1.merge(claims2);
+    JwtClaims claims1 = JwtClaims.newBuilder().build();
+    JwtClaims claims2 = JwtClaims.newBuilder().build();
+    JwtClaims merged = claims1.merge(claims2);
 
     assertNull(merged.getAudience());
     assertNull(merged.getIssuer());
@@ -208,14 +208,14 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void claims_equals() {
-    JwtCredentials.Claims claims1 =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims1 =
+        JwtClaims.newBuilder()
             .setAudience("audience-1")
             .setIssuer("issuer-1")
             .setSubject("subject-1")
             .build();
-    JwtCredentials.Claims claims2 =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims2 =
+        JwtClaims.newBuilder()
             .setAudience("audience-1")
             .setIssuer("issuer-1")
             .setSubject("subject-1")
@@ -226,20 +226,20 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void jwtWithClaims_overwritesClaims() throws IOException {
-    JwtCredentials.Claims claims =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims =
+        JwtClaims.newBuilder()
             .setAudience("some-audience")
             .setIssuer("some-issuer")
             .setSubject("some-subject")
             .build();
     JwtCredentials credentials =
         JwtCredentials.newBuilder()
-            .setClaims(claims)
+            .setJwtClaims(claims)
             .setPrivateKey(getPrivateKey())
             .setPrivateKeyId(PRIVATE_KEY_ID)
             .build();
-    JwtCredentials.Claims claims2 =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims2 =
+        JwtClaims.newBuilder()
             .setAudience("some-audience2")
             .setIssuer("some-issuer2")
             .setSubject("some-subject2")
@@ -251,19 +251,19 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void jwtWithClaims_defaultsClaims() throws IOException {
-    JwtCredentials.Claims claims =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims =
+        JwtClaims.newBuilder()
             .setAudience("some-audience")
             .setIssuer("some-issuer")
             .setSubject("some-subject")
             .build();
     JwtCredentials credentials =
         JwtCredentials.newBuilder()
-            .setClaims(claims)
+            .setJwtClaims(claims)
             .setPrivateKey(getPrivateKey())
             .setPrivateKeyId(PRIVATE_KEY_ID)
             .build();
-    JwtCredentials.Claims claims2 = JwtCredentials.Claims.newBuilder().build();
+    JwtClaims claims2 = JwtClaims.newBuilder().build();
     JwtCredentials credentials2 = credentials.jwtWithClaims(claims2);
     Map<String, List<String>> metadata = credentials2.getRequestMetadata();
     verifyJwtAccess(metadata, "some-audience", "some-issuer", "some-subject", PRIVATE_KEY_ID);
@@ -271,15 +271,15 @@ public class JwtCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void getRequestMetadata_hasJwtAccess() throws IOException {
-    JwtCredentials.Claims claims =
-        JwtCredentials.Claims.newBuilder()
+    JwtClaims claims =
+        JwtClaims.newBuilder()
             .setAudience("some-audience")
             .setIssuer("some-issuer")
             .setSubject("some-subject")
             .build();
     JwtCredentials credentials =
         JwtCredentials.newBuilder()
-            .setClaims(claims)
+            .setJwtClaims(claims)
             .setPrivateKey(getPrivateKey())
             .setPrivateKeyId(PRIVATE_KEY_ID)
             .build();

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -649,6 +649,58 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
     testFromStreamException(serviceAccountStream, "private_key_id");
   }
 
+  @Test
+  public void withClaims_overrideAudience() throws IOException {
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
+    Credentials withAudience = credentials.withClaims(
+        JwtCredentials.Claims.newBuilder()
+            .setAudience("new-audience")
+            .build());
+
+    Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
+
+    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, URI.create("new-audience"), SA_PRIVATE_KEY_ID);
+  }
+
+  @Test
+  public void withClaims_noAudience() throws IOException {
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .build();
+    try {
+      credentials.withClaims(JwtCredentials.Claims.newBuilder().build());
+      fail("Expected to throw exception for missing audience");
+    } catch (IllegalStateException ex) {
+      // expected exception
+    }
+  }
+
+  @Test
+  public void withClaims_defaultAudience() throws IOException {
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setDefaultAudience(URI.create("default-audience"))
+        .build();
+    Credentials withAudience = credentials.withClaims(JwtCredentials.Claims.newBuilder().build());
+
+    Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
+    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, URI.create("default-audience"), SA_PRIVATE_KEY_ID);
+  }
+
   private void verifyJwtAccess(Map<String, List<String>> metadata, String expectedEmail,
       URI expectedAudience, String expectedKeyId) throws IOException {
     assertNotNull(metadata);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -692,7 +692,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
             .build();
     Credentials withAudience =
         credentials.jwtWithClaims(
-            JwtCredentials.Claims.newBuilder().setAudience("new-audience").build());
+            JwtClaims.newBuilder().setAudience("new-audience").build());
 
     Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
 
@@ -710,7 +710,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
             .setPrivateKeyId(SA_PRIVATE_KEY_ID)
             .build();
     try {
-      credentials.jwtWithClaims(JwtCredentials.Claims.newBuilder().build());
+      credentials.jwtWithClaims(JwtClaims.newBuilder().build());
       fail("Expected to throw exception for missing audience");
     } catch (IllegalStateException ex) {
       // expected exception
@@ -729,7 +729,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
             .setDefaultAudience(URI.create("default-audience"))
             .build();
     Credentials withAudience =
-        credentials.jwtWithClaims(JwtCredentials.Claims.newBuilder().build());
+        credentials.jwtWithClaims(JwtClaims.newBuilder().build());
 
     Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, SA_CLIENT_EMAIL, URI.create("default-audience"), SA_PRIVATE_KEY_ID);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -650,7 +650,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
-  public void withClaims_overrideAudience() throws IOException {
+  public void jwtWithClaims_overrideAudience() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
         .setClientId(SA_CLIENT_ID)
@@ -658,7 +658,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
         .setPrivateKey(privateKey)
         .setPrivateKeyId(SA_PRIVATE_KEY_ID)
         .build();
-    Credentials withAudience = credentials.withClaims(
+    Credentials withAudience = credentials.jwtWithClaims(
         JwtCredentials.Claims.newBuilder()
             .setAudience("new-audience")
             .build());
@@ -669,7 +669,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
-  public void withClaims_noAudience() throws IOException {
+  public void jwtWithClaims_noAudience() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
         .setClientId(SA_CLIENT_ID)
@@ -678,7 +678,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
         .setPrivateKeyId(SA_PRIVATE_KEY_ID)
         .build();
     try {
-      credentials.withClaims(JwtCredentials.Claims.newBuilder().build());
+      credentials.jwtWithClaims(JwtCredentials.Claims.newBuilder().build());
       fail("Expected to throw exception for missing audience");
     } catch (IllegalStateException ex) {
       // expected exception
@@ -686,7 +686,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
-  public void withClaims_defaultAudience() throws IOException {
+  public void jwtWithClaims_defaultAudience() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
         .setClientId(SA_CLIENT_ID)
@@ -695,7 +695,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
         .setPrivateKeyId(SA_PRIVATE_KEY_ID)
         .setDefaultAudience(URI.create("default-audience"))
         .build();
-    Credentials withAudience = credentials.withClaims(JwtCredentials.Claims.newBuilder().build());
+    Credentials withAudience = credentials.jwtWithClaims(JwtCredentials.Claims.newBuilder().build());
 
     Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, SA_CLIENT_EMAIL, URI.create("default-audience"), SA_PRIVATE_KEY_ID);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -683,16 +683,16 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void jwtWithClaims_overrideAudience() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .build();
-    Credentials withAudience = credentials.jwtWithClaims(
-        JwtCredentials.Claims.newBuilder()
-            .setAudience("new-audience")
-            .build());
+    ServiceAccountJwtAccessCredentials credentials =
+        ServiceAccountJwtAccessCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .build();
+    Credentials withAudience =
+        credentials.jwtWithClaims(
+            JwtCredentials.Claims.newBuilder().setAudience("new-audience").build());
 
     Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
 
@@ -702,12 +702,13 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void jwtWithClaims_noAudience() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .build();
+    ServiceAccountJwtAccessCredentials credentials =
+        ServiceAccountJwtAccessCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .build();
     try {
       credentials.jwtWithClaims(JwtCredentials.Claims.newBuilder().build());
       fail("Expected to throw exception for missing audience");
@@ -719,14 +720,16 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   @Test
   public void jwtWithClaims_defaultAudience() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountJwtAccessCredentials credentials = ServiceAccountJwtAccessCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .setDefaultAudience(URI.create("default-audience"))
-        .build();
-    Credentials withAudience = credentials.jwtWithClaims(JwtCredentials.Claims.newBuilder().build());
+    ServiceAccountJwtAccessCredentials credentials =
+        ServiceAccountJwtAccessCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setDefaultAudience(URI.create("default-audience"))
+            .build();
+    Credentials withAudience =
+        credentials.jwtWithClaims(JwtCredentials.Claims.newBuilder().build());
 
     Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, SA_CLIENT_EMAIL, URI.create("default-audience"), SA_PRIVATE_KEY_ID);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -691,8 +691,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
             .setPrivateKeyId(SA_PRIVATE_KEY_ID)
             .build();
     Credentials withAudience =
-        credentials.jwtWithClaims(
-            JwtClaims.newBuilder().setAudience("new-audience").build());
+        credentials.jwtWithClaims(JwtClaims.newBuilder().setAudience("new-audience").build());
 
     Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
 
@@ -728,8 +727,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
             .setPrivateKeyId(SA_PRIVATE_KEY_ID)
             .setDefaultAudience(URI.create("default-audience"))
             .build();
-    Credentials withAudience =
-        credentials.jwtWithClaims(JwtClaims.newBuilder().build());
+    Credentials withAudience = credentials.jwtWithClaims(JwtClaims.newBuilder().build());
 
     Map<String, List<String>> metadata = withAudience.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, SA_CLIENT_EMAIL, URI.create("default-audience"), SA_PRIVATE_KEY_ID);

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -45,6 +45,17 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value-annotations</artifactId>
+      <version>1.6.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <version>1.6.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
     </dependency>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -40,6 +40,13 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>com.google.auto.value:auto-value</ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 
@@ -47,13 +54,15 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
-      <version>1.6.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value</artifactId>
-      <version>1.6.2</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.auth</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,8 @@
     <project.junit.version>4.12</project.junit.version>
     <project.guava.version>27.1-android</project.guava.version>
     <project.appengine.version>1.9.74</project.appengine.version>
+    <project.autovalue.version>1.6.2</project.autovalue.version>
+    <project.findbugs.version>3.0.2</project.findbugs.version>
     <deploy.autorelease>false</deploy.autorelease>
   </properties>
 
@@ -93,6 +95,22 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${project.guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auto.value</groupId>
+        <artifactId>auto-value-annotations</artifactId>
+        <version>${project.autovalue.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.auto.value</groupId>
+        <artifactId>auto-value</artifactId>
+        <version>${project.autovalue.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>${project.findbugs.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>
@@ -175,6 +193,11 @@
           <configuration>
             <reportNameSuffix>sponge_log</reportNameSuffix>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>3.1.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     {
       "packagePatterns": ["^com.google.appengine:appengine-"],
       "groupName": "AppEngine packages"
+    },
+    {
+      "packagePatterns": ["^com.google.auto.value:auto-"],
+      "groupName": "AutoValue packages"
     }
   ]
 }


### PR DESCRIPTION
Adds the ability to create custom JWT Credentials (`JwtCredentials`) with custom claims from a `ServiceAccountJwtAccessCredentials` instance.

* `ServiceAccountJwtAccessCredentials` will continue to provide on-demand credentials where the audience is based on the requested URI
* Adds `JwtCredentials` class which can be directly built with a `PrivateKey`, privateKeyId string, and custom `JwtCredentials.Claims`. You can also build new `JwtCredentials` via `JwtCredentials#jwtWithClaims(JwtCredentials.Claims)` which only overrides the new specified claims fields.
* Add `ServiceAccountJwtAccessCredentials#jwtWithClaims(JwtCredentials.Claims)` which will provide a `JwtCredentials` instance with custom claims
* Changed the credentials cache to be keyed of the full Claims object rather than just the URI.

Fixes: #30 