### PR TITLE
chore: add kokoro configs for proposing releases automatically

### DIFF
--- a/.kokoro/continuous/propose_release.cfg
+++ b/.kokoro/continuous/propose_release.cfg
@@ -1,0 +1,53 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "google-auth-library-java/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
+}
+
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/google-auth-library-java/.kokoro/continuous/propose_release.sh"
+}
+
+# tokens used by release-please to keep an up-to-date release PR.
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-key-release-please"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-token-release-please"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-url-release-please"
+    }
+  }
+}

--- a/.kokoro/continuous/propose_release.sh
+++ b/.kokoro/continuous/propose_release.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; then
+  # Groom the release PR as new commits are merged.
+  npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
+    --repo-url=googleapis/google-auth-library-java \
+    --package-name="google-auth-library-java" \
+    --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
+    --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please \
+    --release-type=java-auth-yoshi
+fi

--- a/.kokoro/release/bump_snapshot.cfg
+++ b/.kokoro/release/bump_snapshot.cfg
@@ -1,0 +1,53 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Build logs will be here
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}
+
+# Download trampoline resources.
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
+# Use the trampoline script to run in docker.
+build_file: "google-auth-library-java/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+env_vars: {
+  key: "TRAMPOLINE_IMAGE"
+  value: "gcr.io/cloud-devrel-kokoro-resources/node:10-user"
+}
+
+env_vars: {
+  key: "TRAMPOLINE_BUILD_FILE"
+  value: "github/google-auth-library-java/.kokoro/release/bump_snapshot.sh"
+}
+
+# tokens used by release-please to keep an up-to-date release PR.
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-key-release-please"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-token-release-please"
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "github-magic-proxy-url-release-please"
+    }
+  }
+}

--- a/.kokoro/release/bump_snapshot.sh
+++ b/.kokoro/release/bump_snapshot.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+export NPM_CONFIG_PREFIX=/home/node/.npm-global
+
+if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; then
+  # Groom the release PR as new commits are merged.
+  npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
+    --repo-url=googleapis/google-auth-library-java \
+    --package-name="google-auth-library-java" \
+    --api-url=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please \
+    --proxy-key=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-key-release-please \
+    --snapshot \
+    --release-type=java-auth-yoshi
+fi

--- a/.kokoro/release/bump_snapshot.sh
+++ b/.kokoro/release/bump_snapshot.sh
@@ -19,7 +19,7 @@ set -eo pipefail
 export NPM_CONFIG_PREFIX=/home/node/.npm-global
 
 if [ -f ${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-url-release-please ]; then
-  # Groom the release PR as new commits are merged.
+  # Groom the snapshot release PR immediately after publishing a release
   npx release-please release-pr --token=${KOKORO_KEYSTORE_DIR}/73713_github-magic-proxy-token-release-please \
     --repo-url=googleapis/google-auth-library-java \
     --package-name="google-auth-library-java" \


### PR DESCRIPTION
Commits to master will propose a release.
After releases are published, it will trigger a job to bump the snapshot.