### PR TITLE
chore: hide `IdToken#getJsonWebSignature()`

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/IdToken.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdToken.java
@@ -85,7 +85,7 @@ public class IdToken extends AccessToken implements Serializable {
    *
    * @return returns com.google.api.client.json.webtoken.JsonWebSignature
    */
-  public JsonWebSignature getJsonWebSignature() {
+  JsonWebSignature getJsonWebSignature() {
     return jsonWebSignature;
   }
 


### PR DESCRIPTION
I think we should hide `getJsonWebSignature()` for now until we know if we actually want to expose this class or a version from a different, better supported JWT library.