### PR TITLE
fix: typo in BOM dependency

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -61,7 +61,7 @@
       </dependency>
       <dependency>
         <groupId>com.google.auth</groupId>
-        <artifactId>google-auth-library-oauth2-appengine</artifactId>
+        <artifactId>google-auth-library-appengine</artifactId>
         <version>${project.version}</version>
       </dependency>
     </dependencies>


### PR DESCRIPTION
The google-auth-library-appengine dependency is incorrectly named in the BOM.
