### PR TITLE
deps: make auto-value-annotations an optional dependency

### DIFF
--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -65,6 +65,7 @@
     <dependency>
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
@@ -97,5 +98,4 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value-annotations</artifactId>
         <version>${project.autovalue.version}</version>
+        <optional>true</optional>
       </dependency>
       <dependency>
         <groupId>com.google.auto.value</groupId>


### PR DESCRIPTION
Really it's a compile-only dependency which Maven doesn't support.