### PR TITLE
feat: add IDTokenCredential support

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -39,7 +39,6 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.json.JsonObjectParser;
-import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.util.GenericData;
 import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpTransportFactory;
@@ -196,8 +195,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
       throw new IOException("Empty content from metadata token server request.");
     }
     String rawToken = response.parseAsString();
-    JsonWebSignature jws = JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
-    return new IdToken(rawToken, jws);
+    return IdToken.create(rawToken);
   }
 
   private HttpResponse getMetadataResponse(String url) throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -174,27 +174,23 @@ public class ComputeEngineCredentials extends GoogleCredentials implements Servi
    */
   @Override
   public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options) throws IOException {
-    String optionalParams = "";
+    GenericUrl documentURL = new GenericUrl(getIdentityDocumentUrl());
     if (options != null) {
       if (options.contains(IdTokenProvider.Option.FORMAT_FULL))
-        optionalParams = "&format=full";
+        documentURL.set("format", "full");
       if (options.contains(IdTokenProvider.Option.LICENSES_TRUE))
-        optionalParams = optionalParams + "&licenses=TRUE";
+        documentURL.set("license","TRUE");
     }
-    String documentURL = getIdentityDocumentUrl() + "?audience=" + targetAudience + optionalParams;
+    documentURL.set("audience", targetAudience);
     HttpResponse response = null;
-    try {
-      response = getMetadataResponse(documentURL);
-      InputStream content = response.getContent();
-      if (content == null) {
-        throw new IOException("Empty content from metadata token server request.");
-      }
-      String rawToken = response.parseAsString();
-      JsonWebSignature jws =  JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
-      return new IdToken(rawToken, jws);
-    } catch (IOException ex) {
-      throw new IdTokenProvider.IdTokenProviderException("Unable to get identity document ", ex);
+    response = getMetadataResponse(documentURL.toString());
+    InputStream content = response.getContent();
+    if (content == null) {
+      throw new IOException("Empty content from metadata token server request.");
     }
+    String rawToken = response.parseAsString();
+    JsonWebSignature jws =  JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
+    return new IdToken(rawToken, jws);
   }
 
   private HttpResponse getMetadataResponse(String url) throws IOException {
@@ -359,8 +355,8 @@ public class ComputeEngineCredentials extends GoogleCredentials implements Servi
     }
     InputStream content = response.getContent();
     if (content == null) {
-      // Throw explicitly here on empty content to avoid NullPointerException from parseAs call.
-      // Mock transports will have success code with empty content by default.
+     // Throw explicitly here on empty content to avoid NullPointerException from parseAs call.
+     // Mock transports will have success code with empty content by default.
       throw new IOException("Empty content from metadata token server request.");
     }
     GenericData responseData = response.parseAs(GenericData.class);

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -42,6 +42,7 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.GenericData;
 import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.io.InputStream;
@@ -173,6 +174,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
    * @throws IOException if the attempt to get an IdToken failed
    * @return IdToken object which includes the raw id_token, JsonWebSignature
    */
+  @Beta
   @Override
   public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options)
       throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -164,8 +164,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
    * Returns a Google ID Token from the metadata server on ComputeEngine
    *
    * @param targetAudience the aud: field the IdToken should include
-   * @param options list of Credential specific options for the token. For example, an IDToken
-   *     for a ComputeEngineCredential could have the full formatted claims returned if
+   * @param options list of Credential specific options for the token. For example, an IDToken for a
+   *     ComputeEngineCredential could have the full formatted claims returned if
    *     IdTokenProvider.Option.FORMAT_FULL) is provided as a list option. Valid option values are:
    *     <br>
    *     IdTokenProvider.Option.FORMAT_FULL<br>
@@ -190,8 +190,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
       }
     }
     documentUrl.set("audience", targetAudience);
-    HttpResponse response = null;
-    response = getMetadataResponse(documentUrl.toString());
+    HttpResponse response = getMetadataResponse(documentUrl.toString());
     InputStream content = response.getContent();
     if (content == null) {
       throw new IOException("Empty content from metadata token server request.");

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -164,8 +164,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
    * Returns a Google ID Token from the metadata server on ComputeEngine
    *
    * @param targetAudience the aud: field the IdToken should include
-   * @param options list of Credential specific options for for the token. For example, an IDToken
-   *     for a ComputeEngineCredential could have the full formated claims returned if
+   * @param options list of Credential specific options for the token. For example, an IDToken
+   *     for a ComputeEngineCredential could have the full formatted claims returned if
    *     IdTokenProvider.Option.FORMAT_FULL) is provided as a list option. Valid option values are:
    *     <br>
    *     IdTokenProvider.Option.FORMAT_FULL<br>

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -95,9 +95,6 @@ public class ComputeEngineCredentials extends GoogleCredentials implements Servi
   private static final String PARSE_ERROR_ACCOUNT = "Error parsing service account response. ";
   private static final long serialVersionUID = -4113476462526554235L;
 
-  public static final String ID_TOKEN_FORMAT_FULL = "format";
-  public static final String ID_TOKEN_LICENSES_TRUE = "licenses";
-
   private final String transportFactoryClassName;
 
   private transient HttpTransportFactory transportFactory;
@@ -166,23 +163,22 @@ public class ComputeEngineCredentials extends GoogleCredentials implements Servi
    *                       token. For example, an IDToken for a
    *                       ComputeEngineCredential could have the full formated
    *                       claims returned if
-   *                       ComputeCredentials.ID_TOKEN_FORMAT_FULL) is provided as
+   *                       IdTokenProvider.Option.FORMAT_FULL) is provided as
    *                       a list option.  Valid option values are:
-   *                       * ComputeCredentials.ID_TOKEN_FORMAT_FULL<br>
-   *                       * ComputeCredentials.ID_TOKEN_LICENSES_TRUE<br>
+   *                       * IdTokenProvider.Option.FORMAT_FULL<br>
+   *                       * IdTokenProvider.Option.LICENSES_TRUE<br>
    *                       If no options are set, the default
    *                       are "&amp;format=standard&amp;licenses=false"
-   * @throws IdTokenProvider.IdTokenProviderException if the attempt to get an
-   *                                                  IdToken failed
+   * @throws IOException   if the attempt to get an IdToken failed
    * @return IdToken object which includes the raw id_token, JsonWebSignature.
    */
   @Override
