### PR TITLE
Remove outdated comment on explicit IP address

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -69,7 +69,6 @@ public class ComputeEngineCredentials extends GoogleCredentials
 
   private static final Logger LOGGER = Logger.getLogger(ComputeEngineCredentials.class.getName());
 
-  // Note: the explicit IP address is used to avoid name server resolution issues.
   static final String DEFAULT_METADATA_SERVER_URL = "http://metadata.google.internal";
 
   static final String SIGN_BLOB_URL_FORMAT =


### PR DESCRIPTION
The explicit IP address is no longer used.