### PR TITLE
build: fix version and tags for release-please

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -1,9 +1,9 @@
 # Format:
 # module:released-version:current-version
 
-google-auth-library:0.17.3:0.17.3
-google-auth-library-bom:0.17.3:0.17.3
-google-auth-library-parent:0.17.3:0.17.3
-google-auth-library-appengine:0.17.3:0.17.3
-google-auth-library-credentials:0.17.3:0.17.3
-google-auth-library-oauth2-http:0.17.3:0.17.3
+google-auth-library:0.17.2:0.17.3-SNAPSHOT
+google-auth-library-bom:0.17.2:0.17.3-SNAPSHOT
+google-auth-library-parent:0.17.2:0.17.3-SNAPSHOT
+google-auth-library-appengine:0.17.2:0.17.3-SNAPSHOT
+google-auth-library-credentials:0.17.2:0.17.3-SNAPSHOT
+google-auth-library-oauth2-http:0.17.2:0.17.3-SNAPSHOT


### PR DESCRIPTION
We had an inadvertent tag for 0.17.3 which caused release-please to try and release the wrong version. Pushing this to master should retrigger and fix the release versioning.