### PR TITLE
Release google-auth-library-java v0.17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.17.1</version>
+  <version>0.17.2</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})
@@ -42,7 +42,7 @@ If you are using Gradle, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.17.1'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.17.2'
 ```
 [//]: # ({x-version-update-end})
 
@@ -50,7 +50,7 @@ If you are using SBT, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.17.1"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.17.2"
 ```
 [//]: # ({x-version-update-end})
 

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.17.2-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.17.2</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bom/README.md
+++ b/bom/README.md
@@ -12,7 +12,7 @@ To use it in Maven, add the following to your `pom.xml`:
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-bom</artifactId>
-      <version>0.16.2</version>
+      <version>0.17.2</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-bom</artifactId>
-  <version>0.17.2-SNAPSHOT</version><!-- {x-version-update:google-auth-library-bom:current} -->
+  <version>0.17.2</version><!-- {x-version-update:google-auth-library-bom:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java BOM</name>
   <description>

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.17.2-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.17.2</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.17.2-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.17.2</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-parent</artifactId>
-  <version>0.17.2-SNAPSHOT</version><!-- {x-version-update:google-auth-library-parent:current} -->
+  <version>0.17.2</version><!-- {x-version-update:google-auth-library-parent:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
   <description>Client libraries providing authentication and

--- a/versions.txt
+++ b/versions.txt
@@ -1,9 +1,9 @@
 # Format:
 # module:released-version:current-version
 
-google-auth-library:0.17.1:0.17.2-SNAPSHOT
-google-auth-library-bom:0.17.1:0.17.2-SNAPSHOT
-google-auth-library-parent:0.17.1:0.17.2-SNAPSHOT
-google-auth-library-appengine:0.17.1:0.17.2-SNAPSHOT
-google-auth-library-credentials:0.17.1:0.17.2-SNAPSHOT
-google-auth-library-oauth2-http:0.17.1:0.17.2-SNAPSHOT
+google-auth-library:0.17.2:0.17.2
+google-auth-library-bom:0.17.2:0.17.2
+google-auth-library-parent:0.17.2:0.17.2
+google-auth-library-appengine:0.17.2:0.17.2
+google-auth-library-credentials:0.17.2:0.17.2
+google-auth-library-oauth2-http:0.17.2:0.17.2


### PR DESCRIPTION
This pull request was generated using releasetool.

09-17-2019 16:27 PDT

### Dependencies
- deps: update dependency com.google.http-client:google-http-client-bom to v1.32.0 ([#341](https://github.com/googleapis/google-auth-library-java/pull/341))