### PR TITLE
feat: add logging at FINE level for each step of ADC

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -253,7 +253,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
             e);
       }
     }
-    LOGGER.log(Level.INFO, "Failed to detect whether we are running on Google Compute Engine.");
+    LOGGER.log(Level.FINE, "Failed to detect whether we are running on Google Compute Engine.");
     return false;
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -179,7 +179,11 @@ class DefaultCredentialsProvider {
       InputStream credentialsStream = null;
       try {
         if (isFile(wellKnownFileLocation)) {
-          LOGGER.log(Level.FINE, String.format("Loading credentials from well known file: %s", wellKnownFileLocation.getCanonicalPath()));
+          LOGGER.log(
+              Level.FINE,
+              String.format(
+                  "Loading credentials from well known file: %s",
+                  wellKnownFileLocation.getCanonicalPath()));
           credentialsStream = readStream(wellKnownFileLocation);
           credentials = GoogleCredentials.fromStream(credentialsStream, transportFactory);
         }

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -145,7 +145,9 @@ class DefaultCredentialsProvider {
     GoogleCredentials credentials = null;
     String credentialsPath = getEnv(CREDENTIAL_ENV_VAR);
     if (credentialsPath != null && credentialsPath.length() > 0) {
-      LOGGER.log(Level.FINE, String.format("Loading credentials from file: %s", credentialsPath));
+      LOGGER.log(
+          Level.FINE,
+          String.format("Attempting to load credentials from file: %s", credentialsPath));
       InputStream credentialsStream = null;
       try {
         File credentialsFile = new File(credentialsPath);
@@ -182,7 +184,7 @@ class DefaultCredentialsProvider {
           LOGGER.log(
               Level.FINE,
               String.format(
-                  "Loading credentials from well known file: %s",
+                  "Attempting to load credentials from well known file: %s",
                   wellKnownFileLocation.getCanonicalPath()));
           credentialsStream = readStream(wellKnownFileLocation);
           credentials = GoogleCredentials.fromStream(credentialsStream, transportFactory);

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -145,6 +145,7 @@ class DefaultCredentialsProvider {
     GoogleCredentials credentials = null;
     String credentialsPath = getEnv(CREDENTIAL_ENV_VAR);
     if (credentialsPath != null && credentialsPath.length() > 0) {
+      LOGGER.log(Level.FINE, String.format("Loading credentials from file: %s", credentialsPath));
       InputStream credentialsStream = null;
       try {
         File credentialsFile = new File(credentialsPath);
@@ -178,6 +179,7 @@ class DefaultCredentialsProvider {
       InputStream credentialsStream = null;
       try {
         if (isFile(wellKnownFileLocation)) {
+          LOGGER.log(Level.FINE, String.format("Loading credentials from well known file: %s", wellKnownFileLocation.getCanonicalPath()));
           credentialsStream = readStream(wellKnownFileLocation);
           credentials = GoogleCredentials.fromStream(credentialsStream, transportFactory);
         }
@@ -198,17 +200,20 @@ class DefaultCredentialsProvider {
 
     // Then try GAE 7 standard environment
     if (credentials == null && isOnGAEStandard7() && !skipAppEngineCredentialsCheck()) {
+      LOGGER.log(Level.FINE, "Attempting to load credentials from GAE 7 Standard");
       credentials = tryGetAppEngineCredential();
     }
 
     // Then try Cloud Shell.  This must be done BEFORE checking
     // Compute Engine, as Cloud Shell runs on GCE VMs.
     if (credentials == null) {
+      LOGGER.log(Level.FINE, "Attempting to load credentials from Cloud Shell");
       credentials = tryGetCloudShellCredentials();
     }
 
     // Then try Compute Engine and GAE 8 standard environment
     if (credentials == null) {
+      LOGGER.log(Level.FINE, "Attempting to load credentials from GCE");
       credentials = tryGetComputeCredentials(transportFactory);
     }
 


### PR DESCRIPTION
Fixes #430

Also changing the INFO message that we couldn't detect compute engine credentials as that's a perfectly normal case and can be checked by the return value.