### PR TITLE
chore: updated `JwtClaims.Builder` methods to `public`

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
@@ -110,15 +110,15 @@ public abstract class JwtClaims implements Serializable {
   }
 
   @AutoValue.Builder
-  abstract static class Builder {
-    abstract Builder setAudience(String audience);
+  public abstract static class Builder {
+    public abstract Builder setAudience(String audience);
 
-    abstract Builder setIssuer(String issuer);
+    public abstract Builder setIssuer(String issuer);
 
-    abstract Builder setSubject(String subject);
+    public abstract Builder setSubject(String subject);
 
-    abstract Builder setAdditionalClaims(Map<String, String> additionalClaims);
+    public abstract Builder setAdditionalClaims(Map<String, String> additionalClaims);
 
-    abstract JwtClaims build();
+    public abstract JwtClaims build();
   }
 }


### PR DESCRIPTION
Made JwtClaims#Builder methods public so that the user could create JwtClaims instance.

towards #349