### PR TITLE
Fix declared dependencies from merge issue

### DIFF
--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -48,6 +48,10 @@
       <artifactId>google-auth-library-oauth2-http</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.appengine</groupId>
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
This direct dependency was added in #288, but the presubmit check was not yet set up. It was already being transitively pulled in via `google-auth-library-oauth2-http`