### PR TITLE
fix: allow unset/null privateKeyId for JwtCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -86,7 +86,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
 
   private JwtCredentials(Builder builder) {
     this.privateKey = Preconditions.checkNotNull(builder.getPrivateKey());
-    this.privateKeyId = Preconditions.checkNotNull(builder.getPrivateKeyId());
+    this.privateKeyId = builder.getPrivateKeyId();
     this.jwtClaims = Preconditions.checkNotNull(builder.getJwtClaims());
     Preconditions.checkState(jwtClaims.isComplete(), JWT_INCOMPLETE_ERROR_MESSAGE);
     this.lifeSpanSeconds = Preconditions.checkNotNull(builder.getLifeSpanSeconds());
@@ -220,7 +220,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
     }
 
     public Builder setPrivateKeyId(String privateKeyId) {
-      this.privateKeyId = Preconditions.checkNotNull(privateKeyId);
+      this.privateKeyId = privateKeyId;
       return this;
     }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -264,12 +264,7 @@ public class JwtCredentialsTest extends BaseSerializationTest {
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata();
-    verifyJwtAccess(
-        metadata,
-        "some-audience",
-        "some-issuer",
-        "some-subject",
-        null);
+    verifyJwtAccess(metadata, "some-audience", "some-issuer", "some-subject", null);
   }
 
   @Test
@@ -281,18 +276,10 @@ public class JwtCredentialsTest extends BaseSerializationTest {
             .setSubject("some-subject")
             .build();
     JwtCredentials credentials =
-        JwtCredentials.newBuilder()
-            .setJwtClaims(claims)
-            .setPrivateKey(getPrivateKey())
-            .build();
+        JwtCredentials.newBuilder().setJwtClaims(claims).setPrivateKey(getPrivateKey()).build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata();
-    verifyJwtAccess(
-        metadata,
-        "some-audience",
-        "some-issuer",
-        "some-subject",
-        null);
+    verifyJwtAccess(metadata, "some-audience", "some-issuer", "some-subject", null);
   }
 
   private void verifyJwtAccess(

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -115,22 +115,6 @@ public class JwtCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void builder_requiresPrivateKeyId() {
-    try {
-      JwtClaims claims =
-          JwtClaims.newBuilder()
-              .setAudience("some-audience")
-              .setIssuer("some-issuer")
-              .setSubject("some-subject")
-              .build();
-      JwtCredentials.newBuilder().setJwtClaims(claims).setPrivateKey(getPrivateKey()).build();
-      fail("Should throw exception");
-    } catch (NullPointerException ex) {
-      // expected
-    }
-  }
-
-  @Test
   public void builder_requiresClaims() {
     try {
       JwtCredentials.newBuilder()

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtCredentialsTest.java
@@ -248,6 +248,53 @@ public class JwtCredentialsTest extends BaseSerializationTest {
         Collections.singletonMap("foo", "bar"));
   }
 
+  @Test
+  public void privateKeyIdNull() throws IOException {
+    JwtClaims claims =
+        JwtClaims.newBuilder()
+            .setAudience("some-audience")
+            .setIssuer("some-issuer")
+            .setSubject("some-subject")
+            .build();
+    JwtCredentials credentials =
+        JwtCredentials.newBuilder()
+            .setJwtClaims(claims)
+            .setPrivateKey(getPrivateKey())
+            .setPrivateKeyId(null)
+            .build();
+
+    Map<String, List<String>> metadata = credentials.getRequestMetadata();
+    verifyJwtAccess(
+        metadata,
+        "some-audience",
+        "some-issuer",
+        "some-subject",
+        null);
+  }
+
+  @Test
+  public void privateKeyIdNotSpecified() throws IOException {
+    JwtClaims claims =
+        JwtClaims.newBuilder()
+            .setAudience("some-audience")
+            .setIssuer("some-issuer")
+            .setSubject("some-subject")
+            .build();
+    JwtCredentials credentials =
+        JwtCredentials.newBuilder()
+            .setJwtClaims(claims)
+            .setPrivateKey(getPrivateKey())
+            .build();
+
+    Map<String, List<String>> metadata = credentials.getRequestMetadata();
+    verifyJwtAccess(
+        metadata,
+        "some-audience",
+        "some-issuer",
+        "some-subject",
+        null);
+  }
+
   private void verifyJwtAccess(
       Map<String, List<String>> metadata,
       String expectedAudience,


### PR DESCRIPTION
Fixes #335

This was a regression from 0.16.2
Note that if you load Service Account Credentials from json, that field is required.