### PR TITLE
chore: release 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [0.17.3](https://www.github.com/googleapis/google-auth-library-java/compare/v0.17.2...v0.17.3) (2019-10-09)
+### [0.18.0](https://www.github.com/googleapis/google-auth-library-java/compare/v0.17.2...v0.18.0) (2019-10-09)
 
 
 ### Bug Fixes
@@ -18,7 +18,7 @@
 
 * fix include instructions in google-auth-library-bom README ([#352](https://www.github.com/googleapis/google-auth-library-java/issues/352)) ([f649735](https://www.github.com/googleapis/google-auth-library-java/commit/f649735))
 
-### [0.17.4](https://www.github.com/googleapis/google-auth-library-java/compare/v0.17.3...v0.17.4) (2019-10-08)
+### [0.17.4](https://www.github.com/googleapis/google-auth-library-java/compare/v0.18.0...v0.17.4) (2019-10-08)
 
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>0.17.3</version>
+  <version>0.18.0</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})
@@ -42,7 +42,7 @@ If you are using Gradle, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:0.17.3'
+compile 'com.google.auth:google-auth-library-oauth2-http:0.18.0'
 ```
 [//]: # ({x-version-update-end})
 
@@ -50,7 +50,7 @@ If you are using SBT, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.17.3"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "0.18.0"
 ```
 [//]: # ({x-version-update-end})
 

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.17.3</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.18.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-bom</artifactId>
-  <version>0.17.3</version><!-- {x-version-update:google-auth-library-bom:current} -->
+  <version>0.18.0</version><!-- {x-version-update:google-auth-library-bom:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java BOM</name>
   <description>

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.17.3</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.18.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.auth</groupId>
     <artifactId>google-auth-library-parent</artifactId>
-    <version>0.17.3</version><!-- {x-version-update:google-auth-library-parent:current} -->
+    <version>0.18.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-parent</artifactId>
-  <version>0.17.3</version><!-- {x-version-update:google-auth-library-parent:current} -->
+  <version>0.18.0</version><!-- {x-version-update:google-auth-library-parent:current} -->
   <packaging>pom</packaging>
   <name>Google Auth Library for Java</name>
   <description>Client libraries providing authentication and

--- a/versions.txt
+++ b/versions.txt
@@ -1,9 +1,9 @@
 # Format:
 # module:released-version:current-version
 
-google-auth-library:0.17.3:0.17.3
-google-auth-library-bom:0.17.3:0.17.3
-google-auth-library-parent:0.17.3:0.17.3
-google-auth-library-appengine:0.17.3:0.17.3
-google-auth-library-credentials:0.17.3:0.17.3
-google-auth-library-oauth2-http:0.17.3:0.17.3
+google-auth-library:0.18.0:0.18.0
+google-auth-library-bom:0.18.0:0.18.0
+google-auth-library-parent:0.18.0:0.18.0
+google-auth-library-appengine:0.18.0:0.18.0
+google-auth-library-credentials:0.18.0:0.18.0
+google-auth-library-oauth2-http:0.18.0:0.18.0


### PR DESCRIPTION
We should actually release this as 0.18.0 rather than 0.17.3
See #361 