### PR TITLE
feat: ComputeEngineCredential supports specifying scopes

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -53,11 +53,13 @@ import com.google.auth.ServiceAccountSigner.SigningException;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.GoogleCredentialsTest.MockHttpTransportFactory;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -123,6 +125,22 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
     TestUtils.assertContainsBearerToken(metadata, accessToken);
+  }
+
+  @Test
+  public void getRequestMetadata_hasAccessTokenWithScopes() throws IOException {
+    String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    transportFactory.transport.setAccessToken(accessToken);
+    Set<String> requestedScopes = ImmutableSet.of("scope-1", "scope-2");
+    ComputeEngineCredentials credentials = ComputeEngineCredentials.newBuilder()
+                                           .setScopes(requestedScopes)
+        .setHttpTransportFactory(transportFactory)
+        .build();
+    Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+
+    TestUtils.assertContainsBearerToken(metadata, accessToken);
+    assertEquals(requestedScopes, transportFactory.transport.getReceivedScopes());
   }
 
   @Test
@@ -194,7 +212,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         new MockMetadataServerTransportFactory();
     String expectedToString =
         String.format(
-            "ComputeEngineCredentials{transportFactoryClassName=%s}",
+            "ComputeEngineCredentials{scopes=null, transportFactoryClassName=%s}",
             MockMetadataServerTransportFactory.class.getName());
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder()

--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,7 @@
           <version>3.0.0-M5</version>
           <configuration>
             <reportNameSuffix>sponge_log</reportNameSuffix>
+            <trimStackTrace>false</trimStackTrace>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
The existing behavior of ComputeEngineCredentials is to not provide the `?scopes` parameter in its access token request to the metadata server.  This is workable on GCE, which has the concept of a scope lock / default scopes applied to the VM.  However, neither new AppEngine nor GKE Workload Identity have this concept; they just return a hardcoded set of default scopes if no 
 specific scopes are requested.  This makes usage of some Google APIs impossible using the Java client libraries.

This change adds scope support to ComputeEngineCredentials.  It's optional, so the current behavior will stay the default. 
 However, if the user specifies scopes on the builder or using `createScoped`, then those scopes will be passed to the metadata server.