-  public IdToken idTokenWithAudience(String targetAudience, List<String> options) {
+  public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options) throws IOException {
     String optionalParams = "";
     if (options != null) {
-      if (options.contains(ID_TOKEN_FORMAT_FULL))
+      if (options.contains(IdTokenProvider.Option.FORMAT_FULL))
         optionalParams = "&format=full";
-      if (options.contains(ID_TOKEN_LICENSES_TRUE))
+      if (options.contains(IdTokenProvider.Option.LICENSES_TRUE))
         optionalParams = optionalParams + "&licenses=TRUE";
     }
     String documentURL = getIdentityDocumentUrl() + "?audience=" + targetAudience + optionalParams;

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -156,34 +156,36 @@ public class ComputeEngineCredentials extends GoogleCredentials implements Servi
   }
 
   /**
-   * Returns an Google Id Token from the metadata server on ComputeEngine.
+   * Returns an Google ID Token from the metadata server on ComputeEngine
    * 
-   * @param targetAudience The aud: field the IdToken should include.
-   * @param options        List of Credential specific options for for the
-   *                       token. For example, an IDToken for a
-   *                       ComputeEngineCredential could have the full formated
-   *                       claims returned if
-   *                       IdTokenProvider.Option.FORMAT_FULL) is provided as
-   *                       a list option.  Valid option values are:
-   *                       * IdTokenProvider.Option.FORMAT_FULL<br>
-   *                       * IdTokenProvider.Option.LICENSES_TRUE<br>
-   *                       If no options are set, the default
-   *                       are "&amp;format=standard&amp;licenses=false"
-   * @throws IOException   if the attempt to get an IdToken failed
-   * @return IdToken object which includes the raw id_token, JsonWebSignature.
+   * @param targetAudience the aud: field the IdToken should include
+   * @param options list of Credential specific options for for the
+   * token. For example, an IDToken for a ComputeEngineCredential could have 
+   * the full formated claims returned if IdTokenProvider.Option.FORMAT_FULL) 
+   * is provided as a list option.  Valid option values are:
+   * IdTokenProvider.Option.FORMAT_FULL<br>
+   * IdTokenProvider.Option.LICENSES_TRUE<br>
+   * If no options are set, the default
+   * are "&amp;format=standard&amp;licenses=false"
+   * @throws IOException if the attempt to get an IdToken failed
+   * @return IdToken object which includes the raw id_token, JsonWebSignature
    */
   @Override
   public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options) throws IOException {
-    GenericUrl documentURL = new GenericUrl(getIdentityDocumentUrl());
+    GenericUrl documentUrl = new GenericUrl(getIdentityDocumentUrl());
     if (options != null) {
-      if (options.contains(IdTokenProvider.Option.FORMAT_FULL))
-        documentURL.set("format", "full");
-      if (options.contains(IdTokenProvider.Option.LICENSES_TRUE))
-        documentURL.set("license","TRUE");
+      if (options.contains(IdTokenProvider.Option.FORMAT_FULL)) {
+        documentUrl.set("format", "full");
+      }
+      if (options.contains(IdTokenProvider.Option.LICENSES_TRUE)) {
+        // if license will only get returned if format is also full
+        documentUrl.set("format", "full");
+        documentUrl.set("license","TRUE");
+      }
     }
-    documentURL.set("audience", targetAudience);
+    documentUrl.set("audience", targetAudience);
     HttpResponse response = null;
-    response = getMetadataResponse(documentURL.toString());
+    response = getMetadataResponse(documentUrl.toString());
     InputStream content = response.getContent();
     if (content == null) {
       throw new IOException("Empty content from metadata token server request.");

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -39,7 +39,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonObjectParser;
-import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.util.GenericData;
 import com.google.auth.Credentials;
 import com.google.auth.ServiceAccountSigner;
@@ -209,7 +208,6 @@ class IamUtils {
 
     GenericJson responseData = response.parseAs(GenericJson.class);
     String rawToken = OAuth2Utils.validateString(responseData, "token", PARSE_ERROR_MESSAGE);
-    JsonWebSignature signature = JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
-    return new IdToken(rawToken, signature);
+    return IdToken.create(rawToken);
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -31,10 +31,6 @@
 
 package com.google.auth.oauth2;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Map;
-
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
@@ -49,15 +45,19 @@ import com.google.auth.Credentials;
 import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.common.io.BaseEncoding;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
 /**
  * This internal class provides shared utilities for interacting with the IAM API for common
  * features like signing.
  */
 class IamUtils {
   private static final String SIGN_BLOB_URL_FORMAT =
-          "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:signBlob";
-  private static final String ID_TOKEN_URL_FORMAT = 
-          "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken";
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:signBlob";
+  private static final String ID_TOKEN_URL_FORMAT =
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken";
   private static final String PARSE_ERROR_MESSAGE = "Error parsing error message response. ";
   private static final String PARSE_ERROR_SIGNATURE = "Error parsing signature response. ";
 
@@ -71,21 +71,30 @@ class IamUtils {
    * @param additionalFields additional fields to send in the IAM call
    * @return signed bytes
    */
-  static byte[] sign(String serviceAccountEmail, Credentials credentials, HttpTransport transport,
-      byte[] toSign, Map<String, ?> additionalFields) {
+  static byte[] sign(
+      String serviceAccountEmail,
+      Credentials credentials,
+      HttpTransport transport,
+      byte[] toSign,
+      Map<String, ?> additionalFields) {
     BaseEncoding base64 = BaseEncoding.base64();
     String signature;
     try {
-      signature = getSignature(serviceAccountEmail, credentials, transport,
-              base64.encode(toSign), additionalFields);
+      signature =
+          getSignature(
+              serviceAccountEmail, credentials, transport, base64.encode(toSign), additionalFields);
     } catch (IOException ex) {
       throw new ServiceAccountSigner.SigningException("Failed to sign the provided bytes", ex);
     }
     return base64.decode(signature);
   }
 
-  private static String getSignature(String serviceAccountEmail, Credentials credentials,
-      HttpTransport transport, String bytes, Map<String, ?> additionalFields)
+  private static String getSignature(
+      String serviceAccountEmail,
+      Credentials credentials,
+      HttpTransport transport,
+      String bytes,
+      Map<String, ?> additionalFields)
       throws IOException {
     String signBlobUrl = String.format(SIGN_BLOB_URL_FORMAT, serviceAccountEmail);
     GenericUrl genericUrl = new GenericUrl(signBlobUrl);
@@ -98,8 +107,8 @@ class IamUtils {
     JsonHttpContent signContent = new JsonHttpContent(OAuth2Utils.JSON_FACTORY, signRequest);
 
     HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
-    HttpRequest request = transport.createRequestFactory(adapter)
-         .buildPostRequest(genericUrl, signContent);
+    HttpRequest request =
+        transport.createRequestFactory(adapter).buildPostRequest(genericUrl, signContent);
 
     JsonObjectParser parser = new JsonObjectParser(OAuth2Utils.JSON_FACTORY);
     request.setParser(parser);
@@ -109,14 +118,18 @@ class IamUtils {
     int statusCode = response.getStatusCode();
     if (statusCode >= 400 && statusCode < HttpStatusCodes.STATUS_CODE_SERVER_ERROR) {
       GenericData responseError = response.parseAs(GenericData.class);
-      Map<String, Object> error = OAuth2Utils.validateMap(responseError, "error", PARSE_ERROR_MESSAGE);
+      Map<String, Object> error =
+          OAuth2Utils.validateMap(responseError, "error", PARSE_ERROR_MESSAGE);
       String errorMessage = OAuth2Utils.validateString(error, "message", PARSE_ERROR_MESSAGE);
-      throw new IOException(String.format("Error code %s trying to sign provided bytes: %s",
-                statusCode, errorMessage));
+      throw new IOException(
+          String.format(
+              "Error code %s trying to sign provided bytes: %s", statusCode, errorMessage));
     }
     if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
-      throw new IOException(String.format("Unexpected Error code %s trying to sign provided bytes: %s", statusCode,
-          response.parseAsString()));
+      throw new IOException(
+          String.format(
+              "Unexpected Error code %s trying to sign provided bytes: %s",
+              statusCode, response.parseAsString()));
     }
     InputStream content = response.getContent();
     if (content == null) {
@@ -130,22 +143,26 @@ class IamUtils {
   }
 
   /**
-   * Returns an IdToken issued to the serviceAccount with a specified
-   * targetAudience
+   * Returns an IdToken issued to the serviceAccount with a specified targetAudience
    *
-   * @param serviceAccountEmail the email address for the service account to get
-   *                            an ID Token for
-   * @param credentials  credentials required for making the IAM call
-   * @param transport  transport used for building the HTTP request
-   * @param targetAudience  the audience the issued ID token should include
-   * @param additionalFields  additional fields to send in the IAM call
+   * @param serviceAccountEmail the email address for the service account to get an ID Token for
+   * @param credentials credentials required for making the IAM call
+   * @param transport transport used for building the HTTP request
+   * @param targetAudience the audience the issued ID token should include
+   * @param additionalFields additional fields to send in the IAM call
    * @return IdToken issed to the serviceAccount
    * @throws IOException if the IdToken cannot be issued.
-   * @see    https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateIdToken
+   * @see
+   *     https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateIdToken
    */
-
-  static IdToken getIdToken(String serviceAccountEmail, Credentials credentials, HttpTransport transport,
-      String targetAudience, boolean includeEmail, Map<String, ?> additionalFields) throws IOException {
+  static IdToken getIdToken(
+      String serviceAccountEmail,
+      Credentials credentials,
+      HttpTransport transport,
+      String targetAudience,
+      boolean includeEmail,
+      Map<String, ?> additionalFields)
+      throws IOException {
 
     String idTokenUrl = String.format(ID_TOKEN_URL_FORMAT, serviceAccountEmail);
     GenericUrl genericUrl = new GenericUrl(idTokenUrl);
@@ -159,7 +176,8 @@ class IamUtils {
     JsonHttpContent idTokenContent = new JsonHttpContent(OAuth2Utils.JSON_FACTORY, idTokenRequest);
 
     HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
-    HttpRequest request = transport.createRequestFactory(adapter).buildPostRequest(genericUrl, idTokenContent);
+    HttpRequest request =
+        transport.createRequestFactory(adapter).buildPostRequest(genericUrl, idTokenContent);
 
     JsonObjectParser parser = new JsonObjectParser(OAuth2Utils.JSON_FACTORY);
     request.setParser(parser);
@@ -169,13 +187,17 @@ class IamUtils {
     int statusCode = response.getStatusCode();
     if (statusCode >= 400 && statusCode < HttpStatusCodes.STATUS_CODE_SERVER_ERROR) {
       GenericData responseError = response.parseAs(GenericData.class);
-      Map<String, Object> error = OAuth2Utils.validateMap(responseError, "error", PARSE_ERROR_MESSAGE);
+      Map<String, Object> error =
+          OAuth2Utils.validateMap(responseError, "error", PARSE_ERROR_MESSAGE);
       String errorMessage = OAuth2Utils.validateString(error, "message", PARSE_ERROR_MESSAGE);
-      throw new IOException(String.format("Error code %s trying to getIDToken: %s", statusCode, errorMessage));
+      throw new IOException(
+          String.format("Error code %s trying to getIDToken: %s", statusCode, errorMessage));
     }
     if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
       throw new IOException(
-          String.format("Unexpected Error code %s trying to getIDToken: %s", statusCode, response.parseAsString()));
+          String.format(
+              "Unexpected Error code %s trying to getIDToken: %s",
+              statusCode, response.parseAsString()));
     }
     InputStream content = response.getContent();
     if (content == null) {
@@ -187,8 +209,7 @@ class IamUtils {
 
     GenericJson responseData = response.parseAs(GenericJson.class);
     String rawToken = OAuth2Utils.validateString(responseData, "token", PARSE_ERROR_MESSAGE);
-    JsonWebSignature jws =  JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
+    JsonWebSignature jws = JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
     return new IdToken(rawToken, jws);
   }
-
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -131,15 +131,15 @@ class IamUtils {
 
   /**
    * Returns an IdToken issued to the serviceAccount with a specified
-   * targetAudience.
+   * targetAudience
    *
    * @param serviceAccountEmail the email address for the service account to get
-   *                            an Id Token for
-   * @param credentials         credentials required for making the IAM call
-   * @param transport           transport used for building the HTTP request
-   * @param targetAudience      the audience the issued ID token should include
-   * @param additionalFields    additional fields to send in the IAM call
-   * @return New IdToken issed to the serviceAccount.
+   *                            an ID Token for
+   * @param credentials  credentials required for making the IAM call
+   * @param transport  transport used for building the HTTP request
+   * @param targetAudience  the audience the issued ID token should include
+   * @param additionalFields  additional fields to send in the IAM call
+   * @return IdToken issed to the serviceAccount
    * @throws IOException if the IdToken cannot be issued.
    * @see    https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateIdToken
    */
@@ -156,10 +156,10 @@ class IamUtils {
     for (Map.Entry<String, ?> entry : additionalFields.entrySet()) {
       idTokenRequest.set(entry.getKey(), entry.getValue());
     }
-    JsonHttpContent signContent = new JsonHttpContent(OAuth2Utils.JSON_FACTORY, idTokenRequest);
+    JsonHttpContent idTokenContent = new JsonHttpContent(OAuth2Utils.JSON_FACTORY, idTokenRequest);
 
     HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
-    HttpRequest request = transport.createRequestFactory(adapter).buildPostRequest(genericUrl, signContent);
+    HttpRequest request = transport.createRequestFactory(adapter).buildPostRequest(genericUrl, idTokenContent);
 
     JsonObjectParser parser = new JsonObjectParser(OAuth2Utils.JSON_FACTORY);
     request.setParser(parser);

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -144,20 +144,15 @@ class IamUtils {
    */
 
   static IdToken getIdToken(String serviceAccountEmail, Credentials credentials, HttpTransport transport,
-      String targetAudience, boolean includeEmail, Map<String, ?> additionalFields) {
+      String targetAudience, boolean includeEmail, Map<String, ?> additionalFields) throws IOException {
     IdToken token;
-    try {
       token = getOIDCToken(serviceAccountEmail, credentials, transport, targetAudience, includeEmail, additionalFields);
-    } catch (IOException ex) {
-      throw new IdTokenProvider.IdTokenProviderException("Unexpected Error while getting ID Token: " + ex.getMessage(),
-          ex);
-    }
     return token;
   }
 
   private static IdToken getOIDCToken(String serviceAccountEmail, Credentials credentials, HttpTransport transport,
       String targetAudience, boolean includeEmail, Map<String, ?> additionalFields)
-      throws IOException, IdTokenProvider.IdTokenProviderException {
+      throws IOException {
     String signBlobUrl = String.format(ID_TOKEN_URL_FORMAT, serviceAccountEmail);
     GenericUrl genericUrl = new GenericUrl(signBlobUrl);
 

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -209,7 +209,7 @@ class IamUtils {
 
     GenericJson responseData = response.parseAs(GenericJson.class);
     String rawToken = OAuth2Utils.validateString(responseData, "token", PARSE_ERROR_MESSAGE);
-    JsonWebSignature jws = JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
-    return new IdToken(rawToken, jws);
+    JsonWebSignature signature = JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
+    return new IdToken(rawToken, signature);
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -141,28 +141,22 @@ class IamUtils {
    * @param additionalFields    additional fields to send in the IAM call
    * @return New IdToken issed to the serviceAccount.
    * @throws IOException if the IdToken cannot be issued.
+   * @see    https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateIdToken
    */
 
   static IdToken getIdToken(String serviceAccountEmail, Credentials credentials, HttpTransport transport,
       String targetAudience, boolean includeEmail, Map<String, ?> additionalFields) throws IOException {
-    IdToken token;
-      token = getOIDCToken(serviceAccountEmail, credentials, transport, targetAudience, includeEmail, additionalFields);
-    return token;
-  }
 
-  private static IdToken getOIDCToken(String serviceAccountEmail, Credentials credentials, HttpTransport transport,
-      String targetAudience, boolean includeEmail, Map<String, ?> additionalFields)
-      throws IOException {
-    String signBlobUrl = String.format(ID_TOKEN_URL_FORMAT, serviceAccountEmail);
-    GenericUrl genericUrl = new GenericUrl(signBlobUrl);
+    String idTokenUrl = String.format(ID_TOKEN_URL_FORMAT, serviceAccountEmail);
+    GenericUrl genericUrl = new GenericUrl(idTokenUrl);
 
-    GenericData signRequest = new GenericData();
-    signRequest.set("audience", targetAudience);
-    signRequest.set("includeEmail", includeEmail);
+    GenericData idTokenRequest = new GenericData();
+    idTokenRequest.set("audience", targetAudience);
+    idTokenRequest.set("includeEmail", includeEmail);
     for (Map.Entry<String, ?> entry : additionalFields.entrySet()) {
-      signRequest.set(entry.getKey(), entry.getValue());
+      idTokenRequest.set(entry.getKey(), entry.getValue());
     }
-    JsonHttpContent signContent = new JsonHttpContent(OAuth2Utils.JSON_FACTORY, signRequest);
+    JsonHttpContent signContent = new JsonHttpContent(OAuth2Utils.JSON_FACTORY, idTokenRequest);
 
     HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
     HttpRequest request = transport.createRequestFactory(adapter).buildPostRequest(genericUrl, signContent);

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -64,7 +64,7 @@ public class IdToken extends AccessToken implements Serializable {
    *
    * @param tokenValue String representation of the Id token.
    * @return returns com.google.auth.oauth2.IdToken
-   */  
+   */
   public static IdToken create(String tokenValue) throws IOException {
     return create(tokenValue, OAuth2Utils.JSON_FACTORY);
   }
@@ -75,7 +75,7 @@ public class IdToken extends AccessToken implements Serializable {
    * @param jsonFactory JsonFactory to use for parsing the provided token.
    * @param tokenValue String representation of the Id token.
    * @return returns com.google.auth.oauth2.IdToken
-   */    
+   */
   public static IdToken create(String tokenValue, JsonFactory jsonFactory) throws IOException {
     return new IdToken(tokenValue, JsonWebSignature.parse(jsonFactory, tokenValue));
   }
@@ -119,7 +119,6 @@ public class IdToken extends AccessToken implements Serializable {
   }
 
   private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
-    ois.defaultReadObject();
     String signature = (String) ois.readObject();
     this.jsonWebSignature = JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, signature);
   }

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -31,10 +31,12 @@
 
 package com.google.auth.oauth2;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
 
+import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.common.base.MoreObjects;
 
@@ -45,16 +47,24 @@ public class IdToken extends AccessToken implements Serializable {
 
   private static final long serialVersionUID = -8514239465808977353L;
 
-  private final JsonWebSignature jws;
+  private final JsonWebSignature jsonWebSignature;
 
   /**
-   * @param tokenValue     String representation of the Id token.
-   * @param jws            JsonWebSignature as object
+   * @param tokenValue String representation of the Id token.
+   * @param jsonWebSignature JsonWebSignature as object
    */
-  public IdToken(String tokenValue, JsonWebSignature jws) {
-    super(tokenValue, new Date(jws.getPayload().getExpirationTimeSeconds() * 1000));
-    this.jws = jws;
+  public IdToken(String tokenValue, JsonWebSignature jsonWebSignature) {
+    super(tokenValue, new Date(jsonWebSignature.getPayload().getExpirationTimeSeconds() * 1000));
+    this.jsonWebSignature = jsonWebSignature;
   }
+
+  public static IdToken create(String tokenValue) throws IOException {
+    return create(tokenValue, OAuth2Utils.JSON_FACTORY);
+  }
+  
+  public static IdToken create(String tokenValue, JsonFactory jsonFactory) throws IOException {
+    return new IdToken(tokenValue, JsonWebSignature.parse(jsonFactory, tokenValue));
+  }  
 
   /**
    * The JsonWebSignature as object
@@ -62,18 +72,18 @@ public class IdToken extends AccessToken implements Serializable {
    * @return returns com.google.api.client.json.webtoken.JsonWebSignature
    */
   public JsonWebSignature getJsonWebSignature() {
-    return jws;
+    return jsonWebSignature;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.getTokenValue(), jws);
+    return Objects.hash(super.getTokenValue(), jsonWebSignature);
   }
 
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("tokenValue", super.getTokenValue())
-        .add("JsonWebSignature", jws).toString();
+        .add("JsonWebSignature", jsonWebSignature).toString();
   }
 
   @Override
@@ -83,6 +93,6 @@ public class IdToken extends AccessToken implements Serializable {
     }
     IdToken other = (IdToken) obj;
     return Objects.equals(super.getTokenValue(), other.getTokenValue())
-        && Objects.equals(this.jws, other.jws);
+        && Objects.equals(this.jsonWebSignature, other.jsonWebSignature);
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -39,7 +39,7 @@ import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.common.base.MoreObjects;
 
 /**
- * Represents a temporary IdToken and its JSONWebSingature object.
+ * Represents a temporary IdToken and its JSONWebSingature object
  */
 public class IdToken extends AccessToken implements Serializable {
 
@@ -50,7 +50,6 @@ public class IdToken extends AccessToken implements Serializable {
   /**
    * @param tokenValue     String representation of the Id token.
    * @param jws            JsonWebSignature as object
-   * @param audience       List of the Audiences the idToken was issued for.
    */
   public IdToken(String tokenValue, JsonWebSignature jws) {
     super(tokenValue, new Date(jws.getPayload().getExpirationTimeSeconds() * 1000));
@@ -60,7 +59,7 @@ public class IdToken extends AccessToken implements Serializable {
   /**
    * The JsonWebSignature as object
    *
-   * @return returns com.google.api.client.json.webtoken.JsonWebSignature.
+   * @return returns com.google.api.client.json.webtoken.JsonWebSignature
    */
   public JsonWebSignature getJsonWebSignature() {
     return jws;

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -45,7 +45,6 @@ public class IdToken extends AccessToken implements Serializable {
 
   private static final long serialVersionUID = -8514239465808977353L;
 
-  private final String tokenValue;
   private final JsonWebSignature jws;
 
   /**
@@ -55,23 +54,13 @@ public class IdToken extends AccessToken implements Serializable {
    */
   public IdToken(String tokenValue, JsonWebSignature jws) {
     super(tokenValue, new Date(jws.getPayload().getExpirationTimeSeconds()));
-    this.tokenValue = tokenValue;
     this.jws = jws;
-  }
-
-  /**
-   * String representation of the Id Token.
-   *
-   * @return The raw access token string value.
-   */
-  public String getTokenValue() {
-    return tokenValue;
   }
 
   /**
    * The JsonWebSignature as object
    *
-   * @return List of audiences.
+   * @return returns com.google.api.client.json.webtoken.JsonWebSignature.
    */
   public JsonWebSignature getJsonWebSignature() {
     return jws;
@@ -79,12 +68,12 @@ public class IdToken extends AccessToken implements Serializable {
 
   @Override
   public int hashCode() {
-    return Objects.hash(tokenValue, jws);
+    return Objects.hash(super.getTokenValue(), jws);
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("tokenValue", tokenValue)
+    return MoreObjects.toStringHelper(this).add("tokenValue", super.getTokenValue())
         .add("JsonWebSignature", jws).toString();
   }
 
@@ -94,7 +83,7 @@ public class IdToken extends AccessToken implements Serializable {
       return false;
     }
     IdToken other = (IdToken) obj;
-    return Objects.equals(this.tokenValue, other.tokenValue)
+    return Objects.equals(super.getTokenValue(), other.getTokenValue())
         && Objects.equals(this.jws, other.jws);
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google LLC. nor the names of its
+ *    * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * Copyright 2019, Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google Inc. nor the names of its
+ *    * Neither the name of Google LLC. nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -59,10 +59,23 @@ public class IdToken extends AccessToken implements Serializable {
     this.jsonWebSignature = jsonWebSignature;
   }
 
+  /**
+   * Creates an IdToken given the encoded Json Web Signature.
+   *
+   * @param tokenValue String representation of the Id token.
+   * @return returns com.google.auth.oauth2.IdToken
+   */  
   public static IdToken create(String tokenValue) throws IOException {
     return create(tokenValue, OAuth2Utils.JSON_FACTORY);
   }
 
+  /**
+   * Creates an IdToken given the encoded Json Web Signature and JSON Factory
+   *
+   * @param jsonFactory JsonFactory to use for parsing the provided token.
+   * @param tokenValue String representation of the Id token.
+   * @return returns com.google.auth.oauth2.IdToken
+   */    
   public static IdToken create(String tokenValue, JsonFactory jsonFactory) throws IOException {
     return new IdToken(tokenValue, JsonWebSignature.parse(jsonFactory, tokenValue));
   }

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -38,11 +38,13 @@ import java.util.Objects;
 
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.webtoken.JsonWebSignature;
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 
 /**
- * Represents a temporary IdToken and its JSONWebSingature object
+ * Represents a temporary IdToken and its JsonWebSignature object
  */
+@Beta
 public class IdToken extends AccessToken implements Serializable {
 
   private static final long serialVersionUID = -8514239465808977353L;

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Objects;
+
+import com.google.api.client.json.webtoken.JsonWebSignature;
+import com.google.common.base.MoreObjects;
+
+/**
+ * Represents a temporary IdToken and its JSONWebSingature object.
+ */
+public class IdToken extends AccessToken implements Serializable {
+
+  private static final long serialVersionUID = -8514239465808977353L;
+
+  private final String tokenValue;
+  private final JsonWebSignature jws;
+
+  /**
+   * @param tokenValue     String representation of the Id token.
+   * @param jws            JsonWebSignature as object
+   * @param audience       List of the Audiences the idToken was issued for.
+   */
+  public IdToken(String tokenValue, JsonWebSignature jws) {
+    super(tokenValue, new Date(jws.getPayload().getExpirationTimeSeconds()));
+    this.tokenValue = tokenValue;
+    this.jws = jws;
+  }
+
+  /**
+   * String representation of the Id Token.
+   *
+   * @return The raw access token string value.
+   */
+  public String getTokenValue() {
+    return tokenValue;
+  }
+
+  /**
+   * The JsonWebSignature as object
+   *
+   * @return List of audiences.
+   */
+  public JsonWebSignature getJsonWebSignature() {
+    return jws;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tokenValue, jws);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).add("tokenValue", tokenValue)
+        .add("JsonWebSignature", jws).toString();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AccessToken)) {
+      return false;
+    }
+    IdToken other = (IdToken) obj;
+    return Objects.equals(this.tokenValue, other.tokenValue)
+        && Objects.equals(this.jws, other.jws);
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -53,7 +53,7 @@ public class IdToken extends AccessToken implements Serializable {
    * @param tokenValue String representation of the Id token.
    * @param jsonWebSignature JsonWebSignature as object
    */
-  public IdToken(String tokenValue, JsonWebSignature jsonWebSignature) {
+  private IdToken(String tokenValue, JsonWebSignature jsonWebSignature) {
     super(tokenValue, new Date(jsonWebSignature.getPayload().getExpirationTimeSeconds() * 1000));
     this.jsonWebSignature = jsonWebSignature;
   }

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -51,7 +51,7 @@ public class IdToken extends AccessToken implements Serializable {
   private transient JsonWebSignature jsonWebSignature;
 
   /**
-   * @param tokenValue String representation of the Id token.
+   * @param tokenValue String representation of the ID token.
    * @param jsonWebSignature JsonWebSignature as object
    */
   private IdToken(String tokenValue, JsonWebSignature jsonWebSignature) {
@@ -62,7 +62,7 @@ public class IdToken extends AccessToken implements Serializable {
   /**
    * Creates an IdToken given the encoded Json Web Signature.
    *
-   * @param tokenValue String representation of the Id token.
+   * @param tokenValue String representation of the ID token.
    * @return returns com.google.auth.oauth2.IdToken
    */
   public static IdToken create(String tokenValue) throws IOException {
@@ -73,7 +73,7 @@ public class IdToken extends AccessToken implements Serializable {
    * Creates an IdToken given the encoded Json Web Signature and JSON Factory
    *
    * @param jsonFactory JsonFactory to use for parsing the provided token.
-   * @param tokenValue String representation of the Id token.
+   * @param tokenValue String representation of the ID token.
    * @return returns com.google.auth.oauth2.IdToken
    */
   public static IdToken create(String tokenValue, JsonFactory jsonFactory) throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -53,7 +53,7 @@ public class IdToken extends AccessToken implements Serializable {
    * @param audience       List of the Audiences the idToken was issued for.
    */
   public IdToken(String tokenValue, JsonWebSignature jws) {
-    super(tokenValue, new Date(jws.getPayload().getExpirationTimeSeconds()));
+    super(tokenValue, new Date(jws.getPayload().getExpirationTimeSeconds() * 1000));
     this.jws = jws;
   }
 
@@ -79,7 +79,7 @@ public class IdToken extends AccessToken implements Serializable {
 
   @Override
   public boolean equals(Object obj) {
-    if (!(obj instanceof AccessToken)) {
+    if (!(obj instanceof IdToken)) {
       return false;
     }
     IdToken other = (IdToken) obj;

--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -31,19 +31,16 @@
 
 package com.google.auth.oauth2;
 
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.webtoken.JsonWebSignature;
+import com.google.common.annotations.Beta;
+import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
 
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.webtoken.JsonWebSignature;
-import com.google.common.annotations.Beta;
-import com.google.common.base.MoreObjects;
-
-/**
- * Represents a temporary IdToken and its JsonWebSignature object
- */
+/** Represents a temporary IdToken and its JsonWebSignature object */
 @Beta
 public class IdToken extends AccessToken implements Serializable {
 
@@ -63,10 +60,10 @@ public class IdToken extends AccessToken implements Serializable {
   public static IdToken create(String tokenValue) throws IOException {
     return create(tokenValue, OAuth2Utils.JSON_FACTORY);
   }
-  
+
   public static IdToken create(String tokenValue, JsonFactory jsonFactory) throws IOException {
     return new IdToken(tokenValue, JsonWebSignature.parse(jsonFactory, tokenValue));
-  }  
+  }
 
   /**
    * The JsonWebSignature as object
@@ -84,8 +81,10 @@ public class IdToken extends AccessToken implements Serializable {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("tokenValue", super.getTokenValue())
-        .add("JsonWebSignature", jsonWebSignature).toString();
+    return MoreObjects.toStringHelper(this)
+        .add("tokenValue", super.getTokenValue())
+        .add("JsonWebSignature", jsonWebSignature)
+        .toString();
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -127,7 +127,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
 
   @Override
   public int hashCode() {
-    return Objects.hash(idTokenProvider, targetAudience);
+    return Objects.hash(options, targetAudience);
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -129,17 +129,15 @@ public class IdTokenCredentials extends OAuth2Credentials {
   /**
    * Returns an Google Id Token from the metadata server on ComputeEngine.
    * 
-   * @param sourceCredentials The source credential for the Id Token
-   * @param targetAudience    List aud: field the IdToken should include.
-   * @param options           List of Credential specific options for for the
-   *                          token. For example, an IDToken for a
-   *                          ComputeEngineCredential could include the full
-   *                          formated claims returned if
-   *                          "ComputeEngineCredential.ID_TOKEN_FORMAT_FULL" is
-   *                          specified. Refer to the Credential type for specific
-   *                          extensions.
+   * @param sourceCredentials the source credential for the Id Token
+   * @param targetAudience aud: field the IdToken should include.
+   * @param options list of Credential specific options for for the
+   * token. For example, an IDToken for a ComputeEngineCredential could 
+   * include the full formated claims returned if 
+   * "ComputeEngineCredential.ID_TOKEN_FORMAT_FULL" is specified. 
+   * Refer to the Credential type for specific extensions.
    * @return IdToken object which includes the raw id_token, expirationn and
-   *         audience.
+   * audience
    */
   public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience,
       List<IdTokenProvider.Option> options) {
@@ -151,8 +149,8 @@ public class IdTokenCredentials extends OAuth2Credentials {
    * Returns IdToken credentials associated with the sourceCredentials and with an
    * audience specified.
    * 
-   * @param sourceCredentials The source credential for the Id Token
-   * @param targetAudience    The audience field for the issued ID Token
+   * @param sourceCredentials the source credential for the ID Token
+   * @param targetAudience the audience field for the issued ID Token
    * @return IdTokenCredential
    */
   public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience) {

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -99,7 +99,6 @@ public class IdTokenCredentials extends OAuth2Credentials {
   private GoogleCredentials sourceCredentials;
   private final String transportFactoryClassName;
   private String targetAudience;
-  private IdToken idToken;
   private List<IdTokenProvider.Option> options;
 
   private transient HttpTransportFactory transportFactory;
@@ -178,20 +177,12 @@ public class IdTokenCredentials extends OAuth2Credentials {
     if (this.sourceCredentials.getAccessToken() == null) {
       this.sourceCredentials = this.sourceCredentials.createScoped(Arrays.asList(CLOUD_PLATFORM_SCOPE));
     }
-
-    try {
-      this.sourceCredentials.refreshIfExpired();
-    } catch (IOException e) {
-      throw new IOException("Unable to refresh sourceCredentials", e);
-    }
-
-    this.idToken = ((IdTokenProvider) this.sourceCredentials).idTokenWithAudience(targetAudience, options);
-
-    return this.idToken;
+    
+    return ((IdTokenProvider) this.sourceCredentials).idTokenWithAudience(targetAudience, options);
   }
 
   public IdToken getIdToken() {
-    return this.idToken;
+    return (IdToken) getAccessToken();
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.util.List;
@@ -93,6 +94,7 @@ import java.util.Objects;
  * System.out.println(tokenCredential.getIdToken().getJsonWebSignature().getPayload().getExpirationTimeSeconds());
  * </pre>
  */
+@Beta
 public class IdTokenCredentials extends OAuth2Credentials {
 
   private static final long serialVersionUID = -2133257318957588431L;

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -91,7 +91,7 @@ import com.google.common.base.MoreObjects;
  * System.out.println(tokenCredential.getIdToken().getJsonWebSignature().getPayload().getExpirationTimeSeconds());
  * </pre>
  */
-public class IdTokenCredentials extends GoogleCredentials {
+public class IdTokenCredentials extends OAuth2Credentials {
 
   private static final long serialVersionUID = -2133257318957588431L;
   private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
@@ -223,7 +223,7 @@ public class IdTokenCredentials extends GoogleCredentials {
     return new Builder();
   }
 
-  public static class Builder extends GoogleCredentials.Builder {
+  public static class Builder extends OAuth2Credentials.Builder {
 
     private GoogleCredentials sourceCredentials;
     private String targetAudience;

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -31,7 +31,7 @@
 
 package com.google.auth.oauth2;
 
-
+import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import java.io.IOException;
@@ -58,18 +58,18 @@ import java.util.Objects;
  * if (!adcCreds instanceof IdTokenProvider) {
  *   // handle error message
  * }
- * 
+ *
  * IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
  *     .setIdTokenProvider(adcCreds)
  *     .setTargetAudience(targetAudience).build();
- * 
+ *
  * // for ServiceAccountCredentials
  * ServiceAccountCredentials saCreds = ServiceAccountCredentials.fromStream(new FileInputStream(credPath));
  * saCreds = (ServiceAccountCredentials) saCreds.createScoped(Arrays.asList("https://www.googleapis.com/auth/iam"));
  * IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
  *     .setIdTokenProvider(saCreds)
  *     .setTargetAudience(targetAudience).build();
- * 
+ *
  * // for ComputeEngineCredentials
  * ComputeEngineCredentials caCreds = ComputeEngineCredentials.create();
  * IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
@@ -77,7 +77,7 @@ import java.util.Objects;
  *     .setTargetAudience(targetAudience)
  *     .setOptions(Arrays.asList(ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL))
  *     .build();
- * 
+ *
  * // for ImpersonatedCredentials
  * ImpersonatedCredentials imCreds = ImpersonatedCredentials.create(saCreds,
  *     "impersonated-account@project.iam.gserviceaccount.com", null,
@@ -110,11 +110,10 @@ public class IdTokenCredentials extends OAuth2Credentials {
   private String targetAudience;
   private List<IdTokenProvider.Option> options;
 
-
   private IdTokenCredentials(Builder builder) {
-    this.idTokenProvider = builder.getIdTokenProvider();
-    this.targetAudience = builder.getTargetAudience();
-    this.options = builder.getOptions();
+    this.idTokenProvider = Preconditions.checkNotNull(builder.getIdTokenProvider());
+    this.targetAudience = Preconditions.checkNotNull(builder.getTargetAudience());
+    this.options = Preconditions.checkNotNull(builder.getOptions());
   }
 
   @Override
@@ -128,7 +127,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
 
   @Override
   public int hashCode() {
-    return Objects.hash(idTokenProvider);
+    return Objects.hash(idTokenProvider, targetAudience);
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2018, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.base.MoreObjects;
+
+/**
+ * IdTokenCredentials provides a Google Issued OpenIdConnect token. <br>
+ * Use an ID token to access services that require presenting an ID token for
+ * authentication such as Cloud Functions or Cloud Run.<br>
+ * 
+ * The following Credential subclasses support IDTokens:
+ * ServiceAccountCredentials, ComputeEngineCredentials, ImpersonatedCredentials.
+ * 
+ * For more information see <br>
+ * Usage:<br>
+ * 
+ * <pre>
+ * String credPath = "/path/to/svc_account.json";
+ * String targetAudience = "https://example.com";
+ * 
+ * // For Application Default Credentials (as ServiceAccountCredentials)
+ * // export GOOGLE_APPLICATION_CREDENTIALS=/path/to/svc.json
+ * GoogleCredentials adcCreds = GoogleCredentials.getApplicationDefault();
+ * IdTokenCredentials tokenCredential = IdTokenCredentials.create(adcCreds, targetAudience);
+ * 
+ * // for ServiceAccountCredentials
+ * ServiceAccountCredentials saCreds = ServiceAccountCredentials.fromStream(new FileInputStream(credPath));
+ * saCreds = (ServiceAccountCredentials) saCreds.createScoped(Arrays.asList("https://www.googleapis.com/auth/iam"));
+ * IdTokenCredentials tokenCredential = IdTokenCredentials.create(saCreds, targetAudience);
+ * 
+ * // for ComputeEngineCredentials
+ * ComputeEngineCredentials caCreds = ComputeEngineCredentials.create();
+ * IdTokenCredentials tokenCredential = IdTokenCredentials.create(caCreds, targetAudience,
+ *     Arrays.asList(ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL));
+ *
+ * // for ImpersonatedCredentials
+ * ImpersonatedCredentials imCreds = ImpersonatedCredentials.create(saCreds,
+ *     "impersonated-account@project.iam.gserviceaccount.com", null,
+ *     Arrays.asList("https://www.googleapis.com/auth/cloud-platform"), 300);
+ * IdTokenCredentials tokenCredential = IdTokenCredentials.create(imCreds, targetAudience,
+ *     Arrays.asList(ImpersonatedCredentials.INCLUDE_EMAIL));
+ * 
+ * // Use the IdTokenCredential in an authorized transport
+ * GenericUrl genericUrl = new GenericUrl("https://example.com");
+ * HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(tokenCredential);
+ * HttpTransport transport = new NetHttpTransport();
+ * HttpRequest request = transport.createRequestFactory(adapter).buildGetRequest(genericUrl);
+ * HttpResponse response = request.execute();
+ *
+ * // Print the token, expiration and the audience
+ * System.out.println(tokenCredential.getIdToken().getTokenValue());
+ * System.out.println(tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudienceAsList());
+ * System.out.println(tokenCredential.getIdToken().getJsonWebSignature().getPayload().getExpirationTimeSeconds());
+ * </pre>
+ */
+public class IdTokenCredentials extends GoogleCredentials {
+
+  private static final long serialVersionUID = -2133257318957588431L;
+  private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+
+  private GoogleCredentials sourceCredentials;
+  private final String transportFactoryClassName;
+  private String targetAudience;
+  private IdToken idToken;
+  private List<String> options;
+
+  private transient HttpTransportFactory transportFactory;
+
+  /**
+   * Returns IdToken credentials associated with the sourceCredentials and with an
+   * audience specified. Specify extensions and additional claims for the IdToken
+   * by applying any approprite Options for the given credential type.
+   * 
+   * @param sourceCredentials The source credential for the Id Token
+   * @param targetAudience    The audience field for the issued ID Token
+   * @param options           List of Credential specific options for for the
+   *                          token. For example, an IDToken for a
+   *                          ComputeEngineCredential can return platform specific
+   *                          claims if
+   *                          "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is
+   *                          provided as a list option.
+   * @param transportFactory  HTTP transport factory, creates the transport used
+   *                          to get access tokens.
+   * @return IdTokenCredential
+   */
+  public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience,
+      HttpTransportFactory transportFactory, List<String> options) {
+    return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
+        .setOptions(options).setHttpTransportFactory(transportFactory).build();
+  }
+
+  /**
+   * Returns an Google Id Token from the metadata server on ComputeEngine.
+   * 
+   * @param sourceCredentials The source credential for the Id Token
+   * @param targetAudience    List aud: field the IdToken should include.
+   * @param options           List of Credential specific options for for the
+   *                          token. For example, an IDToken for a
+   *                          ComputeEngineCredential could include the full
+   *                          formated claims returned if
+   *                          "ComputeEngineCredential.ID_TOKEN_FORMAT_FULL" is
+   *                          specified. Refer to the Credential type for specific
+   *                          extensions.
+   * @return IdToken object which includes the raw id_token, expirationn and
+   *         audience.
+   */
+  public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience,
+      List<String> options) {
+    return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
+        .setOptions(options).build();
+  }
+
+  /**
+   * Returns IdToken credentials associated with the sourceCredentials and with an
+   * audience specified.
+   * 
+   * @param sourceCredentials The source credential for the Id Token
+   * @param targetAudience    The audience field for the issued ID Token
+   * @return IdTokenCredential
+   */
+  public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience) {
+    return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
+        .build();
+  }
+
+  private IdTokenCredentials(Builder builder) {
+    this.sourceCredentials = builder.getSourceCredentials();
+    this.targetAudience = builder.getTargetAudience();
+    this.options = builder.getOptions();
+    this.transportFactory = firstNonNull(builder.getHttpTransportFactory(),
+        getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
+    this.transportFactoryClassName = this.transportFactory.getClass().getName();
+  }
+
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    if (!(this.sourceCredentials instanceof IdTokenProvider)) {
+      throw new IOException("Provided sourceToken does not implement IdTokenProvider");
+    }
+    if (this.sourceCredentials.getAccessToken() == null) {
+      this.sourceCredentials = this.sourceCredentials.createScoped(Arrays.asList(CLOUD_PLATFORM_SCOPE));
+    }
+
+    try {
+      this.sourceCredentials.refreshIfExpired();
+    } catch (IOException e) {
+      throw new IOException("Unable to refresh sourceCredentials", e);
+    }
+
+    this.idToken = ((IdTokenProvider) this.sourceCredentials).idTokenWithAudience(targetAudience, options);
+
+    return this.idToken;
+  }
+
+  public IdToken getIdToken() {
+    return this.idToken;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceCredentials);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this).toString();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof IdTokenCredentials)) {
+      return false;
+    }
+    IdTokenCredentials other = (IdTokenCredentials) obj;
+    return Objects.equals(this.sourceCredentials, other.sourceCredentials)
+        && Objects.equals(this.targetAudience, other.targetAudience)
+        && Objects.equals(this.transportFactoryClassName, other.transportFactoryClassName);
+  }
+
+  public Builder toBuilder() {
+    return new Builder();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder extends GoogleCredentials.Builder {
+
+    private GoogleCredentials sourceCredentials;
+    private String targetAudience;
+    private List<String> options;
+    private HttpTransportFactory transportFactory;
+
+    protected Builder() {
+    }
+
+    public Builder setSourceCredentials(GoogleCredentials sourceCredentials) {
+      this.sourceCredentials = sourceCredentials;
+      return this;
+    }
+
+    public GoogleCredentials getSourceCredentials() {
+      return this.sourceCredentials;
+    }
+
+    public Builder setTargetAudience(String targetAudience) {
+      this.targetAudience = targetAudience;
+      return this;
+    }
+
+    public String getTargetAudience() {
+      return this.targetAudience;
+    }
+
+    public Builder setOptions(List<String> options) {
+      this.options = options;
+      return this;
+    }
+
+    public List<String> getOptions() {
+      return this.options;
+    }
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+    }
+
+    public HttpTransportFactory getHttpTransportFactory() {
+      return transportFactory;
+    }
+
+    public IdTokenCredentials build() {
+      return new IdTokenCredentials(this);
+    }
+
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -113,7 +113,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
   private IdTokenCredentials(Builder builder) {
     this.idTokenProvider = Preconditions.checkNotNull(builder.getIdTokenProvider());
     this.targetAudience = Preconditions.checkNotNull(builder.getTargetAudience());
-    this.options = Preconditions.checkNotNull(builder.getOptions());
+    this.options = builder.getOptions();
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -100,7 +100,7 @@ public class IdTokenCredentials extends GoogleCredentials {
   private final String transportFactoryClassName;
   private String targetAudience;
   private IdToken idToken;
-  private List<String> options;
+  private List<IdTokenProvider.Option> options;
 
   private transient HttpTransportFactory transportFactory;
 
@@ -122,7 +122,7 @@ public class IdTokenCredentials extends GoogleCredentials {
    * @return IdTokenCredential
    */
   public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience,
-      HttpTransportFactory transportFactory, List<String> options) {
+      HttpTransportFactory transportFactory, List<IdTokenProvider.Option> options) {
     return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
         .setOptions(options).setHttpTransportFactory(transportFactory).build();
   }
@@ -143,7 +143,7 @@ public class IdTokenCredentials extends GoogleCredentials {
    *         audience.
    */
   public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience,
-      List<String> options) {
+      List<IdTokenProvider.Option> options) {
     return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
         .setOptions(options).build();
   }
@@ -227,7 +227,7 @@ public class IdTokenCredentials extends GoogleCredentials {
 
     private GoogleCredentials sourceCredentials;
     private String targetAudience;
-    private List<String> options;
+    private List<IdTokenProvider.Option> options;
     private HttpTransportFactory transportFactory;
 
     protected Builder() {
@@ -251,12 +251,12 @@ public class IdTokenCredentials extends GoogleCredentials {
       return this.targetAudience;
     }
 
-    public Builder setOptions(List<String> options) {
+    public Builder setOptions(List<IdTokenProvider.Option> options) {
       this.options = options;
       return this;
     }
 
-    public List<String> getOptions() {
+    public List<IdTokenProvider.Option> getOptions() {
       return this.options;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -33,39 +33,37 @@ package com.google.auth.oauth2;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
-import com.google.auth.http.HttpTransportFactory;
-import com.google.common.base.MoreObjects;
-
 /**
  * IdTokenCredentials provides a Google Issued OpenIdConnect token. <br>
- * Use an ID token to access services that require presenting an ID token for
- * authentication such as Cloud Functions or Cloud Run.<br>
- * 
- * The following Credential subclasses support IDTokens:
- * ServiceAccountCredentials, ComputeEngineCredentials, ImpersonatedCredentials.
- * 
- * For more information see <br>
+ * Use an ID token to access services that require presenting an ID token for authentication such as
+ * Cloud Functions or Cloud Run.<br>
+ * The following Credential subclasses support IDTokens: ServiceAccountCredentials,
+ * ComputeEngineCredentials, ImpersonatedCredentials.
+ *
+ * <p>For more information see <br>
  * Usage:<br>
- * 
+ *
  * <pre>
  * String credPath = "/path/to/svc_account.json";
  * String targetAudience = "https://example.com";
- * 
+ *
  * // For Application Default Credentials (as ServiceAccountCredentials)
  * // export GOOGLE_APPLICATION_CREDENTIALS=/path/to/svc.json
  * GoogleCredentials adcCreds = GoogleCredentials.getApplicationDefault();
  * IdTokenCredentials tokenCredential = IdTokenCredentials.create(adcCreds, targetAudience);
- * 
+ *
  * // for ServiceAccountCredentials
  * ServiceAccountCredentials saCreds = ServiceAccountCredentials.fromStream(new FileInputStream(credPath));
  * saCreds = (ServiceAccountCredentials) saCreds.createScoped(Arrays.asList("https://www.googleapis.com/auth/iam"));
  * IdTokenCredentials tokenCredential = IdTokenCredentials.create(saCreds, targetAudience);
- * 
+ *
  * // for ComputeEngineCredentials
  * ComputeEngineCredentials caCreds = ComputeEngineCredentials.create();
  * IdTokenCredentials tokenCredential = IdTokenCredentials.create(caCreds, targetAudience,
@@ -77,7 +75,7 @@ import com.google.common.base.MoreObjects;
  *     Arrays.asList("https://www.googleapis.com/auth/cloud-platform"), 300);
  * IdTokenCredentials tokenCredential = IdTokenCredentials.create(imCreds, targetAudience,
  *     Arrays.asList(ImpersonatedCredentials.INCLUDE_EMAIL));
- * 
+ *
  * // Use the IdTokenCredential in an authorized transport
  * GenericUrl genericUrl = new GenericUrl("https://example.com");
  * HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(tokenCredential);
@@ -94,7 +92,8 @@ import com.google.common.base.MoreObjects;
 public class IdTokenCredentials extends OAuth2Credentials {
 
   private static final long serialVersionUID = -2133257318957588431L;
-  private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+  private static final String CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
 
   private GoogleCredentials sourceCredentials;
   private final String transportFactoryClassName;
@@ -104,57 +103,67 @@ public class IdTokenCredentials extends OAuth2Credentials {
   private transient HttpTransportFactory transportFactory;
 
   /**
-   * Returns IdToken credentials associated with the sourceCredentials and with an
-   * audience specified. Specify extensions and additional claims for the IdToken
-   * by applying any approprite Options for the given credential type.
-   * 
+   * Returns IdToken credentials associated with the sourceCredentials and with an audience
+   * specified. Specify extensions and additional claims for the IdToken by applying any approprite
+   * Options for the given credential type.
+   *
    * @param sourceCredentials The source credential for the Id Token
-   * @param targetAudience    The audience field for the issued ID Token
-   * @param options           List of Credential specific options for for the
-   *                          token. For example, an IDToken for a
-   *                          ComputeEngineCredential can return platform specific
-   *                          claims if
-   *                          "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is
-   *                          provided as a list option.
-   * @param transportFactory  HTTP transport factory, creates the transport used
-   *                          to get access tokens.
+   * @param targetAudience The audience field for the issued ID Token
+   * @param options List of Credential specific options for for the token. For example, an IDToken
+   *     for a ComputeEngineCredential can return platform specific claims if
+   *     "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is provided as a list option.
+   * @param transportFactory HTTP transport factory, creates the transport used to get access
+   *     tokens.
    * @return IdTokenCredential
    */
-  public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience,
-      HttpTransportFactory transportFactory, List<IdTokenProvider.Option> options) {
-    return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
-        .setOptions(options).setHttpTransportFactory(transportFactory).build();
+  public static IdTokenCredentials create(
+      GoogleCredentials sourceCredentials,
+      String targetAudience,
+      HttpTransportFactory transportFactory,
+      List<IdTokenProvider.Option> options) {
+    return IdTokenCredentials.newBuilder()
+        .setSourceCredentials(sourceCredentials)
+        .setTargetAudience(targetAudience)
+        .setOptions(options)
+        .setHttpTransportFactory(transportFactory)
+        .build();
   }
 
   /**
    * Returns an Google Id Token from the metadata server on ComputeEngine.
-   * 
+   *
    * @param sourceCredentials the source credential for the Id Token
    * @param targetAudience aud: field the IdToken should include.
-   * @param options list of Credential specific options for for the
-   * token. For example, an IDToken for a ComputeEngineCredential could 
-   * include the full formated claims returned if 
-   * "ComputeEngineCredential.ID_TOKEN_FORMAT_FULL" is specified. 
-   * Refer to the Credential type for specific extensions.
-   * @return IdToken object which includes the raw id_token, expirationn and
-   * audience
+   * @param options list of Credential specific options for for the token. For example, an IDToken
+   *     for a ComputeEngineCredential could include the full formated claims returned if
+   *     "ComputeEngineCredential.ID_TOKEN_FORMAT_FULL" is specified. Refer to the Credential type
+   *     for specific extensions.
+   * @return IdToken object which includes the raw id_token, expirationn and audience
    */
-  public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience,
+  public static IdTokenCredentials create(
+      GoogleCredentials sourceCredentials,
+      String targetAudience,
       List<IdTokenProvider.Option> options) {
-    return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
-        .setOptions(options).build();
+    return IdTokenCredentials.newBuilder()
+        .setSourceCredentials(sourceCredentials)
+        .setTargetAudience(targetAudience)
+        .setOptions(options)
+        .build();
   }
 
   /**
-   * Returns IdToken credentials associated with the sourceCredentials and with an
-   * audience specified.
-   * 
+   * Returns IdToken credentials associated with the sourceCredentials and with an audience
+   * specified.
+   *
    * @param sourceCredentials the source credential for the ID Token
    * @param targetAudience the audience field for the issued ID Token
    * @return IdTokenCredential
    */
-  public static IdTokenCredentials create(GoogleCredentials sourceCredentials, String targetAudience) {
-    return IdTokenCredentials.newBuilder().setSourceCredentials(sourceCredentials).setTargetAudience(targetAudience)
+  public static IdTokenCredentials create(
+      GoogleCredentials sourceCredentials, String targetAudience) {
+    return IdTokenCredentials.newBuilder()
+        .setSourceCredentials(sourceCredentials)
+        .setTargetAudience(targetAudience)
         .build();
   }
 
@@ -162,8 +171,10 @@ public class IdTokenCredentials extends OAuth2Credentials {
     this.sourceCredentials = builder.getSourceCredentials();
     this.targetAudience = builder.getTargetAudience();
     this.options = builder.getOptions();
-    this.transportFactory = firstNonNull(builder.getHttpTransportFactory(),
-        getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
+    this.transportFactory =
+        firstNonNull(
+            builder.getHttpTransportFactory(),
+            getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
     this.transportFactoryClassName = this.transportFactory.getClass().getName();
   }
 
@@ -173,9 +184,10 @@ public class IdTokenCredentials extends OAuth2Credentials {
       throw new IOException("Provided sourceToken does not implement IdTokenProvider");
     }
     if (this.sourceCredentials.getAccessToken() == null) {
-      this.sourceCredentials = this.sourceCredentials.createScoped(Arrays.asList(CLOUD_PLATFORM_SCOPE));
+      this.sourceCredentials =
+          this.sourceCredentials.createScoped(Arrays.asList(CLOUD_PLATFORM_SCOPE));
     }
-    
+
     return ((IdTokenProvider) this.sourceCredentials).idTokenWithAudience(targetAudience, options);
   }
 
@@ -219,8 +231,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
     private List<IdTokenProvider.Option> options;
     private HttpTransportFactory transportFactory;
 
-    protected Builder() {
-    }
+    protected Builder() {}
 
     public Builder setSourceCredentials(GoogleCredentials sourceCredentials) {
       this.sourceCredentials = sourceCredentials;
@@ -261,6 +272,5 @@ public class IdTokenCredentials extends OAuth2Credentials {
     public IdTokenCredentials build() {
       return new IdTokenCredentials(this);
     }
-
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -58,28 +58,35 @@ import java.util.Objects;
  * if (!adcCreds instanceof IdTokenProvider) {
  *   // handle error message
  * }
- * IdTokenCredentials tokenCredential = IdTokenCredentials.create((IdTokenProvider) adcCreds, targetAudience);
- * // or
+ * 
  * IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
- *     .setIdTokenProvider((IdTokenProvider) adcCreds)
+ *     .setIdTokenProvider(adcCreds)
  *     .setTargetAudience(targetAudience).build();
  * 
  * // for ServiceAccountCredentials
  * ServiceAccountCredentials saCreds = ServiceAccountCredentials.fromStream(new FileInputStream(credPath));
  * saCreds = (ServiceAccountCredentials) saCreds.createScoped(Arrays.asList("https://www.googleapis.com/auth/iam"));
- * IdTokenCredentials tokenCredential = IdTokenCredentials.create(saCreds, targetAudience);
- *
+ * IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+ *     .setIdTokenProvider(saCreds)
+ *     .setTargetAudience(targetAudience).build();
+ * 
  * // for ComputeEngineCredentials
  * ComputeEngineCredentials caCreds = ComputeEngineCredentials.create();
- * IdTokenCredentials tokenCredential = IdTokenCredentials.create(caCreds, targetAudience,
- *     Arrays.asList(ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL));
- *
+ * IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+ *     .setIdTokenProvider(caCreds)
+ *     .setTargetAudience(targetAudience)
+ *     .setOptions(Arrays.asList(ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL))
+ *     .build();
+ * 
  * // for ImpersonatedCredentials
  * ImpersonatedCredentials imCreds = ImpersonatedCredentials.create(saCreds,
  *     "impersonated-account@project.iam.gserviceaccount.com", null,
  *     Arrays.asList("https://www.googleapis.com/auth/cloud-platform"), 300);
- * IdTokenCredentials tokenCredential = IdTokenCredentials.create(imCreds, targetAudience,
- *     Arrays.asList(ImpersonatedCredentials.INCLUDE_EMAIL));
+ * IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+ *     .setIdTokenProvider(imCreds)
+ *     .setTargetAudience(targetAudience)
+ *     .setOptions(Arrays.asList(ImpersonatedCredentials.INCLUDE_EMAIL))
+ *     .build();
  *
  * // Use the IdTokenCredential in an authorized transport
  * GenericUrl genericUrl = new GenericUrl("https://example.com");
@@ -103,46 +110,6 @@ public class IdTokenCredentials extends OAuth2Credentials {
   private String targetAudience;
   private List<IdTokenProvider.Option> options;
 
-
-  /**
-   * Returns IdToken credentials associated with the sourceCredentials and with an audience
-   * specified. Specify extensions and additional claims for the IdToken by applying any approprite
-   * Options for the given credential type.
-   *
-   * @param idTokenProvider The source credential for the Id Token that implements IdTokenProvider 
-   * @param targetAudience The audience field for the issued ID Token
-   * @param options List of Credential specific options for for the token. For example, an IDToken
-   *     for a ComputeEngineCredential can return platform specific claims if
-   *     "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is provided as a list option.
-   *     tokens.
-   * @return IdTokenCredential
-   */
-  public static IdTokenCredentials create(
-      IdTokenProvider idTokenProvider,
-      String targetAudience,
-      List<IdTokenProvider.Option> options) {
-    return IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(idTokenProvider)
-        .setTargetAudience(targetAudience)
-        .setOptions(options)
-        .build();
-  }
-
-  /**
-   * Returns IdToken credentials associated with the sourceCredentials and with an audience
-   * specified.
-   *
-   * @param idTokenProvider The source credential for the Id Token that implements IdTokenProvider 
-   * @param targetAudience The audience field for the issued ID Token
-   * @return IdTokenCredential
-   */
-  public static IdTokenCredentials create(
-      IdTokenProvider idTokenProvider, String targetAudience) {
-    return IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(idTokenProvider)
-        .setTargetAudience(targetAudience)
-        .build();
-  }
 
   private IdTokenCredentials(Builder builder) {
     this.idTokenProvider = builder.getIdTokenProvider();
@@ -180,7 +147,10 @@ public class IdTokenCredentials extends OAuth2Credentials {
   }
 
   public Builder toBuilder() {
-    return new Builder();
+    return new Builder()
+        .setIdTokenProvider(this.idTokenProvider)
+        .setTargetAudience(this.targetAudience)
+        .setOptions(this.options);
   }
 
   public static Builder newBuilder() {

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, Google Inc. All rights reserved.
+ * Copyright 2019, Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google Inc. nor the names of its
+ *    * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -34,56 +34,43 @@ package com.google.auth.oauth2;
 import java.io.IOException;
 import java.util.List;
 
-import com.google.auth.oauth2.IdToken;
-
-/**
- * Interface for an Google OIDC token Provider. This type represents a google
- * issued OIDC token.
- */
+/** Interface for an Google OIDC token Provider. This type represents a google issued OIDC token. */
 public interface IdTokenProvider {
 
   /**
    * Enum of various credential-specific options to apply to the token.
-   * 
-   * <li><b>ComputeEngineCredentials</b>:  
-   *    <li><em>FORMAT_FULL</em></li>
-   *    <li><em>LICENSES_TRUE</em></li>
-   * <li><b>ImpersonatedCredential</b>:  
-   *    <li><em>INCLUDE_EMAIL</em><li>
-   * 
-  */
+   * <li><b>ComputeEngineCredentials</b>:
+   * <li><em>FORMAT_FULL</em>
+   * <li><em>LICENSES_TRUE</em>
+   * <li><b>ImpersonatedCredential</b>:
+   * <li><em>INCLUDE_EMAIL</em>
+   * <li>
+   */
   public enum Option {
-      FORMAT_FULL("formatFull"),
-      LICENSES_TRUE("licensesTrue"),
-      INCLUDE_EMAIL("includeEmail");
+    FORMAT_FULL("formatFull"),
+    LICENSES_TRUE("licensesTrue"),
+    INCLUDE_EMAIL("includeEmail");
 
-      private String option;
-  
-      Option(String option) {
-          this.option = option;
-      }
-  
-      public String getOption() {
-          return option;
-      }    
+    private String option;
+
+    Option(String option) {
+      this.option = option;
+    }
+
+    public String getOption() {
+      return option;
+    }
   }
 
   /**
    * Returns the a Google OpenID Token with the provided audience field.
-   * 
-   * @param targetAudience List of audiences the issued ID Token should be valid for.
-   *                       targetAudience accepts a single string value (multiple audience
-   *                       are not supported)
-   * @param options        List of Credential specific options for for the
-   *                       token. For example, an IDToken for a
-   *                       ComputeEngineCredential can return platform specific
-   *                       claims if
-   *                       "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is
-   *                       provided as a list option.
-   * @return IdToken object which includes the raw id_token, expiration and
-   *         audience.
+   *
+   * @param targetAudience List of audiences the issued ID Token should be valid for. targetAudience
+   *     accepts a single string value (multiple audience are not supported)
+   * @param options List of Credential specific options for for the token. For example, an IDToken
+   *     for a ComputeEngineCredential can return platform specific claims if
+   *     "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is provided as a list option.
+   * @return IdToken object which includes the raw id_token, expiration and audience.
    */
-
   IdToken idTokenWithAudience(String targetAudience, List<Option> options) throws IOException;
-
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -63,10 +63,10 @@ public interface IdTokenProvider {
   }
 
   /**
-   * Returns the a Google OpenID Token with the provided audience field.
+   * Returns a Google OpenID Token with the provided audience field.
    *
    * @param targetAudience List of audiences the issued ID Token should be valid for. targetAudience
-   *     accepts a single string value (multiple audience are not supported)
+   *     accepts a single string value (multiple audiences are not supported)
    * @param options List of Credential specific options for for the token. For example, an IDToken
    *     for a ComputeEngineCredential can return platform specific claims if
    *     "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is provided as a list option.

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -31,6 +31,7 @@
 
 package com.google.auth.oauth2;
 
+import java.io.IOException;
 import java.util.Objects;
 import java.util.List;
 
@@ -42,7 +43,7 @@ import com.google.auth.oauth2.IdToken;
  */
 public interface IdTokenProvider {
 
-  class IdTokenProviderException extends RuntimeException {
+  class IdTokenProviderException extends IOException {
 
     private static final long serialVersionUID = -6503954300538942223L;
 
@@ -67,6 +68,30 @@ public interface IdTokenProvider {
       return Objects.hash(getMessage(), getCause());
     }
   }
+  /**
+   * Enum of various credential-specific options to apply to the token.
+   * 
+   * <li><b>ComputeEngineCredentials</b>:  
+   *    <li><em>FORMAT_FULL</em></li>
+   *    <li><em>LICENSES_TRUE</em></li>
+   * <li><b>ImpersonatedCredential</b>:  <em>INCLUDE_EMAIL</em>
+   * 
+  */
+  public enum Option {
+      FORMAT_FULL("formatFull"),
+      LICENSES_TRUE("licensesTrue"),
+      INCLUDE_EMAIL("includeEmail");
+
+      private String option;
+  
+      Option(String option) {
+          this.option = option;
+      }
+  
+      public String getOption() {
+          return option;
+      }    
+  }
 
   /**
    * Returns the a Google OpenID Token with the provided audience field.
@@ -84,6 +109,6 @@ public interface IdTokenProvider {
    *         audience.
    */
 
-  IdToken idTokenWithAudience(String targetAudience, List<String> options);
+  IdToken idTokenWithAudience(String targetAudience, List<Option> options) throws IOException;
 
 }

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2019, Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google Inc. nor the names of its
+ *    * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *
@@ -32,7 +32,6 @@
 package com.google.auth.oauth2;
 
 import java.io.IOException;
-import java.util.Objects;
 import java.util.List;
 
 import com.google.auth.oauth2.IdToken;
@@ -43,38 +42,14 @@ import com.google.auth.oauth2.IdToken;
  */
 public interface IdTokenProvider {
 
-  class IdTokenProviderException extends IOException {
-
-    private static final long serialVersionUID = -6503954300538942223L;
-
-    public IdTokenProviderException(String message, Exception cause) {
-      super(message, cause);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (obj == this) {
-        return true;
-      }
-      if (!(obj instanceof IdTokenProviderException)) {
-        return false;
-      }
-      IdTokenProviderException other = (IdTokenProviderException) obj;
-      return Objects.equals(getCause(), other.getCause()) && Objects.equals(getMessage(), other.getMessage());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(getMessage(), getCause());
-    }
-  }
   /**
    * Enum of various credential-specific options to apply to the token.
    * 
    * <li><b>ComputeEngineCredentials</b>:  
    *    <li><em>FORMAT_FULL</em></li>
    *    <li><em>LICENSES_TRUE</em></li>
-   * <li><b>ImpersonatedCredential</b>:  <em>INCLUDE_EMAIL</em>
+   * <li><b>ImpersonatedCredential</b>:  
+   *    <li><em>INCLUDE_EMAIL</em><li>
    * 
   */
   public enum Option {

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -41,12 +41,17 @@ public interface IdTokenProvider {
 
   /**
    * Enum of various credential-specific options to apply to the token.
-   * <li><b>ComputeEngineCredentials</b>:
-   * <li><em>FORMAT_FULL</em>
-   * <li><em>LICENSES_TRUE</em>
-   * <li><b>ImpersonatedCredential</b>:
-   * <li><em>INCLUDE_EMAIL</em>
-   * <li>
+   * 
+   * <b>ComputeEngineCredentials</b>
+   * <ul>
+   * <li>FORMAT_FULL</li>
+   * <li>LICENSES_TRUE</li>
+   * </ul>
+   * <br/>
+   * <b>ImpersonatedCredential</b>
+   * <ul>
+   * <li>INCLUDE_EMAIL</li>
+   * </ul>
    */
   public enum Option {
     FORMAT_FULL("formatFull"),

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -31,10 +31,12 @@
 
 package com.google.auth.oauth2;
 
+import com.google.common.annotations.Beta;
 import java.io.IOException;
 import java.util.List;
 
-/** Interface for an Google OIDC token Provider. This type represents a google issued OIDC token. */
+/** Interface for an Google OIDC token provider. This type represents a google issued OIDC token. */
+@Beta
 public interface IdTokenProvider {
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -41,16 +41,19 @@ public interface IdTokenProvider {
 
   /**
    * Enum of various credential-specific options to apply to the token.
-   * 
-   * <b>ComputeEngineCredentials</b>
+   *
+   * <p><b>ComputeEngineCredentials</b>
+   *
    * <ul>
-   * <li>FORMAT_FULL</li>
-   * <li>LICENSES_TRUE</li>
+   *   <li>FORMAT_FULL
+   *   <li>LICENSES_TRUE
    * </ul>
-   * <br/>
+   *
+   * <br>
    * <b>ImpersonatedCredential</b>
+   *
    * <ul>
-   * <li>INCLUDE_EMAIL</li>
+   *   <li>INCLUDE_EMAIL
    * </ul>
    */
   public enum Option {

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -55,7 +55,7 @@ public interface IdTokenProvider {
 
     private String option;
 
-    Option(String option) {
+    private Option(String option) {
       this.option = option;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import java.util.Objects;
+import java.util.List;
+
+import com.google.auth.oauth2.IdToken;
+
+/**
+ * Interface for an Google OIDC token Provider. This type represents a google
+ * issued OIDC token.
+ */
+public interface IdTokenProvider {
+
+  class IdTokenProviderException extends RuntimeException {
+
+    private static final long serialVersionUID = -6503954300538942223L;
+
+    public IdTokenProviderException(String message, Exception cause) {
+      super(message, cause);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (!(obj instanceof IdTokenProviderException)) {
+        return false;
+      }
+      IdTokenProviderException other = (IdTokenProviderException) obj;
+      return Objects.equals(getCause(), other.getCause()) && Objects.equals(getMessage(), other.getMessage());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(getMessage(), getCause());
+    }
+  }
+
+  /**
+   * Returns the a Google OpenID Token with the provided audience field.
+   * 
+   * @param targetAudience List of audiences the issued ID Token should be valid for.
+   *                       targetAudience accepts a single string value (multiple audience
+   *                       are not supported)
+   * @param options        List of Credential specific options for for the
+   *                       token. For example, an IDToken for a
+   *                       ComputeEngineCredential can return platform specific
+   *                       claims if
+   *                       "ComputeEngineCredentials.ID_TOKEN_FORMAT_FULL" is
+   *                       provided as a list option.
+   * @return IdToken object which includes the raw id_token, expiration and
+   *         audience.
+   */
+
+  IdToken idTokenWithAudience(String targetAudience, List<String> options);
+
+}

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -280,7 +280,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
   /**
    * Returns an IdToken for the current Credential
    *
-   * @param targetAudience The audience field for the issued ID Token
+   * @param targetAudience the audience field for the issued ID Token
    * @param options List of Credential specific options for for the token. For example, an IDToken
    *     for a ImpersonatedCredentials can return the email address within the token claims if
    *     "ImpersonatedCredentials.INCLUDE_EMAIL" is provided as a list option.<br>

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -45,6 +45,7 @@ import com.google.api.client.util.GenericData;
 import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -288,6 +289,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
    * @return IdToken object which includes the raw id_token, expiration and audience.
    * @throws IOException if the attempt to get an IdToken failed
    */
+  @Beta
   @Override
   public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options)
       throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -278,7 +278,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
   }
 
   /**
-   * Returns an IdToken for the current Credential
+   * Returns an IdToken for the current Credential.
    *
    * @param targetAudience the audience field for the issued ID Token
    * @param options List of Credential specific options for for the token. For example, an IDToken

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -94,8 +94,6 @@ public class ImpersonatedCredentials extends GoogleCredentials implements Servic
   private static final String SCOPE_EMPTY_ERROR = "Scopes cannot be null";
   private static final String LIFETIME_EXCEEDED_ERROR = "lifetime must be less than or equal to 3600";
 
-  public static final String INCLUDE_EMAIL = "includeEmail";
-
   private GoogleCredentials sourceCredentials;
   private String targetPrincipal;
   private List<String> delegates;
@@ -274,15 +272,14 @@ public class ImpersonatedCredentials extends GoogleCredentials implements Servic
    *                       "includeEmail" attribute in the API request
    * @return IdToken object which includes the raw id_token, expiration and
    *         audience.
-   * @throws IdTokenProvider.IdTokenProviderException if the attempt to get an
-   *                                                  IdToken failed
+   * @throws IOException if the attempt to get an IdToken failed
    */
 
   @Override
-  public IdToken idTokenWithAudience(String targetAudience, List<String> options) {
+  public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options) throws IOException {
     boolean includeEmail = false;
     if (options != null)
-      if (options.contains(INCLUDE_EMAIL))
+      if (options.contains(IdTokenProvider.Option.INCLUDE_EMAIL))
         includeEmail = true;
     return IamUtils.getIdToken(getAccount(), sourceCredentials, transportFactory.create(), targetAudience, includeEmail,
         ImmutableMap.of("delegates", this.delegates));

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -277,10 +277,7 @@ public class ImpersonatedCredentials extends GoogleCredentials implements Servic
 
   @Override
   public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options) throws IOException {
-    boolean includeEmail = false;
-    if (options != null)
-      if (options.contains(IdTokenProvider.Option.INCLUDE_EMAIL))
-        includeEmail = true;
+    boolean includeEmail = options != null && options.contains(IdTokenProvider.Option.INCLUDE_EMAIL);
     return IamUtils.getIdToken(getAccount(), sourceCredentials, transportFactory.create(), targetAudience, includeEmail,
         ImmutableMap.of("delegates", this.delegates));
   }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -55,6 +55,7 @@ import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.SecurityUtils;
 import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.Beta;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -448,6 +449,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
    * @throws IOException if the attempt to get an IdToken failed
    * @return IdToken object which includes the raw id_token, expiration and audience
    */
+  @Beta
   @Override
   public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options)
       throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -374,12 +374,12 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
   /**
    * Returns a Google Id Token from the metadata server on ComputeEngine.
    *
-   * @param targetAudience The aud: field the IdToken should include.
-   * @param options        List of Credential specific options for for the
-   *                       token. Currently unused for ServiceAccountCredentials.
-   * @throws IOException   if the attempt to get an IdToken failed
+   * @param targetAudience the aud: field the IdToken should include.
+   * @param options list of Credential specific options for for the
+   * token. Currently unused for ServiceAccountCredentials.
+   * @throws IOException if the attempt to get an IdToken failed
    * @return IdToken object which includes the raw id_token, expiration and
-   *         audience.
+   * audience
    */
   @Override
   public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options) throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -441,7 +441,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
   }
 
   /**
-   * Returns a Google Id Token from the metadata server on ComputeEngine.
+   * Returns a Google ID Token from the metadata server on ComputeEngine.
    *
    * @param targetAudience the aud: field the IdToken should include.
    * @param options list of Credential specific options for for the token. Currently unused for
@@ -468,8 +468,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     HttpRequestFactory requestFactory = transportFactory.create().createRequestFactory();
     HttpRequest request = requestFactory.buildPostRequest(new GenericUrl(tokenServerUri), content);
     request.setParser(new JsonObjectParser(jsonFactory));
-    HttpResponse response;
-    response = request.execute();
+    HttpResponse response = request.execute();
 
     GenericData responseData = response.parseAs(GenericData.class);
     String rawToken = OAuth2Utils.validateString(responseData, "id_token", PARSE_ERROR_PREFIX);
@@ -677,8 +676,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
     try {
       payload.set("target_audience", targetAudience);
 
-      String assertion;      
-      assertion = JsonWebSignature.signUsingRsaSha256(privateKey, jsonFactory, header, payload);
+      String assertion =
+          JsonWebSignature.signUsingRsaSha256(privateKey, jsonFactory, header, payload);
       return assertion;
     } catch (GeneralSecurityException e) {
       throw new IOException(

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -654,16 +654,16 @@ public class ServiceAccountCredentials extends GoogleCredentials
       payload.setAudience(audience);
     }
 
-    payload.set("target_audience", targetAudience);
-
-    String assertion;
     try {
+      payload.set("target_audience", targetAudience);
+
+      String assertion;      
       assertion = JsonWebSignature.signUsingRsaSha256(privateKey, jsonFactory, header, payload);
+      return assertion;
     } catch (GeneralSecurityException e) {
       throw new IOException(
           "Error signing service account access token request with private key.", e);
     }
-    return assertion;
   }
 
   @SuppressWarnings("unused")

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -377,14 +377,12 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
    * @param targetAudience The aud: field the IdToken should include.
    * @param options        List of Credential specific options for for the
    *                       token. Currently unused for ServiceAccountCredentials.
-   * @throws IdTokenProvider.IdTokenProviderException if the attempt to get an
-   *                                                  IdToken failed
+   * @throws IOException   if the attempt to get an IdToken failed
    * @return IdToken object which includes the raw id_token, expiration and
    *         audience.
    */
   @Override
-  public IdToken idTokenWithAudience(String targetAudience, List<String> options) {
-    try {
+  public IdToken idTokenWithAudience(String targetAudience, List<IdTokenProvider.Option> options) throws IOException {
 
       JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
       long currentTime = clock.currentTimeMillis();
@@ -399,20 +397,14 @@ public class ServiceAccountCredentials extends GoogleCredentials implements Serv
       HttpRequest request = requestFactory.buildPostRequest(new GenericUrl(tokenServerUri), content);
       request.setParser(new JsonObjectParser(jsonFactory));
       HttpResponse response;
-      try {
-        response = request.execute();
-      } catch (IOException e) {
-        throw new IOException(String.format("Error getting idToken for service account: %s", e.getMessage()), e);
-      }
+      response = request.execute();
 
       GenericData responseData = response.parseAs(GenericData.class);
       String rawToken = OAuth2Utils.validateString(responseData, "id_token", PARSE_ERROR_PREFIX);
 
       JsonWebSignature jws =  JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
       return new IdToken(rawToken, jws);
-    } catch (IOException ex) {
-      throw new IdTokenProvider.IdTokenProviderException("Unable to Parse IDToken " + ex.getMessage(), ex);
-    }
+
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -56,6 +56,7 @@ import com.google.api.client.util.SecurityUtils;
 import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -653,6 +654,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return assertion;
   }
 
+  @VisibleForTesting
   String createAssertionForIdToken(
       JsonFactory jsonFactory, long currentTime, String audience, String targetAudience)
       throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -472,8 +472,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     GenericData responseData = response.parseAs(GenericData.class);
     String rawToken = OAuth2Utils.validateString(responseData, "id_token", PARSE_ERROR_PREFIX);
 
-    JsonWebSignature jws = JsonWebSignature.parse(OAuth2Utils.JSON_FACTORY, rawToken);
-    return new IdToken(rawToken, jws);
+    return IdToken.create(rawToken);
   }
 
   /** Returns whether the scopes are empty, meaning createScoped must be called before use. */

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -68,14 +68,14 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
 
-  public static final String standardIdToken =
+  public static final String STANDARD_ID_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyO"
           + "TNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiL"
           + "CJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJleHAiOjE1NjQ0NzUwNTEsImlhdCI6MTU2NDQ3MTQ1MSwi"
           + "aXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyMTAxNTUwODM0MjAwNzA4NTY4In0"
           + ".redacted";
 
-  public static final String fullIdToken =
+  public static final String FULL_ID_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyOTNh"
           + "ZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiLCJhe"
           + "nAiOiIxMTIxNzkwNjI3MjAzOTEzMDU4ODUiLCJlbWFpbCI6IjEwNzEyODQxODQ0MzYtY29tcHV0ZUBkZXZlbG9wZ"
@@ -86,7 +86,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
           + "XMtY2VudHJhbDEtYSJ9fSwiaWF0IjoxNTY0NTE1ODk2LCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb"
           + "20iLCJzdWIiOiIxMTIxNzkwNjI3MjAzOTEzMDU4ODUifQ.redacted";
 
-  public static final String fullIdTokenWithLicense =
+  public static final String FULL_ID_TOKEN_WITH_LICENSE =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOG"
           + "I3OTIyOTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.ew0KICAiYXVkIjogImh0dHBzOi8"
           + "vZm9vLmJhciIsDQogICJhenAiOiAiMTEyMTc5MDYyNzIwMzkxMzA1ODg1IiwNCiAgImVtYWlsIjogIjEyMzQ1Ni1"
@@ -480,7 +480,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
   @Test
   public void idTokenWithAudience_sameAs() throws IOException {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
-    transportFactory.transport.setIdToken(standardIdToken);
+    transportFactory.transport.setIdToken(STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
@@ -491,8 +491,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
             .setTargetAudience(targetAudience)
             .build();
     tokenCredential.refresh();
-    assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
-    assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
+    assertEquals(STANDARD_ID_TOKEN, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(STANDARD_ID_TOKEN, tokenCredential.getIdToken().getTokenValue());
     assertEquals(
         targetAudience,
         (String) tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudience());
@@ -511,8 +511,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
             .setTargetAudience(targetAudience)
             .build();
     tokenCredential.refresh();
-    assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
-    assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
+    assertEquals(STANDARD_ID_TOKEN, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(STANDARD_ID_TOKEN, tokenCredential.getIdToken().getTokenValue());
     assertNull(tokenCredential.getIdToken().getJsonWebSignature().getPayload().get("google"));
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -485,10 +485,11 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(credentials)
-        .setTargetAudience(targetAudience)
-        .build();     
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
     tokenCredential.refresh();
     assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
@@ -504,10 +505,11 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(credentials)
-        .setTargetAudience(targetAudience)
-        .build();     
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
     tokenCredential.refresh();
     assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
@@ -522,11 +524,12 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(credentials)
-        .setTargetAudience(targetAudience)
-        .setOptions(Arrays.asList(IdTokenProvider.Option.FORMAT_FULL))
-        .build();             
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .setOptions(Arrays.asList(IdTokenProvider.Option.FORMAT_FULL))
+            .build();
     tokenCredential.refresh();
     Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
     if (!p.containsKey("google")) {
@@ -544,11 +547,14 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(credentials)
-        .setTargetAudience(targetAudience)
-        .setOptions(Arrays.asList(IdTokenProvider.Option.FORMAT_FULL, IdTokenProvider.Option.LICENSES_TRUE))
-        .build();
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .setOptions(
+                Arrays.asList(
+                    IdTokenProvider.Option.FORMAT_FULL, IdTokenProvider.Option.LICENSES_TRUE))
+            .build();
     tokenCredential.refresh();
     Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
     if (!p.containsKey("google")) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -465,7 +465,10 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(credentials)
+        .setTargetAudience(targetAudience)
+        .build();     
     tokenCredential.refresh();
     assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
@@ -481,7 +484,10 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(credentials)
+        .setTargetAudience(targetAudience)
+        .build();     
     tokenCredential.refresh();
     assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
@@ -496,9 +502,11 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential =
-        IdTokenCredentials.create(
-            credentials, targetAudience, Arrays.asList(IdTokenProvider.Option.FORMAT_FULL));
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(credentials)
+        .setTargetAudience(targetAudience)
+        .setOptions(Arrays.asList(IdTokenProvider.Option.FORMAT_FULL))
+        .build();             
     tokenCredential.refresh();
     Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
     if (!p.containsKey("google")) {
@@ -516,12 +524,11 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential =
-        IdTokenCredentials.create(
-            credentials,
-            targetAudience,
-            Arrays.asList(
-                IdTokenProvider.Option.FORMAT_FULL, IdTokenProvider.Option.LICENSES_TRUE));
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(credentials)
+        .setTargetAudience(targetAudience)
+        .setOptions(Arrays.asList(IdTokenProvider.Option.FORMAT_FULL, IdTokenProvider.Option.LICENSES_TRUE))
+        .build();
     tokenCredential.refresh();
     Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
     if (!p.containsKey("google")) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -68,6 +68,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
 
+  // Id Token which includes basic default claims
   public static final String STANDARD_ID_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyO"
           + "TNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiL"
@@ -75,6 +76,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
           + "aXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyMTAxNTUwODM0MjAwNzA4NTY4In0"
           + ".redacted";
 
+  // Id Token which includes GCE extended claims
   public static final String FULL_ID_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyOTNh"
           + "ZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiLCJhe"
@@ -86,6 +88,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
           + "XMtY2VudHJhbDEtYSJ9fSwiaWF0IjoxNTY0NTE1ODk2LCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb"
           + "20iLCJzdWIiOiIxMTIxNzkwNjI3MjAzOTEzMDU4ODUifQ.redacted";
 
+  // Id Token which includes GCE extended claims and any VM License data (if applicable)
   public static final String FULL_ID_TOKEN_WITH_LICENSE =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOG"
           + "I3OTIyOTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.ew0KICAiYXVkIjogImh0dHBzOi8"

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -43,29 +44,61 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.webtoken.JsonWebToken.Payload;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.api.client.util.ArrayMap;
 import com.google.api.client.util.Clock;
 import com.google.auth.ServiceAccountSigner.SigningException;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentialsTest.MockHttpTransportFactory;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-
-/**
- * Test case for {@link ComputeEngineCredentials}.
- */
+/** Test case for {@link ComputeEngineCredentials}. */
 @RunWith(JUnit4.class)
 public class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
+
+  public static final String standardIdToken =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyO"
+          + "TNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiL"
+          + "CJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJleHAiOjE1NjQ0NzUwNTEsImlhdCI6MTU2NDQ3MTQ1MSwi"
+          + "aXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyMTAxNTUwODM0MjAwNzA4NTY4In0"
+          + ".redacted";
+
+  public static final String fullIdToken =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyOTNh"
+          + "ZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiLCJhe"
+          + "nAiOiIxMTIxNzkwNjI3MjAzOTEzMDU4ODUiLCJlbWFpbCI6IjEwNzEyODQxODQ0MzYtY29tcHV0ZUBkZXZlbG9wZ"
+          + "XIuZ3NlcnZpY2VhY2NvdW50LmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJleHAiOjE1NjQ1MTk0OTYsImdvb"
+          + "2dsZSI6eyJjb21wdXRlX2VuZ2luZSI6eyJpbnN0YW5jZV9jcmVhdGlvbl90aW1lc3RhbXAiOjE1NjMyMzA5MDcsI"
+          + "mluc3RhbmNlX2lkIjoiMzQ5Nzk3NDM5MzQ0MTE3OTI0MyIsImluc3RhbmNlX25hbWUiOiJpYW0iLCJwcm9qZWN0X"
+          + "2lkIjoibWluZXJhbC1taW51dGlhLTgyMCIsInByb2plY3RfbnVtYmVyIjoxMDcxMjg0MTg0NDM2LCJ6b25lIjoid"
+          + "XMtY2VudHJhbDEtYSJ9fSwiaWF0IjoxNTY0NTE1ODk2LCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb"
+          + "20iLCJzdWIiOiIxMTIxNzkwNjI3MjAzOTEzMDU4ODUifQ.redacted";
+
+  public static final String fullIdTokenWithLicense =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOG"
+          + "I3OTIyOTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.ew0KICAiYXVkIjogImh0dHBzOi8"
+          + "vZm9vLmJhciIsDQogICJhenAiOiAiMTEyMTc5MDYyNzIwMzkxMzA1ODg1IiwNCiAgImVtYWlsIjogIjEyMzQ1Ni1"
+          + "jb21wdXRlQGRldmVsb3Blci5nc2VydmljZWFjY291bnQuY29tIiwNCiAgImVtYWlsX3ZlcmlmaWVkIjogdHJ1ZSw"
+          + "NCiAgImV4cCI6IDE1NjQ1MTk0OTYsDQogICJnb29nbGUiOiB7DQogICAgImNvbXB1dGVfZW5naW5lIjogew0KICA"
+          + "gICAgImluc3RhbmNlX2NyZWF0aW9uX3RpbWVzdGFtcCI6IDE1NjMyMzA5MDcsDQogICAgICAiaW5zdGFuY2VfaWQ"
+          + "iOiAiMzQ5Nzk3NDM5MzQ0MTE3OTI0MyIsDQogICAgICAiaW5zdGFuY2VfbmFtZSI6ICJpYW0iLA0KICAgICAgInB"
+          + "yb2plY3RfaWQiOiAiZm9vLWJhci04MjAiLA0KICAgICAgInByb2plY3RfbnVtYmVyIjogMTA3MTI4NDE4NDQzNiw"
+          + "NCiAgICAgICJ6b25lIjogInVzLWNlbnRyYWwxLWEiDQogICAgfSwNCiAgICAibGljZW5zZSI6IFsNCiAgICAgICA"
+          + "iTElDRU5TRV8xIiwNCiAgICAgICAiTElDRU5TRV8yIg0KICAgIF0NCiAgfSwNCiAgImlhdCI6IDE1NjQ1MTU4OTY"
+          + "sDQogICJpc3MiOiAiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwNCiAgInN1YiI6ICIxMTIxNzkwNjI3MjA"
+          + "zOTEzMDU4ODUiDQp9.redacted";
 
   static class MockMetadataServerTransportFactory implements HttpTransportFactory {
 
@@ -143,7 +176,9 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
-        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(serverTransportFactory)
+            .build();
     ComputeEngineCredentials otherCredentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(httpTransportFactory).build();
     assertFalse(credentials.equals(otherCredentials));
@@ -155,10 +190,13 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
     String expectedToString =
-        String.format("ComputeEngineCredentials{transportFactoryClassName=%s}",
+        String.format(
+            "ComputeEngineCredentials{transportFactoryClassName=%s}",
             MockMetadataServerTransportFactory.class.getName());
     ComputeEngineCredentials credentials =
-        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(serverTransportFactory)
+            .build();
     assertEquals(expectedToString, credentials.toString());
   }
 
@@ -167,9 +205,13 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
-        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(serverTransportFactory)
+            .build();
     ComputeEngineCredentials otherCredentials =
-        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(serverTransportFactory)
+            .build();
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 
@@ -178,7 +220,9 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
     ComputeEngineCredentials credentials =
-        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(serverTransportFactory).build();
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(serverTransportFactory)
+            .build();
     GoogleCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
@@ -199,34 +243,33 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
-            ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     assertEquals(defaultAccountEmail, credentials.getAccount());
   }
 
   @Test
   public void getAccount_missing_throws() {
-    MockMetadataServerTransportFactory transportFactory =
-        new MockMetadataServerTransportFactory();
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     String defaultAccountEmail = "mail@mail.com";
 
-    transportFactory.transport = new MockMetadataServerTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url)
-          throws IOException {
-        if (isGetServiceAccountsUrl(url)) {
-          return new MockLowLevelHttpRequest(url) {
-            @Override
-            public LowLevelHttpResponse execute() throws IOException {
-              return new MockLowLevelHttpResponse()
-                  .setStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND)
-                  .setContent("");
+    transportFactory.transport =
+        new MockMetadataServerTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            if (isGetServiceAccountsUrl(url)) {
+              return new MockLowLevelHttpRequest(url) {
+                @Override
+                public LowLevelHttpResponse execute() throws IOException {
+                  return new MockLowLevelHttpResponse()
+                      .setStatusCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND)
+                      .setContent("");
+                }
+              };
             }
-          };
-        }
-        return super.buildRequest(method, url);
-      }
-    };
+            return super.buildRequest(method, url);
+          }
+        };
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
@@ -243,26 +286,25 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void getAccount_emptyContent_throws() {
-    MockMetadataServerTransportFactory transportFactory =
-        new MockMetadataServerTransportFactory();
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     String defaultAccountEmail = "mail@mail.com";
 
-    transportFactory.transport = new MockMetadataServerTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url)
-          throws IOException {
-        if (isGetServiceAccountsUrl(url)) {
-          return new MockLowLevelHttpRequest(url) {
-            @Override
-            public LowLevelHttpResponse execute() throws IOException {
-              return new MockLowLevelHttpResponse()
-                  .setStatusCode(HttpStatusCodes.STATUS_CODE_OK);
+    transportFactory.transport =
+        new MockMetadataServerTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            if (isGetServiceAccountsUrl(url)) {
+              return new MockLowLevelHttpRequest(url) {
+                @Override
+                public LowLevelHttpResponse execute() throws IOException {
+                  return new MockLowLevelHttpResponse()
+                      .setStatusCode(HttpStatusCodes.STATUS_CODE_OK);
+                }
+              };
             }
-          };
-        }
-        return super.buildRequest(method, url);
-      }
-    };
+            return super.buildRequest(method, url);
+          }
+        };
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
@@ -288,7 +330,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
     transportFactory.transport.setSignature(expectedSignature);
     ComputeEngineCredentials credentials =
-            ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
     assertArrayEquals(expectedSignature, credentials.sign(expectedSignature));
   }
@@ -299,23 +341,23 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
     String defaultAccountEmail = "mail@mail.com";
 
-    transportFactory.transport = new MockMetadataServerTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url)
-          throws IOException {
-        if (isSignRequestUrl(url)) {
-          return new MockLowLevelHttpRequest(url) {
-            @Override
-            public LowLevelHttpResponse execute() throws IOException {
-              return new MockLowLevelHttpResponse()
-                  .setStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN)
-                  .setContent(TestUtils.errorJson("Sign Error"));
+    transportFactory.transport =
+        new MockMetadataServerTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            if (isSignRequestUrl(url)) {
+              return new MockLowLevelHttpRequest(url) {
+                @Override
+                public LowLevelHttpResponse execute() throws IOException {
+                  return new MockLowLevelHttpResponse()
+                      .setStatusCode(HttpStatusCodes.STATUS_CODE_FORBIDDEN)
+                      .setContent(TestUtils.errorJson("Sign Error"));
+                }
+              };
             }
-          };
-        }
-        return super.buildRequest(method, url);
-      }
-    };
+            return super.buildRequest(method, url);
+          }
+        };
 
     transportFactory.transport.setAccessToken(accessToken);
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
@@ -340,23 +382,23 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
     String defaultAccountEmail = "mail@mail.com";
 
-    transportFactory.transport = new MockMetadataServerTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url)
-          throws IOException {
-        if (isSignRequestUrl(url)) {
-          return new MockLowLevelHttpRequest(url) {
-            @Override
-            public LowLevelHttpResponse execute() throws IOException {
-              return new MockLowLevelHttpResponse()
-                  .setStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
-                  .setContent(TestUtils.errorJson("Sign Error"));
+    transportFactory.transport =
+        new MockMetadataServerTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            if (isSignRequestUrl(url)) {
+              return new MockLowLevelHttpRequest(url) {
+                @Override
+                public LowLevelHttpResponse execute() throws IOException {
+                  return new MockLowLevelHttpResponse()
+                      .setStatusCode(HttpStatusCodes.STATUS_CODE_SERVER_ERROR)
+                      .setContent(TestUtils.errorJson("Sign Error"));
+                }
+              };
             }
-          };
-        }
-        return super.buildRequest(method, url);
-      }
-    };
+            return super.buildRequest(method, url);
+          }
+        };
 
     transportFactory.transport.setAccessToken(accessToken);
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
@@ -381,22 +423,22 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
     String defaultAccountEmail = "mail@mail.com";
 
-    transportFactory.transport = new MockMetadataServerTransport() {
-      @Override
-      public LowLevelHttpRequest buildRequest(String method, String url)
-          throws IOException {
-        if (isSignRequestUrl(url)) {
-          return new MockLowLevelHttpRequest(url) {
-            @Override
-            public LowLevelHttpResponse execute() throws IOException {
-              return new MockLowLevelHttpResponse()
-                  .setStatusCode(HttpStatusCodes.STATUS_CODE_OK);
+    transportFactory.transport =
+        new MockMetadataServerTransport() {
+          @Override
+          public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+            if (isSignRequestUrl(url)) {
+              return new MockLowLevelHttpRequest(url) {
+                @Override
+                public LowLevelHttpResponse execute() throws IOException {
+                  return new MockLowLevelHttpResponse()
+                      .setStatusCode(HttpStatusCodes.STATUS_CODE_OK);
+                }
+              };
             }
-          };
-        }
-        return super.buildRequest(method, url);
-      }
-    };
+            return super.buildRequest(method, url);
+          }
+        };
 
     transportFactory.transport.setAccessToken(accessToken);
     transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
@@ -413,5 +455,79 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
       assertNotNull(e.getCause());
       assertTrue(e.getCause().getMessage().contains("Empty content"));
     }
+  }
+
+  @Test
+  public void idTokenWithAudience_sameAs() throws IOException {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    transportFactory.transport.setIdToken(standardIdToken);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    tokenCredential.refresh();
+    assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
+    assertEquals(
+        targetAudience,
+        (String) tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudience());
+  }
+
+  @Test
+  public void idTokenWithAudience_standard() throws IOException {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    tokenCredential.refresh();
+    assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
+    assertNull(tokenCredential.getIdToken().getJsonWebSignature().getPayload().get("google"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void idTokenWithAudience_full() throws IOException {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.create(
+            credentials, targetAudience, Arrays.asList(IdTokenProvider.Option.FORMAT_FULL));
+    tokenCredential.refresh();
+    Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
+    if (!p.containsKey("google")) {
+      assertFalse("Full ID Token format not provided", false);
+    }
+    ArrayMap<String, ArrayMap> googleClaim = (ArrayMap<String, ArrayMap>) p.get("google");
+    assert (googleClaim.containsKey("compute_engine"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void idTokenWithAudience_license() throws IOException {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.create(
+            credentials,
+            targetAudience,
+            Arrays.asList(
+                IdTokenProvider.Option.FORMAT_FULL, IdTokenProvider.Option.LICENSES_TRUE));
+    tokenCredential.refresh();
+    Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
+    if (!p.containsKey("google")) {
+      assertFalse("Full ID Token format not provided", false);
+    }
+    ArrayMap<String, ArrayMap> googleClaim = (ArrayMap<String, ArrayMap>) p.get("google");
+    assert (googleClaim.containsKey("license"));
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * 2019 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC
+ * Copyright 2019, Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google LLC. nor the names of its
+ *    * Neither the name of Google LLC nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test case for {@link IdTokenCredentials}. */
+@RunWith(JUnit4.class)
+public class IdTokenCredentialsTest extends BaseSerializationTest {
+
+  @Test
+  public void hashCode_equals() throws IOException {
+    ComputeEngineCredentialsTest.MockMetadataServerTransportFactory transportFactory =
+        new ComputeEngineCredentialsTest.MockMetadataServerTransportFactory();
+    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.standardIdToken);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
+    tokenCredential.refresh();
+
+    IdTokenCredentials otherCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
+    otherCredential.refresh();
+    assertEquals(tokenCredential, tokenCredential.toBuilder().build());
+    assertEquals(tokenCredential.hashCode(), otherCredential.hashCode());
+  }
+
+  @Test
+  public void toString_equals() throws IOException {
+    ComputeEngineCredentialsTest.MockMetadataServerTransportFactory transportFactory =
+        new ComputeEngineCredentialsTest.MockMetadataServerTransportFactory();
+    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.standardIdToken);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
+    tokenCredential.refresh();
+
+    IdTokenCredentials otherCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
+    otherCredential.refresh();
+
+    assertEquals(tokenCredential.toString(), otherCredential.toString());
+  }
+
+  @Test
+  public void serialize() throws IOException, ClassNotFoundException {
+
+    ComputeEngineCredentialsTest.MockMetadataServerTransportFactory transportFactory =
+        new ComputeEngineCredentialsTest.MockMetadataServerTransportFactory();
+    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.standardIdToken);
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
+    tokenCredential.refresh();
+    IdTokenCredentials deserializedCredentials = serializeAndDeserialize(tokenCredential);
+    assertEquals(tokenCredential, deserializedCredentials);
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdTokenCredentialsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015, Google Inc. All rights reserved.
+ * 2019 Google LLC
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -12,7 +12,7 @@
  * in the documentation and/or other materials provided with the
  * distribution.
  *
- *    * Neither the name of Google Inc. nor the names of its
+ *    * Neither the name of Google LLC. nor the names of its
  * contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
  *
@@ -46,7 +46,7 @@ public class IdTokenCredentialsTest extends BaseSerializationTest {
   public void hashCode_equals() throws IOException {
     ComputeEngineCredentialsTest.MockMetadataServerTransportFactory transportFactory =
         new ComputeEngineCredentialsTest.MockMetadataServerTransportFactory();
-    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.standardIdToken);
+    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
@@ -72,7 +72,7 @@ public class IdTokenCredentialsTest extends BaseSerializationTest {
   public void toString_equals() throws IOException {
     ComputeEngineCredentialsTest.MockMetadataServerTransportFactory transportFactory =
         new ComputeEngineCredentialsTest.MockMetadataServerTransportFactory();
-    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.standardIdToken);
+    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 
@@ -99,7 +99,7 @@ public class IdTokenCredentialsTest extends BaseSerializationTest {
 
     ComputeEngineCredentialsTest.MockMetadataServerTransportFactory transportFactory =
         new ComputeEngineCredentialsTest.MockMetadataServerTransportFactory();
-    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.standardIdToken);
+    transportFactory.transport.setIdToken(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdTokenTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdTokenTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2016, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Date;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for AccessToken */
+@RunWith(JUnit4.class)
+public class IdTokenTest extends BaseSerializationTest {
+
+  private static final String TOKEN_1 =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6IjM0OTRiMWU3ODZjZGFkMDkyZTQyMzc2NmJiZTM3ZjU0ZWQ4N2IyMmQiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJodHRwczovL2Zvby5iYXIiLCJhenAiOiJzdmMtMi00MjlAbWluZXJhbC1taW51dGlhLTgyMC5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInN1YiI6IjEwMDE0NzEwNjk5Njc2NDQ3OTA4NSIsImVtYWlsIjoic3ZjLTItNDI5QG1pbmVyYWwtbWludXRpYS04MjAuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaWF0IjoxNTY1Mzg3NTM4LCJleHAiOjE1NjUzOTExMzh9.foo";
+  private static final String TOKEN_2 =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6IjM0OTRiMWU3ODZjZGFkMDkyZTQyMzc2NmJiZTM3ZjU0ZWQ4N2IyMmQiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiJodHRwczovL2Jhci5mb28iLCJhenAiOiJzdmMtMi00MjlAbWluZXJhbC1taW51dGlhLTgyMC5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsInN1YiI6IjEwMDE0NzEwNjk5Njc2NDQ3OTA4NSIsImVtYWlsIjoic3ZjLTItNDI5QG1pbmVyYWwtbWludXRpYS04MjAuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaWF0IjoxNTY1Mzg4NjM0LCJleHAiOjE1NjUzOTIyMzR9.foo";
+  private static final Date EXPIRATION_DATE = new Date((long) 1565391138 * 1000);
+
+  @Test
+  public void constructor() throws IOException {
+    IdToken idToken = IdToken.create(TOKEN_1);
+    assertEquals(TOKEN_1, idToken.getTokenValue());
+    assertEquals(EXPIRATION_DATE, idToken.getExpirationTime());
+  }
+
+  @Test
+  public void equals_true() throws IOException {
+    IdToken accessToken = IdToken.create(TOKEN_1);
+    IdToken otherAccessToken = IdToken.create(TOKEN_1);
+    assertTrue(accessToken.equals(otherAccessToken));
+    assertTrue(otherAccessToken.equals(accessToken));
+  }
+
+  @Test
+  public void equals_false_token() throws IOException {
+    IdToken accessToken = IdToken.create(TOKEN_1);
+    IdToken otherAccessToken = IdToken.create(TOKEN_2);
+    assertFalse(accessToken.equals(otherAccessToken));
+    assertFalse(otherAccessToken.equals(accessToken));
+  }
+
+  @Test
+  public void toString_test() throws IOException {
+    IdToken accessToken = IdToken.create(TOKEN_1);
+    String expectedToString =
+        String.format(
+            "IdToken{tokenValue=%s, JsonWebSignature=JsonWebSignature{header={\"alg\":\"RS256\",\"kid\":\"3494b1e786cdad092e423766bbe37f54ed87b22d\",\"typ\":\"JWT\"}, payload={\"aud\":\"https://foo.bar\",\"exp\":1565391138,\"iat\":1565387538,\"iss\":\"https://accounts.google.com\",\"sub\":\"100147106996764479085\",\"azp\":\"svc-2-429@mineral-minutia-820.iam.gserviceaccount.com\",\"email\":\"svc-2-429@mineral-minutia-820.iam.gserviceaccount.com\",\"email_verified\":true}}}",
+            TOKEN_1);
+    assertEquals(expectedToString, accessToken.toString());
+  }
+
+  @Test
+  public void hashCode_equals() throws IOException {
+    IdToken accessToken = IdToken.create(TOKEN_1);
+    IdToken otherAccessToken = IdToken.create(TOKEN_1);
+    assertEquals(accessToken.hashCode(), otherAccessToken.hashCode());
+  }
+
+  @Test
+  public void serialize() throws IOException, ClassNotFoundException {
+    IdToken accessToken = IdToken.create(TOKEN_1);
+    IdToken deserializedAccessToken = serializeAndDeserialize(accessToken);
+    assertEquals(accessToken, deserializedAccessToken);
+    assertEquals(accessToken.hashCode(), deserializedAccessToken.hashCode());
+    assertEquals(accessToken.toString(), deserializedAccessToken.toString());
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -508,8 +508,10 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setIdToken(standardIdToken);
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential =
-        IdTokenCredentials.create(targetCredentials, targetAudience);
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(targetCredentials)
+        .setTargetAudience(targetAudience)
+        .build();
     tokenCredential.refresh();
     assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
@@ -539,9 +541,11 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setIdToken(tokenWithEmail);
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential =
-        IdTokenCredentials.create(
-            targetCredentials, targetAudience, Arrays.asList(IdTokenProvider.Option.INCLUDE_EMAIL));
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(targetCredentials)
+        .setTargetAudience(targetAudience)
+        .setOptions(Arrays.asList(IdTokenProvider.Option.INCLUDE_EMAIL))
+        .build();
     tokenCredential.refresh();
     assertEquals(tokenWithEmail, tokenCredential.getAccessToken().getTokenValue());
     Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -508,10 +508,11 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setIdToken(standardIdToken);
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(targetCredentials)
-        .setTargetAudience(targetAudience)
-        .build();
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(targetCredentials)
+            .setTargetAudience(targetAudience)
+            .build();
     tokenCredential.refresh();
     assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
@@ -541,11 +542,12 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setIdToken(tokenWithEmail);
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(targetCredentials)
-        .setTargetAudience(targetAudience)
-        .setOptions(Arrays.asList(IdTokenProvider.Option.INCLUDE_EMAIL))
-        .build();
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(targetCredentials)
+            .setTargetAudience(targetAudience)
+            .setOptions(Arrays.asList(IdTokenProvider.Option.INCLUDE_EMAIL))
+            .build();
     tokenCredential.refresh();
     assertEquals(tokenWithEmail, tokenCredential.getAccessToken().getTokenValue());
     Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -86,14 +86,14 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
           + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
           + "==\n-----END PRIVATE KEY-----\n";
 
-  public static final String standardIdToken =
+  public static final String STANDARD_ID_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIy"
           + "OTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIi"
           + "LCJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJleHAiOjE1NjQ1MzI5NzIsImlhdCI6MTU2NDUyOTM3Miw"
           + "iaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyMTAxNTUwODM0MjAwNzA4NTY4In"
           + "0.redacted";
 
-  public static final String tokenWithEmail =
+  public static final String TOKEN_WITH_EMAIL =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIy"
           + "OTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIi"
           + "LCJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJlbWFpbCI6ImltcGVyc29uYXRlZC1hY2NvdW50QGZhYmx"
@@ -505,7 +505,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
             VALID_LIFETIME,
             mtransportFactory);
 
-    mtransportFactory.transport.setIdToken(standardIdToken);
+    mtransportFactory.transport.setIdToken(STANDARD_ID_TOKEN);
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -514,8 +514,8 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
             .setTargetAudience(targetAudience)
             .build();
     tokenCredential.refresh();
-    assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
-    assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
+    assertEquals(STANDARD_ID_TOKEN, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(STANDARD_ID_TOKEN, tokenCredential.getIdToken().getTokenValue());
     assertEquals(
         targetAudience,
         (String) tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudience());
@@ -539,7 +539,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
             VALID_LIFETIME,
             mtransportFactory);
 
-    mtransportFactory.transport.setIdToken(tokenWithEmail);
+    mtransportFactory.transport.setIdToken(TOKEN_WITH_EMAIL);
 
     String targetAudience = "https://foo.bar";
     IdTokenCredentials tokenCredential =
@@ -549,7 +549,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
             .setOptions(Arrays.asList(IdTokenProvider.Option.INCLUDE_EMAIL))
             .build();
     tokenCredential.refresh();
-    assertEquals(tokenWithEmail, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(TOKEN_WITH_EMAIL, tokenCredential.getAccessToken().getTokenValue());
     Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
     assertTrue(p.containsKey("email"));
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -86,6 +86,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
           + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
           + "==\n-----END PRIVATE KEY-----\n";
 
+  // Id Token provided by the default IAM API that does not include the "email" claim
   public static final String STANDARD_ID_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIy"
           + "OTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIi"
@@ -93,6 +94,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
           + "iaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyMTAxNTUwODM0MjAwNzA4NTY4In"
           + "0.redacted";
 
+  // Id Token provided by the default IAM API that includes the "email" claim
   public static final String TOKEN_WITH_EMAIL =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIy"
           + "OTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIi"

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -33,64 +33,79 @@ package com.google.auth.oauth2;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.JsonGenerator;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.webtoken.JsonWebToken.Payload;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
-import com.google.auth.Credentials;
+import com.google.api.client.util.Clock;
+import com.google.auth.ServiceAccountSigner.SigningException;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.GoogleCredentialsTest.MockTokenServerTransportFactory;
 import com.google.common.collect.ImmutableList;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.security.PrivateKey;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.List;
-
-import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.JsonGenerator;
-import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.api.client.util.Clock;
-import com.google.auth.http.HttpTransportFactory;
-import com.google.auth.oauth2.GoogleCredentialsTest.MockTokenServerTransportFactory;
-import com.google.auth.ServiceAccountSigner.SigningException;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import java.util.Date;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
 
-/**
- * Test case for {@link ImpersonatedCredentials}.
- */
+/** Test case for {@link ImpersonatedCredentials}. */
 @RunWith(JUnit4.class)
 public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
-  private static final String SA_CLIENT_EMAIL = "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
+  private static final String SA_CLIENT_EMAIL =
+      "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
   private static final String SA_PRIVATE_KEY_ID = "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
-  static final String SA_PRIVATE_KEY_PKCS8 = "-----BEGIN PRIVATE KEY-----\n"
-      + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
-      + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
-      + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
-      + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
-      + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
-      + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
-      + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
-      + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
-      + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
-      + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
-      + "==\n-----END PRIVATE KEY-----\n";
+  static final String SA_PRIVATE_KEY_PKCS8 =
+      "-----BEGIN PRIVATE KEY-----\n"
+          + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
+          + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
+          + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
+          + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
+          + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
+          + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
+          + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
+          + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
+          + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
+          + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
+          + "==\n-----END PRIVATE KEY-----\n";
+
+  public static final String standardIdToken =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIy"
+          + "OTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIi"
+          + "LCJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJleHAiOjE1NjQ1MzI5NzIsImlhdCI6MTU2NDUyOTM3Miw"
+          + "iaXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyMTAxNTUwODM0MjAwNzA4NTY4In"
+          + "0.redacted";
+
+  public static final String tokenWithEmail =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIy"
+          + "OTNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIi"
+          + "LCJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJlbWFpbCI6ImltcGVyc29uYXRlZC1hY2NvdW50QGZhYmx"
+          + "lZC1yYXktMTA0MTE3LmlhbS5nc2VydmljZWFjY291bnQuY29tIiwiZW1haWxfdmVyaWZpZWQiOnRydWUsImV4cC"
+          + "I6MTU2NDUzMzA0MiwiaWF0IjoxNTY0NTI5NDQyLCJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iL"
+          + "CJzdWIiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgifQ.redacted";
 
   private static final String PROJECT_ID = "project-id";
-  private static final String IMPERSONATED_CLIENT_EMAIL = "impersonated-account@iam.gserviceaccount.com";
-  private static final List<String> SCOPES = Arrays.asList("https://www.googleapis.com/auth/devstorage.read_only");
+  private static final String IMPERSONATED_CLIENT_EMAIL =
+      "impersonated-account@iam.gserviceaccount.com";
+  private static final List<String> SCOPES =
+      Arrays.asList("https://www.googleapis.com/auth/devstorage.read_only");
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
   private static final int VALID_LIFETIME = 300;
   private static final int INVALID_LIFETIME = 3800;
@@ -111,13 +126,15 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
   private GoogleCredentials getSourceCredentials() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountCredentials sourceCredentials = ServiceAccountCredentials.newBuilder()
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .setScopes(SCOPES)
-        .setProjectId(PROJECT_ID)
-        .setHttpTransportFactory(transportFactory).build();
+    ServiceAccountCredentials sourceCredentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setScopes(SCOPES)
+            .setProjectId(PROJECT_ID)
+            .setHttpTransportFactory(transportFactory)
+            .build();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
 
     return sourceCredentials;
@@ -133,10 +150,16 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setTokenResponseErrorCode(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
     mtransportFactory.transport.setTokenResponseErrorContent(
-        generateErrorJson(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED,
-            expectedMessage, "global", "forbidden"));
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+        generateErrorJson(
+            HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, expectedMessage, "global", "forbidden"));
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     try {
       targetCredentials.refreshAccessToken().getTokenValue();
@@ -158,10 +181,11 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(invalidTargetEmail);
     mtransportFactory.transport.setTokenResponseErrorCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
     mtransportFactory.transport.setTokenResponseErrorContent(
-        generateErrorJson(HttpStatusCodes.STATUS_CODE_BAD_REQUEST,
-            expectedMessage, "global", "badRequest"));
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        invalidTargetEmail, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+        generateErrorJson(
+            HttpStatusCodes.STATUS_CODE_BAD_REQUEST, expectedMessage, "global", "badRequest"));
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials, invalidTargetEmail, null, SCOPES, VALID_LIFETIME, mtransportFactory);
 
     try {
       targetCredentials.refreshAccessToken().getTokenValue();
@@ -177,15 +201,17 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials sourceCredentials = getSourceCredentials();
     try {
-      ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-          IMPERSONATED_CLIENT_EMAIL, null, SCOPES, INVALID_LIFETIME);
+      ImpersonatedCredentials targetCredentials =
+          ImpersonatedCredentials.create(
+              sourceCredentials, IMPERSONATED_CLIENT_EMAIL, null, SCOPES, INVALID_LIFETIME);
       targetCredentials.refreshAccessToken().getTokenValue();
-      fail(String.format("Should throw exception with message containing '%s'",
-          "lifetime must be less than or equal to 3600"));
+      fail(
+          String.format(
+              "Should throw exception with message containing '%s'",
+              "lifetime must be less than or equal to 3600"));
     } catch (IllegalStateException expected) {
       assertTrue(expected.getMessage().contains("lifetime must be less than or equal to 3600"));
     }
-
   }
 
   @Test()
@@ -193,15 +219,16 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
     GoogleCredentials sourceCredentials = getSourceCredentials();
     try {
-      ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-          IMPERSONATED_CLIENT_EMAIL, null, null, VALID_LIFETIME);
+      ImpersonatedCredentials targetCredentials =
+          ImpersonatedCredentials.create(
+              sourceCredentials, IMPERSONATED_CLIENT_EMAIL, null, null, VALID_LIFETIME);
       targetCredentials.refreshAccessToken().getTokenValue();
-      fail(String.format("Should throw exception with message containing '%s'",
-          "Scopes cannot be null"));
+      fail(
+          String.format(
+              "Should throw exception with message containing '%s'", "Scopes cannot be null"));
     } catch (IllegalStateException expected) {
       assertTrue(expected.getMessage().contains("Scopes cannot be null"));
     }
-
   }
 
   @Test()
@@ -213,8 +240,14 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     assertEquals(ACCESS_TOKEN, targetCredentials.refreshAccessToken().getTokenValue());
   }
@@ -229,8 +262,14 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
     List<String> delegates = Arrays.asList("delegate-account@iam.gserviceaccount.com");
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, delegates, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            delegates,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     assertEquals(ACCESS_TOKEN, targetCredentials.refreshAccessToken().getTokenValue());
   }
@@ -245,8 +284,14 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken("foo");
     mtransportFactory.transport.setExpireTime("1973-09-29T15:01:23");
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     try {
       targetCredentials.refreshAccessToken().getTokenValue();
@@ -264,12 +309,17 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     assertEquals(IMPERSONATED_CLIENT_EMAIL, targetCredentials.getAccount());
   }
-
 
   @Test
   public void sign_sameAs() throws IOException {
@@ -279,8 +329,14 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
 
@@ -298,10 +354,14 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, ImmutableList.of("delegate@example.com"), SCOPES, VALID_LIFETIME,
-        mtransportFactory);
-
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            ImmutableList.of("delegate@example.com"),
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
 
@@ -311,8 +371,10 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     assertArrayEquals(expectedSignature, targetCredentials.sign(expectedSignature));
 
     MockLowLevelHttpRequest request = mtransportFactory.transport.getRequest();
-    GenericJson body = JSON_FACTORY.createJsonParser(request.getContentAsString())
-        .parseAndClose(GenericJson.class);
+    GenericJson body =
+        JSON_FACTORY
+            .createJsonParser(request.getContentAsString())
+            .parseAndClose(GenericJson.class);
     List<String> delegates = new ArrayList<>();
     delegates.add("delegate@example.com");
     assertEquals(delegates, body.get("delegates"));
@@ -325,19 +387,24 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     c.setTime(expiry);
     c.add(Calendar.DATE, 1);
     expiry = c.getTime();
-    GoogleCredentials sourceCredentials = new GoogleCredentials.Builder()
-        .setAccessToken(new AccessToken("source-token", expiry))
-        .build();
+    GoogleCredentials sourceCredentials =
+        new GoogleCredentials.Builder()
+            .setAccessToken(new AccessToken("source-token", expiry))
+            .build();
 
     MockIAMCredentialsServiceTransportFactory mtransportFactory =
         new MockIAMCredentialsServiceTransportFactory();
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, ImmutableList.of("delegate@example.com"), SCOPES, VALID_LIFETIME,
-        mtransportFactory);
-
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            ImmutableList.of("delegate@example.com"),
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
 
@@ -351,21 +418,28 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void sign_accessDenied_throws() throws IOException  {
+  public void sign_accessDenied_throws() throws IOException {
     GoogleCredentials sourceCredentials = getSourceCredentials();
     MockIAMCredentialsServiceTransportFactory mtransportFactory =
         new MockIAMCredentialsServiceTransportFactory();
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
 
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setSignedBlob(expectedSignature);
-    mtransportFactory.transport.setSigningErrorResponseCodeAndMessage(HttpStatusCodes.STATUS_CODE_FORBIDDEN, "Sign Error");
+    mtransportFactory.transport.setSigningErrorResponseCodeAndMessage(
+        HttpStatusCodes.STATUS_CODE_FORBIDDEN, "Sign Error");
 
     try {
       byte[] bytes = {0xD, 0xE, 0xA, 0xD};
@@ -386,14 +460,21 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
 
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setSignedBlob(expectedSignature);
-    mtransportFactory.transport.setSigningErrorResponseCodeAndMessage(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, "Sign Error");
+    mtransportFactory.transport.setSigningErrorResponseCodeAndMessage(
+        HttpStatusCodes.STATUS_CODE_SERVER_ERROR, "Sign Error");
 
     try {
       byte[] bytes = {0xD, 0xE, 0xA, 0xD};
@@ -407,6 +488,67 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
+  public void idTokenWithAudience_sameAs() throws IOException {
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
+    mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
+
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
+
+    mtransportFactory.transport.setIdToken(standardIdToken);
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.create(targetCredentials, targetAudience);
+    tokenCredential.refresh();
+    assertEquals(standardIdToken, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(standardIdToken, tokenCredential.getIdToken().getTokenValue());
+    assertEquals(
+        targetAudience,
+        (String) tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudience());
+  }
+
+  @Test
+  public void idTokenWithAudience_withEmail() throws IOException {
+    GoogleCredentials sourceCredentials = getSourceCredentials();
+    MockIAMCredentialsServiceTransportFactory mtransportFactory =
+        new MockIAMCredentialsServiceTransportFactory();
+    mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
+    mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
+
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
+
+    mtransportFactory.transport.setIdToken(tokenWithEmail);
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.create(
+            targetCredentials, targetAudience, Arrays.asList(IdTokenProvider.Option.INCLUDE_EMAIL));
+    tokenCredential.refresh();
+    assertEquals(tokenWithEmail, tokenCredential.getAccessToken().getTokenValue());
+    Payload p = tokenCredential.getIdToken().getJsonWebSignature().getPayload();
+    assertTrue(p.containsKey("email"));
+  }
+
+  @Test
   public void hashCode_equals() throws IOException {
     GoogleCredentials sourceCredentials = getSourceCredentials();
     MockIAMCredentialsServiceTransportFactory mtransportFactory =
@@ -414,11 +556,23 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
-    ImpersonatedCredentials credentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials credentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
-    ImpersonatedCredentials otherCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials otherCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
 
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
@@ -433,8 +587,14 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mtransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mtransportFactory.transport.setExpireTime(getDefaultExpireTime());
 
-    ImpersonatedCredentials targetCredentials = ImpersonatedCredentials.create(sourceCredentials,
-        IMPERSONATED_CLIENT_EMAIL, null, SCOPES, VALID_LIFETIME, mtransportFactory);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            SCOPES,
+            VALID_LIFETIME,
+            mtransportFactory);
     GoogleCredentials deserializedCredentials = serializeAndDeserialize(targetCredentials);
     assertEquals(targetCredentials, deserializedCredentials);
     assertEquals(targetCredentials.hashCode(), deserializedCredentials.hashCode());
@@ -446,12 +606,13 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     Date currentDate = new Date();
     Calendar c = Calendar.getInstance();
     c.setTime(currentDate);
-    c.add(Calendar.SECOND, VALID_LIFETIME);    
+    c.add(Calendar.SECOND, VALID_LIFETIME);
     return new SimpleDateFormat(RFC3339).format(c.getTime());
   }
 
-  private String generateErrorJson(int errorCode, String errorMessage, String errorDomain,
-      String errorReason) throws IOException {
+  private String generateErrorJson(
+      int errorCode, String errorMessage, String errorDomain, String errorReason)
+      throws IOException {
 
     JsonFactory factory = new JacksonFactory();
     ByteArrayOutputStream bout = new ByteArrayOutputStream();

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
@@ -48,6 +48,8 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
 
   private static final String IAM_ACCESS_TOKEN_ENDPOINT =
       "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken";
+  private static final String IAM_ID_TOKEN_ENDPOINT =
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken";
   private static final String IAM_SIGN_ENDPOINT =
       "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:signBlob";
   private Integer tokenResponseErrorCode;

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
@@ -92,7 +92,7 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
     this.signedBlob = signedBlob;
   }
 
-  public void setSigningErrorResponseCodeAndMessage(int responseCode, String errorMessage) {
+  public void setErrorResponseCodeAndMessage(int responseCode, String errorMessage) {
     this.responseCode = responseCode;
     this.errorMessage = errorMessage;
   }
@@ -187,6 +187,14 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
           new MockLowLevelHttpRequest(url) {
             @Override
             public LowLevelHttpResponse execute() throws IOException {
+
+              if (responseCode != HttpStatusCodes.STATUS_CODE_OK) {
+                return new MockLowLevelHttpResponse()
+                    .setStatusCode(responseCode)
+                    .setContentType(Json.MEDIA_TYPE)
+                    .setContent(errorMessage);
+              }
+
               GenericJson refreshContents = new GenericJson();
               refreshContents.setFactory(OAuth2Utils.JSON_FACTORY);
               refreshContents.put("token", idToken);

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -166,23 +166,22 @@ public class MockMetadataServerTransport extends MockHttpTransport {
       }
 
       // https://cloud.google.com/compute/docs/instances/verifying-instance-identity#token_format
-      URL u = new URL(url);
-      Map<String, String> query_pairs = new HashMap<String, String>();
-      String query = u.getQuery();
+      Map<String, String> queryPairs = new HashMap<String, String>();
+      String query = (new URL(url)).getQuery();
       String[] pairs = query.split("&");
       for (String pair : pairs) {
         int idx = pair.indexOf("=");
-        query_pairs.put(
+        queryPairs.put(
             URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
             URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
       }
 
-      if (query_pairs.containsKey("format")) {
-        if (((String) query_pairs.get("format")).equals("full")) {
+      if (queryPairs.containsKey("format")) {
+        if (((String) queryPairs.get("format")).equals("full")) {
 
           // return license only if format=full is set
-          if (query_pairs.containsKey("license")) {
-            if (((String) query_pairs.get("license")).equals("TRUE")) {
+          if (queryPairs.containsKey("license")) {
+            if (((String) queryPairs.get("license")).equals("TRUE")) {
               return new MockLowLevelHttpRequest(url) {
                 @Override
                 public LowLevelHttpResponse execute() throws IOException {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -186,7 +186,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
                 @Override
                 public LowLevelHttpResponse execute() throws IOException {
                   return new MockLowLevelHttpResponse()
-                      .setContent(ComputeEngineCredentialsTest.fullIdTokenWithLicense);
+                      .setContent(ComputeEngineCredentialsTest.FULL_ID_TOKEN_WITH_LICENSE);
                 }
               };
             }
@@ -196,7 +196,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
             @Override
             public LowLevelHttpResponse execute() throws IOException {
               return new MockLowLevelHttpResponse()
-                  .setContent(ComputeEngineCredentialsTest.fullIdToken);
+                  .setContent(ComputeEngineCredentialsTest.FULL_ID_TOKEN);
             }
           };
         }
@@ -206,7 +206,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
         @Override
         public LowLevelHttpResponse execute() throws IOException {
           return new MockLowLevelHttpResponse()
-              .setContent(ComputeEngineCredentialsTest.standardIdToken);
+              .setContent(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
         }
       };
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -142,6 +142,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
           Map<String, String> query = TestUtils.parseQuery(content);
           String accessToken;
           String refreshToken = null;
+          boolean generateAccessToken = true;
 
           String foundId = query.get("client_id");
           if (foundId != null) {
@@ -179,24 +180,38 @@ public class MockTokenServerTransport extends MockHttpTransport {
               throw new IOException("Service Account Email not found as issuer.");
             }
             accessToken = serviceAccounts.get(foundEmail);
+            String foundTargetAudience = (String) signature.getPayload().get("target_audience");
             String foundScopes = (String) signature.getPayload().get("scope");
-            if (foundScopes == null || foundScopes.length() == 0) {
-              throw new IOException("Scopes not found.");
+            if ((foundScopes == null || foundScopes.length() == 0)
+                && (foundTargetAudience == null || foundTargetAudience.length() == 0)) {
+              throw new IOException("Either target_audience or scopes must be specified.");
+            }
+
+            if (foundScopes != null && foundTargetAudience != null) {
+              throw new IOException("Only one of target_audience or scopes must be specified.");
+            }
+            if (foundTargetAudience != null) {
+              generateAccessToken = false;
             }
           } else {
             throw new IOException("Unknown token type.");
           }
 
           // Create the JSON response
-          GenericJson refreshContents = new GenericJson();
-          refreshContents.setFactory(JSON_FACTORY);
-          refreshContents.put("access_token", accessToken);
-          refreshContents.put("expires_in", expiresInSeconds);
-          refreshContents.put("token_type", "Bearer");
-          if (refreshToken != null) {
-            refreshContents.put("refresh_token", refreshToken);
+          // https://developers.google.com/identity/protocols/OpenIDConnect#server-flow
+          GenericJson responseContents = new GenericJson();
+          responseContents.setFactory(JSON_FACTORY);
+          responseContents.put("token_type", "Bearer");
+          responseContents.put("expires_in", expiresInSeconds);
+          if (generateAccessToken) {
+            responseContents.put("access_token", accessToken);
+            if (refreshToken != null) {
+              responseContents.put("refresh_token", refreshToken);
+            }
+          } else {
+            responseContents.put("id_token", ServiceAccountCredentialsTest.defaultIDToken);
           }
-          String refreshText = refreshContents.toPrettyString();
+          String refreshText = responseContents.toPrettyString();
 
           return new MockLowLevelHttpResponse()
               .setContentType(Json.MEDIA_TYPE)

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -209,7 +209,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
               responseContents.put("refresh_token", refreshToken);
             }
           } else {
-            responseContents.put("id_token", ServiceAccountCredentialsTest.defaultIDToken);
+            responseContents.put("id_token", ServiceAccountCredentialsTest.DEFAULT_ID_TOKEN);
           }
           String refreshText = responseContents.toPrettyString();
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -34,6 +34,7 @@ package com.google.auth.oauth2;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -192,33 +193,58 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
    @Test
    public void createAssertionForIdToken_correct() throws IOException {
+
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
+        .setClientId(SA_CLIENT_ID)
+        .setClientEmail(SA_CLIENT_EMAIL)
+        .setPrivateKey(privateKey)
+        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+        .setProjectId(PROJECT_ID)
+        .build();
+
+    JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
+    long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
+    String assertion =
+        credentials.createAssertionForIdToken(jsonFactory, currentTimeMillis, null, "https://foo.com/bar");
+
+    JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
+    JsonWebToken.Payload payload = signature.getPayload();
+    assertEquals(SA_CLIENT_EMAIL, payload.getIssuer());
+    assertEquals("https://foo.com/bar", (String)(payload.getUnknownKeys().get("target_audience")));
+    assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
+    assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
+    assertEquals(SERVICE_ACCOUNT_USER, payload.getSubject());
+    }
+
+    @Test
+    public void createAssertionForIdToken_incorrect() throws IOException {
+ 
      PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-     List<String> scopes = Arrays.asList("scope1", "scope2");
      ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
          .setClientId(SA_CLIENT_ID)
          .setClientEmail(SA_CLIENT_EMAIL)
          .setPrivateKey(privateKey)
          .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-         .setScopes(scopes)
          .setServiceAccountUser(SERVICE_ACCOUNT_USER)
          .setProjectId(PROJECT_ID)
          .build();
  
      JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
      long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-     String targetAudience = "https://foo.bar";
-     String assertion = credentials.createAssertionForIdToken(jsonFactory, currentTimeMillis, null, targetAudience);
+     String assertion =
+         credentials.createAssertionForIdToken(jsonFactory, currentTimeMillis, null, "https://foo.com/bar");
  
      JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
      JsonWebToken.Payload payload = signature.getPayload();
      assertEquals(SA_CLIENT_EMAIL, payload.getIssuer());
-     assertEquals(OAuth2Utils.TOKEN_SERVER_URI.toString(), payload.getAudience());
+     assertNotEquals("https://bar.com/foo", (String)(payload.getUnknownKeys().get("target_audience")));
      assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
      assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
      assertEquals(SERVICE_ACCOUNT_USER, payload.getSubject());
-     assertEquals(Joiner.on(' ').join(scopes), payload.get("scope"));
-    }
- 
+    }    
+
 
   @Test
   public void createAssertion_withTokenUri_correct() throws IOException {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -102,7 +102,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
   private static final HttpTransportFactory DUMMY_TRANSPORT_FACTORY =
       new MockTokenServerTransportFactory();
-  public static final String defaultIDToken =
+  public static final String DEFAULT_ID_TOKEN =
       "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyO"
           + "TNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiL"
           + "CJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJleHAiOjE1NjQ0NzUwNTEsImlhdCI6MTU2NDQ3MTQ1MSwi"
@@ -608,8 +608,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setTargetAudience(targetAudience)
             .build();
     tokenCredential.refresh();
-    assertEquals(defaultIDToken, tokenCredential.getAccessToken().getTokenValue());
-    assertEquals(defaultIDToken, tokenCredential.getIdToken().getTokenValue());
+    assertEquals(DEFAULT_ID_TOKEN, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(DEFAULT_ID_TOKEN, tokenCredential.getIdToken().getTokenValue());
     assertEquals(
         targetAudience,
         (String) tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudience());

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -585,7 +585,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void idTokenWithAudience_correct() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =
@@ -613,7 +613,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void idTokenWithAudience_incorrect() throws IOException {
-    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     MockTokenServerTransport transport = transportFactory.transport;
     ServiceAccountCredentials credentials =

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -602,10 +602,11 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(credentials)
-        .setTargetAudience(targetAudience)
-        .build();
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
     tokenCredential.refresh();
     assertEquals(defaultIDToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(defaultIDToken, tokenCredential.getIdToken().getTokenValue());
@@ -633,10 +634,11 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
 
     String targetAudience = "https://bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
-        .setIdTokenProvider(credentials)
-        .setTargetAudience(targetAudience)
-        .build();    
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder()
+            .setIdTokenProvider(credentials)
+            .setTargetAudience(targetAudience)
+            .build();
     tokenCredential.refresh();
     assertNotEquals(
         targetAudience,

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -602,7 +602,10 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
 
     String targetAudience = "https://foo.bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(credentials)
+        .setTargetAudience(targetAudience)
+        .build();
     tokenCredential.refresh();
     assertEquals(defaultIDToken, tokenCredential.getAccessToken().getTokenValue());
     assertEquals(defaultIDToken, tokenCredential.getIdToken().getTokenValue());
@@ -630,7 +633,10 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
 
     String targetAudience = "https://bar";
-    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    IdTokenCredentials tokenCredential = IdTokenCredentials.newBuilder()
+        .setIdTokenProvider(credentials)
+        .setTargetAudience(targetAudience)
+        .build();    
     tokenCredential.refresh();
     assertNotEquals(
         targetAudience,

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -54,7 +54,6 @@ import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentialsTest.MockHttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentialsTest.MockTokenServerTransportFactory;
 import com.google.common.collect.ImmutableSet;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -69,14 +68,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Test case for {@link ServiceAccountCredentials}.
- */
+/** Test case for {@link ServiceAccountCredentials}. */
 @RunWith(JUnit4.class)
 public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
@@ -84,20 +80,20 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
   private static final String SA_CLIENT_ID =
       "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr.apps.googleusercontent.com";
-  private static final String SA_PRIVATE_KEY_ID =
-      "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
-  static final String SA_PRIVATE_KEY_PKCS8 = "-----BEGIN PRIVATE KEY-----\n"
-      + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
-      + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
-      + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
-      + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
-      + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
-      + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
-      + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
-      + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
-      + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
-      + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
-      + "==\n-----END PRIVATE KEY-----\n";
+  private static final String SA_PRIVATE_KEY_ID = "d84a4fefcf50791d4a90f2d7af17469d6282df9d";
+  static final String SA_PRIVATE_KEY_PKCS8 =
+      "-----BEGIN PRIVATE KEY-----\n"
+          + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
+          + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
+          + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
+          + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
+          + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
+          + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
+          + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
+          + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
+          + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
+          + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
+          + "==\n-----END PRIVATE KEY-----\n";
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
   private static final Collection<String> SCOPES = Collections.singletonList("dummy.scope");
   private static final String SERVICE_ACCOUNT_USER = "user@example.com";
@@ -106,19 +102,26 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
   private static final HttpTransportFactory DUMMY_TRANSPORT_FACTORY =
       new MockTokenServerTransportFactory();
+  public static final String defaultIDToken =
+      "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRmMzc1ODkwOGI3OTIyO"
+          + "TNhZDk3N2EwYjk5MWQ5OGE3N2Y0ZWVlY2QiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJodHRwczovL2Zvby5iYXIiL"
+          + "CJhenAiOiIxMDIxMDE1NTA4MzQyMDA3MDg1NjgiLCJleHAiOjE1NjQ0NzUwNTEsImlhdCI6MTU2NDQ3MTQ1MSwi"
+          + "aXNzIjoiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tIiwic3ViIjoiMTAyMTAxNTUwODM0MjAwNzA4NTY4In0"
+          + ".redacted";
 
   @Test
   public void createdScoped_clones() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    GoogleCredentials credentials = ServiceAccountCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .setScopes(SCOPES)
-        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
-        .setProjectId(PROJECT_ID)
-        .build();
+    GoogleCredentials credentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setScopes(SCOPES)
+            .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+            .setProjectId(PROJECT_ID)
+            .build();
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
     ServiceAccountCredentials newCredentials =
@@ -132,21 +135,23 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(SERVICE_ACCOUNT_USER, newCredentials.getServiceAccountUser());
     assertEquals(PROJECT_ID, newCredentials.getProjectId());
 
-    assertArrayEquals(SCOPES.toArray(), ((ServiceAccountCredentials)credentials).getScopes().toArray());
+    assertArrayEquals(
+        SCOPES.toArray(), ((ServiceAccountCredentials) credentials).getScopes().toArray());
   }
 
-    @Test
+  @Test
   public void createdDelegated_clones() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .setScopes(SCOPES)
-        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
-        .setProjectId(PROJECT_ID)
-        .build();
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setScopes(SCOPES)
+            .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+            .setProjectId(PROJECT_ID)
+            .build();
     String newServiceAccountUser = "stranger@other.org";
 
     ServiceAccountCredentials newCredentials =
@@ -160,22 +165,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(newServiceAccountUser, newCredentials.getServiceAccountUser());
     assertEquals(PROJECT_ID, newCredentials.getProjectId());
 
-    assertEquals(SERVICE_ACCOUNT_USER, ((ServiceAccountCredentials)credentials).getServiceAccountUser());
-}
+    assertEquals(
+        SERVICE_ACCOUNT_USER, ((ServiceAccountCredentials) credentials).getServiceAccountUser());
+  }
 
   @Test
   public void createAssertion_correct() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     List<String> scopes = Arrays.asList("scope1", "scope2");
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .setScopes(scopes)
-        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
-        .setProjectId(PROJECT_ID)
-        .build();
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setScopes(scopes)
+            .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+            .setProjectId(PROJECT_ID)
+            .build();
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
@@ -189,76 +196,81 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
     assertEquals(SERVICE_ACCOUNT_USER, payload.getSubject());
     assertEquals(Joiner.on(' ').join(scopes), payload.get("scope"));
-   }
+  }
 
-   @Test
-   public void createAssertionForIdToken_correct() throws IOException {
+  @Test
+  public void createAssertionForIdToken_correct() throws IOException {
 
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
-        .setProjectId(PROJECT_ID)
-        .build();
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+            .setProjectId(PROJECT_ID)
+            .build();
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
     String assertion =
-        credentials.createAssertionForIdToken(jsonFactory, currentTimeMillis, null, "https://foo.com/bar");
+        credentials.createAssertionForIdToken(
+            jsonFactory, currentTimeMillis, null, "https://foo.com/bar");
 
     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
     JsonWebToken.Payload payload = signature.getPayload();
     assertEquals(SA_CLIENT_EMAIL, payload.getIssuer());
-    assertEquals("https://foo.com/bar", (String)(payload.getUnknownKeys().get("target_audience")));
+    assertEquals("https://foo.com/bar", (String) (payload.getUnknownKeys().get("target_audience")));
     assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
     assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
     assertEquals(SERVICE_ACCOUNT_USER, payload.getSubject());
-    }
+  }
 
-    @Test
-    public void createAssertionForIdToken_incorrect() throws IOException {
- 
-     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
-     ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
-         .setClientId(SA_CLIENT_ID)
-         .setClientEmail(SA_CLIENT_EMAIL)
-         .setPrivateKey(privateKey)
-         .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-         .setServiceAccountUser(SERVICE_ACCOUNT_USER)
-         .setProjectId(PROJECT_ID)
-         .build();
- 
-     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
-     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-     String assertion =
-         credentials.createAssertionForIdToken(jsonFactory, currentTimeMillis, null, "https://foo.com/bar");
- 
-     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
-     JsonWebToken.Payload payload = signature.getPayload();
-     assertEquals(SA_CLIENT_EMAIL, payload.getIssuer());
-     assertNotEquals("https://bar.com/foo", (String)(payload.getUnknownKeys().get("target_audience")));
-     assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
-     assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
-     assertEquals(SERVICE_ACCOUNT_USER, payload.getSubject());
-    }    
+  @Test
+  public void createAssertionForIdToken_incorrect() throws IOException {
 
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+            .setProjectId(PROJECT_ID)
+            .build();
+
+    JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
+    long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
+    String assertion =
+        credentials.createAssertionForIdToken(
+            jsonFactory, currentTimeMillis, null, "https://foo.com/bar");
+
+    JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
+    JsonWebToken.Payload payload = signature.getPayload();
+    assertEquals(SA_CLIENT_EMAIL, payload.getIssuer());
+    assertNotEquals(
+        "https://bar.com/foo", (String) (payload.getUnknownKeys().get("target_audience")));
+    assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
+    assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
+    assertEquals(SERVICE_ACCOUNT_USER, payload.getSubject());
+  }
 
   @Test
   public void createAssertion_withTokenUri_correct() throws IOException {
     PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8);
     List<String> scopes = Arrays.asList("scope1", "scope2");
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.newBuilder()
-        .setClientId(SA_CLIENT_ID)
-        .setClientEmail(SA_CLIENT_EMAIL)
-        .setPrivateKey(privateKey)
-        .setPrivateKeyId(SA_PRIVATE_KEY_ID)
-        .setScopes(scopes)
-        .setServiceAccountUser(SERVICE_ACCOUNT_USER)
-        .setProjectId(PROJECT_ID)
-        .build();
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId(SA_CLIENT_ID)
+            .setClientEmail(SA_CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(SA_PRIVATE_KEY_ID)
+            .setScopes(scopes)
+            .setServiceAccountUser(SERVICE_ACCOUNT_USER)
+            .setProjectId(PROJECT_ID)
+            .build();
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
@@ -273,14 +285,21 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
     assertEquals(SERVICE_ACCOUNT_USER, payload.getSubject());
     assertEquals(Joiner.on(' ').join(scopes), payload.get("scope"));
-   }
+  }
 
   @Test
   public void createdScoped_enablesAccessTokens() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    GoogleCredentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null, transportFactory, null);
+    GoogleCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            null,
+            transportFactory,
+            null);
 
     try {
       credentials.getRequestMetadata(CALL_URI);
@@ -297,16 +316,18 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void createScopedRequired_emptyScopes_true() throws IOException {
-    GoogleCredentials credentials = ServiceAccountCredentials.fromPkcs8(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, EMPTY_SCOPES);
+    GoogleCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, EMPTY_SCOPES);
 
     assertTrue(credentials.createScopedRequired());
   }
 
   @Test
   public void createScopedRequired_nonEmptyScopes_false() throws IOException {
-    GoogleCredentials credentials = ServiceAccountCredentials.fromPkcs8(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES);
+    GoogleCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES);
 
     assertFalse(credentials.createScopedRequired());
   }
@@ -315,10 +336,12 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void fromJSON_getProjectId() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    GenericJson json = writeServiceAccountJson(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
+    GenericJson json =
+        writeServiceAccountJson(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
 
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromJson(json, transportFactory);
     assertEquals(PROJECT_ID, credentials.getProjectId());
   }
 
@@ -326,10 +349,12 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void fromJSON_getProjectIdNull() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    GenericJson json = writeServiceAccountJson(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
+    GenericJson json =
+        writeServiceAccountJson(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
 
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromJson(json, transportFactory);
     assertNull(credentials.getProjectId());
   }
 
@@ -337,8 +362,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void fromJSON_hasAccessToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    GenericJson json = writeServiceAccountJson(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
+    GenericJson json =
+        writeServiceAccountJson(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
 
     GoogleCredentials credentials = ServiceAccountCredentials.fromJson(json, transportFactory);
 
@@ -352,8 +378,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     final String tokenServerUri = "https://foo.com/bar";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    GenericJson json = writeServiceAccountJson(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
+    GenericJson json =
+        writeServiceAccountJson(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, PROJECT_ID);
     json.put("token_uri", tokenServerUri);
     ServiceAccountCredentials credentials =
         ServiceAccountCredentials.fromJson(json, transportFactory);
@@ -364,8 +391,15 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void getRequestMetadata_hasAccessToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory, null);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            null);
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -378,9 +412,15 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     transportFactory.transport.setTokenServerUri(TOKEN_SERVER);
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
-        TOKEN_SERVER);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            TOKEN_SERVER);
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
@@ -544,9 +584,64 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
+  public void idTokenWithAudience_correct() throws IOException {
+    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    MockTokenServerTransport transport = transportFactory.transport;
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            null);
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken1);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
+
+    String targetAudience = "https://foo.bar";
+    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    tokenCredential.refresh();
+    assertEquals(defaultIDToken, tokenCredential.getAccessToken().getTokenValue());
+    assertEquals(defaultIDToken, tokenCredential.getIdToken().getTokenValue());
+    assertEquals(
+        targetAudience,
+        (String) tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudience());
+  }
+
+  @Test
+  public void idTokenWithAudience_incorrect() throws IOException {
+    final String accessToken1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    MockTokenServerTransport transport = transportFactory.transport;
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            null);
+
+    transport.addServiceAccount(SA_CLIENT_EMAIL, accessToken1);
+    TestUtils.assertContainsBearerToken(credentials.getRequestMetadata(CALL_URI), accessToken1);
+
+    String targetAudience = "https://bar";
+    IdTokenCredentials tokenCredential = IdTokenCredentials.create(credentials, targetAudience);
+    tokenCredential.refresh();
+    assertNotEquals(
+        targetAudience,
+        (String) tokenCredential.getIdToken().getJsonWebSignature().getPayload().getAudience());
+  }
+
+  @Test
   public void getScopes_nullReturnsEmpty() throws IOException {
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
 
     Collection<String> scopes = credentials.getScopes();
 
@@ -556,8 +651,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void getAccount_sameAs() throws IOException {
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
     assertEquals(SA_CLIENT_EMAIL, credentials.getAccount());
   }
 
@@ -565,8 +661,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void sign_sameAs()
       throws IOException, NoSuchAlgorithmException, InvalidKeyException, SignatureException {
     byte[] toSign = {0xD, 0xE, 0xA, 0xD};
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, null);
     byte[] signedBytes = credentials.sign(toSign);
     Signature signature = Signature.getInstance(OAuth2Utils.SIGNATURE_ALGORITHM);
     signature.initSign(credentials.getPrivateKey());
@@ -578,12 +675,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void equals_true() throws IOException {
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
-        tokenServer);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
-        tokenServer);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            tokenServer);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            tokenServer);
     assertTrue(credentials.equals(otherCredentials));
     assertTrue(otherCredentials.equals(credentials));
   }
@@ -592,12 +701,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void equals_false_clientId() throws IOException {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     MockTokenServerTransportFactory serverTransportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8("otherClientId",
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            "otherClientId",
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -606,12 +727,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void equals_false_email() throws IOException {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     MockTokenServerTransportFactory serverTransportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        "otherEmail", SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            "otherEmail",
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -620,12 +753,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void equals_false_keyId() throws IOException {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     MockTokenServerTransportFactory serverTransportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, "otherId", SCOPES, serverTransportFactory,
-        tokenServer1);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            "otherId",
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -634,12 +779,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void equals_false_scopes() throws IOException {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     MockTokenServerTransportFactory serverTransportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, ImmutableSet.<String>of(),
-        serverTransportFactory, tokenServer1);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            ImmutableSet.<String>of(),
+            serverTransportFactory,
+            tokenServer1);
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -649,12 +806,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     MockHttpTransportFactory httpTransportFactory = new MockHttpTransportFactory();
     MockTokenServerTransportFactory serverTransportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, httpTransportFactory,
-        tokenServer1);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            httpTransportFactory,
+            tokenServer1);
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -664,12 +833,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     final URI tokenServer1 = URI.create("https://foo1.com/bar");
     final URI tokenServer2 = URI.create("https://foo2.com/bar");
     MockTokenServerTransportFactory serverTransportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer1);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, serverTransportFactory,
-        tokenServer2);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer1);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            serverTransportFactory,
+            tokenServer2);
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
@@ -678,19 +859,27 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void toString_containsFields() throws IOException {
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
-        tokenServer, SERVICE_ACCOUNT_USER);
-    String expectedToString = String.format(
-        "ServiceAccountCredentials{clientId=%s, clientEmail=%s, privateKeyId=%s, "
-            + "transportFactoryClassName=%s, tokenServerUri=%s, scopes=%s, serviceAccountUser=%s}",
-        SA_CLIENT_ID,
-        SA_CLIENT_EMAIL,
-        SA_PRIVATE_KEY_ID,
-        MockTokenServerTransportFactory.class.getName(),
-        tokenServer,
-        SCOPES,
-        SERVICE_ACCOUNT_USER);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            tokenServer,
+            SERVICE_ACCOUNT_USER);
+    String expectedToString =
+        String.format(
+            "ServiceAccountCredentials{clientId=%s, clientEmail=%s, privateKeyId=%s, "
+                + "transportFactoryClassName=%s, tokenServerUri=%s, scopes=%s, serviceAccountUser=%s}",
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_ID,
+            MockTokenServerTransportFactory.class.getName(),
+            tokenServer,
+            SCOPES,
+            SERVICE_ACCOUNT_USER);
     assertEquals(expectedToString, credentials.toString());
   }
 
@@ -698,12 +887,24 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void hashCode_equals() throws IOException {
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
-        tokenServer);
-    OAuth2Credentials otherCredentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
-        tokenServer);
+    OAuth2Credentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            tokenServer);
+    OAuth2Credentials otherCredentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            tokenServer);
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 
@@ -711,15 +912,22 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void serialize() throws IOException, ClassNotFoundException {
     final URI tokenServer = URI.create("https://foo.com/bar");
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
-    ServiceAccountCredentials credentials = ServiceAccountCredentials.fromPkcs8(SA_CLIENT_ID,
-        SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID, SCOPES, transportFactory,
-        tokenServer);
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.fromPkcs8(
+            SA_CLIENT_ID,
+            SA_CLIENT_EMAIL,
+            SA_PRIVATE_KEY_PKCS8,
+            SA_PRIVATE_KEY_ID,
+            SCOPES,
+            transportFactory,
+            tokenServer);
     ServiceAccountCredentials deserializedCredentials = serializeAndDeserialize(credentials);
     assertEquals(credentials, deserializedCredentials);
     assertEquals(credentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(credentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
-    assertEquals(MockTokenServerTransportFactory.class,
+    assertEquals(
+        MockTokenServerTransportFactory.class,
         deserializedCredentials.toBuilder().getHttpTransportFactory().getClass());
   }
 
@@ -749,8 +957,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   public void fromStream_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
-    InputStream serviceAccountStream = writeServiceAccountStream(
-        SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
+    InputStream serviceAccountStream =
+        writeServiceAccountStream(
+            SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
 
     GoogleCredentials credentials =
         ServiceAccountCredentials.fromStream(serviceAccountStream, transportFactory);
@@ -794,7 +1003,11 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   static GenericJson writeServiceAccountJson(
-      String clientId, String clientEmail, String privateKeyPkcs8, String privateKeyId, String projectId) {
+      String clientId,
+      String clientEmail,
+      String privateKeyPkcs8,
+      String privateKeyId,
+      String projectId) {
     GenericJson json = new GenericJson();
     if (clientId != null) {
       json.put("client_id", clientId);
@@ -815,8 +1028,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     return json;
   }
 
-  static InputStream writeServiceAccountStream(String clientId, String clientEmail,
-      String privateKeyPkcs8, String privateKeyId) throws IOException {
+  static InputStream writeServiceAccountStream(
+      String clientId, String clientEmail, String privateKeyPkcs8, String privateKeyId)
+      throws IOException {
     GenericJson json =
         writeServiceAccountJson(clientId, clientEmail, privateKeyPkcs8, privateKeyId, null);
     return TestUtils.jsonToInputStream(json);
@@ -825,8 +1039,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       ServiceAccountCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);
-      fail(String.format("Should throw exception with message containing '%s'",
-          expectedMessageContent));
+      fail(
+          String.format(
+              "Should throw exception with message containing '%s'", expectedMessageContent));
     } catch (IOException expected) {
       assertTrue(expected.getMessage().contains(expectedMessageContent));
     }


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-auth-library-java/issues/99

Adds support for IDTokens into `google-auth-java` for `ServiceAccountCredentials`, `ComuteEngineCredentials` and `ImpersonatedCredentials` 

GCP users currently have to do these steps manually and outside of `google-auth-java`:   
   ref: https://github.com/salrashid123/salrashid123.github.io/tree/master/google_id_token#java
this change wraps the various flows into the library

I do not have any testcases here. I'm submitting this first for review of the api surface.  Usage for this change is shown here:
 https://github.com/googleapis/google-auth-library-java/issues/99#issuecomment-512899563

