### PR TITLE
feat: adds support for AWS credentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -146,11 +146,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
   public String retrieveSubjectToken() throws IOException {
     // The targeted region is required to generate the signed request. The regional
     // endpoint must also be used.
-    String region = retrieveResource(((AwsCredentialSource) credentialSource).regionUrl, "region");
-
-    // There is an extra appended character that must be removed. If `us-east-1b` is returned,
-    // we want `us-east-1`.
-    region = region.substring(0, region.length() - 1);
+    String region = getAwsRegion();
 
     AwsSecurityCredentials credentials = getAwsSecurityCredentials();
 
@@ -222,6 +218,19 @@ public class AwsCredentials extends ExternalAccountCredentials {
         ((AwsCredentialSource) credentialSource)
             .regionalCredentialVerificationUrl.replace("{region}", signature.getRegion()));
     return token.toString();
+  }
+
+  private String getAwsRegion() throws IOException {
+    // For AWS Lambda, the region is retrieved through the AWS_REGION environment variable.
+    String region = getEnv("AWS_REGION");
+    if (region != null) {
+      return region;
+    }
+    region = retrieveResource(((AwsCredentialSource) credentialSource).regionUrl, "region");
+
+    // There is an extra appended character that must be removed. If `us-east-1b` is returned,
+    // we want `us-east-1`.
+    return region.substring(0, region.length() - 1);
   }
 
   @VisibleForTesting

--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -31,8 +31,6 @@
 
 package com.google.auth.oauth2;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
@@ -49,7 +47,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
- * AWS credentials representing a 3PI for calling Google APIs.
+ * AWS credentials representing a third-party identity for calling Google APIs.
  *
  * <p>By default, attempts to exchange the 3PI credential for a GCP access token.
  */
@@ -66,7 +64,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
     private String regionalCredentialVerificationUrl;
 
     /**
-     * The source of the 3P credential. The credential source map must contain the `region_url`,
+     * The source of the AWS credential. The credential source map must contain the `region_url`,
      * `url, and `regional_cred_verification_url` entries.
      *
      * <p>The `region_url` is used to retrieve to targeted region.
@@ -78,10 +76,23 @@ public class AwsCredentials extends ExternalAccountCredentials {
      */
     AwsCredentialSource(Map<String, Object> credentialSourceMap) {
       super(credentialSourceMap);
-      this.regionUrl = (String) checkNotNull(credentialSourceMap.get("region_url"));
-      this.url = (String) checkNotNull(credentialSourceMap.get("url"));
+      if (!credentialSourceMap.containsKey("region_url")) {
+        throw new IllegalArgumentException(
+            "A region_url representing the targeted region must be specified.");
+      }
+      if (!credentialSourceMap.containsKey("url")) {
+        throw new IllegalArgumentException(
+            "A url representing the metadata server endpoint must be specified.");
+      }
+      if (!credentialSourceMap.containsKey("regional_cred_verification_url")) {
+        throw new IllegalArgumentException(
+            "A regional_cred_verification_url representing the"
+                + " GetCallerIdentity action URL must be specified.");
+      }
+      this.regionUrl = (String) credentialSourceMap.get("region_url");
+      this.url = (String) credentialSourceMap.get("url");
       this.regionalCredentialVerificationUrl =
-          (String) checkNotNull(credentialSourceMap.get("regional_cred_verification_url"));
+          (String) credentialSourceMap.get("regional_cred_verification_url");
     }
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -63,7 +63,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
 
     private String regionUrl;
     private String url;
-    private String regionalCredVerificationUrl;
+    private String regionalCredentialVerificationUrl;
 
     /**
      * The source of the 3P credential. The credential source map must contain the `region_url`,
@@ -74,13 +74,13 @@ public class AwsCredentials extends ExternalAccountCredentials {
      * <p>The `url` is the metadata server URL which is used to retrieve the AWS credentials.
      *
      * <p>The `regional_cred_verification_url` is the regional GetCallerIdentity action URL, used to
-     * determine the account ID and it's roles.
+     * determine the account ID and its roles.
      */
     AwsCredentialSource(Map<String, Object> credentialSourceMap) {
       super(credentialSourceMap);
       this.regionUrl = (String) checkNotNull(credentialSourceMap.get("region_url"));
       this.url = (String) checkNotNull(credentialSourceMap.get("url"));
-      this.regionalCredVerificationUrl =
+      this.regionalCredentialVerificationUrl =
           (String) checkNotNull(credentialSourceMap.get("regional_cred_verification_url"));
     }
   }
@@ -152,7 +152,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
                 credentials,
                 "POST",
                 ((AwsCredentialSource) credentialSource)
-                    .regionalCredVerificationUrl.replace("{region}", region),
+                    .regionalCredentialVerificationUrl.replace("{region}", region),
                 region)
             .setAdditionalHeaders(headers)
             .build();
@@ -209,7 +209,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
     token.put(
         "url",
         ((AwsCredentialSource) credentialSource)
-            .regionalCredVerificationUrl.replace("{region}", signature.getRegion()));
+            .regionalCredentialVerificationUrl.replace("{region}", signature.getRegion()));
     return token.toString();
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * AWS credentials representing a 3PI for calling Google APIs.
+ *
+ * <p>By default, attempts to exchange the 3PI credential for a GCP access token.
+ */
+public class AwsCredentials extends ExternalAccountCredentials {
+
+  /**
+   * The AWS credential source. Stores data required to retrieve the AWS credential from the AWS
+   * metadata server.
+   */
+  static class AwsCredentialSource extends CredentialSource {
+
+    private String regionUrl;
+    private String url;
+    private String regionalCredVerificationUrl;
+
+    /**
+     * The source of the 3P credential. The credential source map must contain the `region_url`,
+     * `url, and `regional_cred_verification_url` entries.
+     *
+     * <p>The `region_url` is used to retrieve to targeted region.
+     *
+     * <p>The `url` is the metadata server URL which is used to retrieve the AWS credentials.
+     *
+     * <p>The `regional_cred_verification_url` is the regional GetCallerIdentity action URL, used to
+     * determine the account ID and it's roles.
+     */
+    AwsCredentialSource(Map<String, Object> credentialSourceMap) {
+      super(credentialSourceMap);
+      this.regionUrl = (String) checkNotNull(credentialSourceMap.get("region_url"));
+      this.url = (String) checkNotNull(credentialSourceMap.get("url"));
+      this.regionalCredVerificationUrl =
+          (String) checkNotNull(credentialSourceMap.get("regional_cred_verification_url"));
+    }
+  }
+
+  /**
+   * Internal constructor. See {@link
+   * ExternalAccountCredentials#ExternalAccountCredentials(HttpTransportFactory, String, String,
+   * String, String, CredentialSource, String, String, String, String, Collection)}
+   */
+  AwsCredentials(
+      HttpTransportFactory transportFactory,
+      String audience,
+      String subjectTokenType,
+      String tokenUrl,
+      String tokenInfoUrl,
+      AwsCredentialSource credentialSource,
+      @Nullable String serviceAccountImpersonationUrl,
+      @Nullable String quotaProjectId,
+      @Nullable String clientId,
+      @Nullable String clientSecret,
+      @Nullable Collection<String> scopes) {
+    super(
+        transportFactory,
+        audience,
+        subjectTokenType,
+        tokenUrl,
+        tokenInfoUrl,
+        credentialSource,
+        serviceAccountImpersonationUrl,
+        quotaProjectId,
+        clientId,
+        clientSecret,
+        scopes);
+  }
+
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    StsTokenExchangeRequest.Builder stsTokenExchangeRequest =
+        StsTokenExchangeRequest.newBuilder(retrieveSubjectToken(), subjectTokenType)
+            .setAudience(audience);
+
+    // Add scopes, if possible.
+    if (scopes != null && !scopes.isEmpty()) {
+      stsTokenExchangeRequest.setScopes(new ArrayList<>(scopes));
+    }
+
+    AccessToken accessToken = exchange3PICredentialForAccessToken(stsTokenExchangeRequest.build());
+    return attemptServiceAccountImpersonation(accessToken);
+  }
+
+  @Override
+  public String retrieveSubjectToken() throws IOException {
+    // The targeted region is required to generate the signed request. The regional
+    // endpoint must also be used.
+    String region = retrieveResource(((AwsCredentialSource) credentialSource).regionUrl, "region");
+
+    // There is an extra appended character that must be removed. If `us-east-1b` is returned,
+    // we want `us-east-1`.
+    region = region.substring(0, region.length() - 1);
+
+    AwsSecurityCredentials credentials = getAwsSecurityCredentials();
+
+    // Generate the signed request to the AWS STS GetCallerIdentity API.
+    Map<String, String> headers = new HashMap<>();
+    headers.put("x-goog-cloud-target-resource", audience);
+
+    AwsRequestSigner signer =
+        AwsRequestSigner.newBuilder(
+                credentials,
+                "POST",
+                ((AwsCredentialSource) credentialSource)
+                    .regionalCredVerificationUrl.replace("{region}", region),
+                region)
+            .setAdditionalHeaders(headers)
+            .build();
+
+    AwsRequestSignature awsRequestSignature = signer.sign();
+    return buildSubjectToken(awsRequestSignature);
+  }
+
+  /** Clones the AwsCredentials with the specified scopes. */
+  @Override
+  public GoogleCredentials createScoped(Collection<String> newScopes) {
+    return new AwsCredentials(
+        transportFactory,
+        audience,
+        subjectTokenType,
+        tokenUrl,
+        tokenInfoUrl,
+        (AwsCredentialSource) credentialSource,
+        serviceAccountImpersonationUrl,
+        quotaProjectId,
+        clientId,
+        clientSecret,
+        newScopes);
+  }
+
+  private String retrieveResource(String url, String resourceName) throws IOException {
+    try {
+      HttpRequestFactory requestFactory = transportFactory.create().createRequestFactory();
+      HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
+      HttpResponse response = request.execute();
+      return response.parseAsString();
+    } catch (IOException e) {
+      throw new IOException(String.format("Failed to retrieve AWS %s.", resourceName), e);
+    }
+  }
+
+  private String buildSubjectToken(AwsRequestSignature signature) {
+    GenericJson headers = new GenericJson();
+    headers.setFactory(OAuth2Utils.JSON_FACTORY);
+
+    Map<String, String> canonicalHeaders = signature.getCanonicalHeaders();
+    for (String headerName : canonicalHeaders.keySet()) {
+      headers.put(headerName, canonicalHeaders.get(headerName));
+    }
+
+    headers.put("Authorization", signature.getAuthorizationHeader());
+    headers.put("x-goog-cloud-target-resource", audience);
+
+    GenericJson token = new GenericJson();
+    token.setFactory(OAuth2Utils.JSON_FACTORY);
+
+    token.put("headers", headers);
+    token.put("method", signature.getHttpMethod());
+    token.put(
+        "url",
+        ((AwsCredentialSource) credentialSource)
+            .regionalCredVerificationUrl.replace("{region}", signature.getRegion()));
+    return token.toString();
+  }
+
+  @VisibleForTesting
+  AwsSecurityCredentials getAwsSecurityCredentials() throws IOException {
+    // Check environment variables for credentials first.
+    String accessKeyId = getEnv("AWS_ACCESS_KEY_ID");
+    String secretAccessKey = getEnv("AWS_SECRET_ACCESS_KEY");
+    String token = getEnv("Token");
+    if (accessKeyId != null && secretAccessKey != null) {
+      return new AwsSecurityCredentials(accessKeyId, secretAccessKey, token);
+    }
+
+    // Credentials not retrievable from environment variables - call metadata server.
+    AwsCredentialSource awsCredentialSource = (AwsCredentialSource) credentialSource;
+    // Retrieve the IAM role that is attached to the VM. This is required to retrieve the AWS
+    // security credentials.
+    String roleName = retrieveResource(awsCredentialSource.url, "IAM role");
+
+    // Retrieve the AWS security credentials by calling the endpoint specified by the credential
+    // source.
+    String awsCredentials =
+        retrieveResource(awsCredentialSource.url + "/" + roleName, "credentials");
+
+    JsonParser parser = OAuth2Utils.JSON_FACTORY.createJsonParser(awsCredentials);
+    GenericJson genericJson = parser.parseAndClose(GenericJson.class);
+
+    accessKeyId = (String) genericJson.get("AccessKeyId");
+    secretAccessKey = (String) genericJson.get("SecretAccessKey");
+    token = (String) genericJson.get("Token");
+
+    // These credentials last for a few hours - we may consider caching these in the
+    // future.
+    return new AwsSecurityCredentials(accessKeyId, secretAccessKey, token);
+  }
+
+  @VisibleForTesting
+  String getEnv(String name) {
+    return System.getenv(name);
+  }
+
+  public static AwsCredentials.Builder newBuilder() {
+    return new AwsCredentials.Builder();
+  }
+
+  public static AwsCredentials.Builder newBuilder(AwsCredentials awsCredentials) {
+    return new AwsCredentials.Builder(awsCredentials);
+  }
+
+  public static class Builder extends ExternalAccountCredentials.Builder {
+
+    protected Builder() {}
+
+    protected Builder(AwsCredentials credentials) {
+      super(credentials);
+    }
+
+    @Override
+    public AwsCredentials build() {
+      return new AwsCredentials(
+          transportFactory,
+          audience,
+          subjectTokenType,
+          tokenUrl,
+          tokenInfoUrl,
+          (AwsCredentialSource) credentialSource,
+          serviceAccountImpersonationUrl,
+          quotaProjectId,
+          clientId,
+          clientSecret,
+          scopes);
+    }
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -324,10 +324,6 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
    */
   public abstract String retrieveSubjectToken() throws IOException;
 
-  public HttpTransportFactory getTransportFactory() {
-    return transportFactory;
-  }
-
   public String getAudience() {
     return audience;
   }

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -234,7 +234,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
 
     protected Builder() {}
 
-    protected Builder(ExternalAccountCredentials credentials) {
+    protected Builder(IdentityPoolCredentials credentials) {
       super(credentials);
     }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -143,11 +143,11 @@ public class AwsCredentialsTest {
 
     Map<String, String> headers = (Map<String, String>) json.get("headers");
 
-    assertEquals(json.get("method"), "POST");
-    assertEquals(json.get("url"), GET_CALLER_IDENTITY_URL);
-    assertEquals(headers.get("host"), URI.create(GET_CALLER_IDENTITY_URL).getHost());
-    assertEquals(headers.get("x-amz-security-token"), "token");
-    assertEquals(headers.get("x-goog-cloud-target-resource"), awsCredential.getAudience());
+    assertEquals("POST", json.get("method"));
+    assertEquals(GET_CALLER_IDENTITY_URL, json.get("url"));
+    assertEquals(URI.create(GET_CALLER_IDENTITY_URL).getHost(), headers.get("host"));
+    assertEquals("token", headers.get("x-amz-security-token"));
+    assertEquals(awsCredential.getAudience(), headers.get("x-goog-cloud-target-resource"));
     assertTrue(headers.containsKey("x-amz-date"));
     assertNotNull(headers.get("Authorization"));
   }
@@ -177,7 +177,7 @@ public class AwsCredentialsTest {
               }
             });
 
-    assertEquals(e.getMessage(), "Failed to retrieve AWS region.");
+    assertEquals("Failed to retrieve AWS region.", e.getMessage());
   }
 
   @Test
@@ -206,7 +206,7 @@ public class AwsCredentialsTest {
               }
             });
 
-    assertEquals(e.getMessage(), "Failed to retrieve AWS IAM role.");
+    assertEquals("Failed to retrieve AWS IAM role.", e.getMessage());
   }
 
   @Test
@@ -235,7 +235,7 @@ public class AwsCredentialsTest {
               }
             });
 
-    assertEquals(e.getMessage(), "Failed to retrieve AWS credentials.");
+    assertEquals("Failed to retrieve AWS credentials.", e.getMessage());
   }
 
   @Test
@@ -246,8 +246,8 @@ public class AwsCredentialsTest {
 
     AwsSecurityCredentials credentials = testAwsCredentials.getAwsSecurityCredentials();
 
-    assertEquals(credentials.getAccessKeyId(), "awsAccessKeyId");
-    assertEquals(credentials.getSecretAccessKey(), "awsSecretAccessKey");
+    assertEquals("awsAccessKeyId", credentials.getAccessKeyId());
+    assertEquals("awsSecretAccessKey", credentials.getSecretAccessKey());
     assertNull(credentials.getToken());
   }
 
@@ -260,9 +260,9 @@ public class AwsCredentialsTest {
 
     AwsSecurityCredentials credentials = testAwsCredentials.getAwsSecurityCredentials();
 
-    assertEquals(credentials.getAccessKeyId(), "awsAccessKeyId");
-    assertEquals(credentials.getSecretAccessKey(), "awsSecretAccessKey");
-    assertEquals(credentials.getToken(), "token");
+    assertEquals("awsAccessKeyId", credentials.getAccessKeyId());
+    assertEquals("awsSecretAccessKey", credentials.getSecretAccessKey());
+    assertEquals("token", credentials.getToken());
   }
 
   @Test
@@ -279,9 +279,9 @@ public class AwsCredentialsTest {
 
     AwsSecurityCredentials credentials = awsCredential.getAwsSecurityCredentials();
 
-    assertEquals(credentials.getAccessKeyId(), "accessKeyId");
-    assertEquals(credentials.getSecretAccessKey(), "secretAccessKey");
-    assertEquals(credentials.getToken(), "token");
+    assertEquals("accessKeyId", credentials.getAccessKeyId());
+    assertEquals("secretAccessKey", credentials.getSecretAccessKey());
+    assertEquals("token", credentials.getToken());
   }
 
   @Test
@@ -299,18 +299,18 @@ public class AwsCredentialsTest {
 
     AwsCredentials newCredentials = (AwsCredentials) credentials.createScoped(newScopes);
 
-    assertEquals(newCredentials.getAudience(), credentials.getAudience());
-    assertEquals(newCredentials.getSubjectTokenType(), credentials.getSubjectTokenType());
-    assertEquals(newCredentials.getTokenUrl(), credentials.getTokenUrl());
-    assertEquals(newCredentials.getTokenInfoUrl(), credentials.getTokenInfoUrl());
+    assertEquals(credentials.getAudience(), newCredentials.getAudience());
+    assertEquals(credentials.getSubjectTokenType(), newCredentials.getSubjectTokenType());
+    assertEquals(credentials.getTokenUrl(), newCredentials.getTokenUrl());
+    assertEquals(credentials.getTokenInfoUrl(), newCredentials.getTokenInfoUrl());
     assertEquals(
-        newCredentials.getServiceAccountImpersonationUrl(),
-        credentials.getServiceAccountImpersonationUrl());
-    assertEquals(newCredentials.getCredentialSource(), credentials.getCredentialSource());
-    assertEquals(newCredentials.getQuotaProjectId(), credentials.getQuotaProjectId());
-    assertEquals(newCredentials.getClientId(), credentials.getClientId());
-    assertEquals(newCredentials.getClientSecret(), credentials.getClientSecret());
-    assertEquals(newCredentials.getScopes(), newScopes);
+        credentials.getServiceAccountImpersonationUrl(),
+        newCredentials.getServiceAccountImpersonationUrl());
+    assertEquals(credentials.getCredentialSource(), newCredentials.getCredentialSource());
+    assertEquals(credentials.getQuotaProjectId(), newCredentials.getQuotaProjectId());
+    assertEquals(credentials.getClientId(), newCredentials.getClientId());
+    assertEquals(credentials.getClientSecret(), newCredentials.getClientSecret());
+    assertEquals(newScopes, newCredentials.getScopes());
   }
 
   private AwsCredentialSource buildAwsCredentialSource(

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -32,8 +32,11 @@
 package com.google.auth.oauth2;
 
 import static com.google.auth.TestUtils.getDefaultExpireTime;
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonParser;
@@ -97,7 +100,7 @@ public class AwsCredentialsTest {
                 .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
-    assertThat(accessToken.getTokenValue()).isEqualTo(transportFactory.transport.getAccessToken());
+    assertEquals(accessToken.getTokenValue(), transportFactory.transport.getAccessToken());
   }
 
   @Test
@@ -118,7 +121,7 @@ public class AwsCredentialsTest {
                 .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
-    assertThat(accessToken.getTokenValue()).isEqualTo(transportFactory.transport.getAccessToken());
+    assertEquals(accessToken.getTokenValue(), transportFactory.transport.getAccessToken());
   }
 
   @Test
@@ -140,13 +143,13 @@ public class AwsCredentialsTest {
 
     Map<String, String> headers = (Map<String, String>) json.get("headers");
 
-    assertThat(json.get("method")).isEqualTo("POST");
-    assertThat(json.get("url")).isEqualTo(GET_CALLER_IDENTITY_URL);
-    assertThat(headers.get("host")).isEqualTo(URI.create(GET_CALLER_IDENTITY_URL).getHost());
-    assertThat(headers.containsKey("x-amz-date")).isTrue();
-    assertThat(headers.get("x-amz-security-token")).isEqualTo("token");
-    assertThat(headers.get("x-goog-cloud-target-resource")).isEqualTo(awsCredential.getAudience());
-    assertThat(headers.get("Authorization")).isNotNull();
+    assertEquals(json.get("method"), "POST");
+    assertEquals(json.get("url"), GET_CALLER_IDENTITY_URL);
+    assertEquals(headers.get("host"), URI.create(GET_CALLER_IDENTITY_URL).getHost());
+    assertEquals(headers.get("x-amz-security-token"), "token");
+    assertEquals(headers.get("x-goog-cloud-target-resource"), awsCredential.getAudience());
+    assertTrue(headers.containsKey("x-amz-date"));
+    assertNotNull(headers.get("Authorization"));
   }
 
   @Test
@@ -174,7 +177,7 @@ public class AwsCredentialsTest {
               }
             });
 
-    assertThat(e.getMessage()).isEqualTo("Failed to retrieve AWS region.");
+    assertEquals(e.getMessage(), "Failed to retrieve AWS region.");
   }
 
   @Test
@@ -203,7 +206,7 @@ public class AwsCredentialsTest {
               }
             });
 
-    assertThat(e.getMessage()).isEqualTo("Failed to retrieve AWS IAM role.");
+    assertEquals(e.getMessage(), "Failed to retrieve AWS IAM role.");
   }
 
   @Test
@@ -232,7 +235,7 @@ public class AwsCredentialsTest {
               }
             });
 
-    assertThat(e.getMessage()).isEqualTo("Failed to retrieve AWS credentials.");
+    assertEquals(e.getMessage(), "Failed to retrieve AWS credentials.");
   }
 
   @Test
@@ -243,9 +246,9 @@ public class AwsCredentialsTest {
 
     AwsSecurityCredentials credentials = testAwsCredentials.getAwsSecurityCredentials();
 
-    assertThat(credentials.getAccessKeyId()).isEqualTo("awsAccessKeyId");
-    assertThat(credentials.getSecretAccessKey()).isEqualTo("awsSecretAccessKey");
-    assertThat(credentials.getToken()).isNull();
+    assertEquals(credentials.getAccessKeyId(), "awsAccessKeyId");
+    assertEquals(credentials.getSecretAccessKey(), "awsSecretAccessKey");
+    assertNull(credentials.getToken());
   }
 
   @Test
@@ -257,9 +260,9 @@ public class AwsCredentialsTest {
 
     AwsSecurityCredentials credentials = testAwsCredentials.getAwsSecurityCredentials();
 
-    assertThat(credentials.getAccessKeyId()).isEqualTo("awsAccessKeyId");
-    assertThat(credentials.getSecretAccessKey()).isEqualTo("awsSecretAccessKey");
-    assertThat(credentials.getToken()).isEqualTo("token");
+    assertEquals(credentials.getAccessKeyId(), "awsAccessKeyId");
+    assertEquals(credentials.getSecretAccessKey(), "awsSecretAccessKey");
+    assertEquals(credentials.getToken(), "token");
   }
 
   @Test
@@ -276,9 +279,9 @@ public class AwsCredentialsTest {
 
     AwsSecurityCredentials credentials = awsCredential.getAwsSecurityCredentials();
 
-    assertThat(credentials.getAccessKeyId()).isEqualTo("accessKeyId");
-    assertThat(credentials.getSecretAccessKey()).isEqualTo("secretAccessKey");
-    assertThat(credentials.getToken()).isEqualTo("token");
+    assertEquals(credentials.getAccessKeyId(), "accessKeyId");
+    assertEquals(credentials.getSecretAccessKey(), "secretAccessKey");
+    assertEquals(credentials.getToken(), "token");
   }
 
   @Test
@@ -296,17 +299,18 @@ public class AwsCredentialsTest {
 
     AwsCredentials newCredentials = (AwsCredentials) credentials.createScoped(newScopes);
 
-    assertThat(newCredentials.getAudience()).isEqualTo(credentials.getAudience());
-    assertThat(newCredentials.getSubjectTokenType()).isEqualTo(credentials.getSubjectTokenType());
-    assertThat(newCredentials.getTokenUrl()).isEqualTo(credentials.getTokenUrl());
-    assertThat(newCredentials.getTokenInfoUrl()).isEqualTo(credentials.getTokenInfoUrl());
-    assertThat(newCredentials.getServiceAccountImpersonationUrl())
-        .isEqualTo(credentials.getServiceAccountImpersonationUrl());
-    assertThat(newCredentials.getCredentialSource()).isEqualTo(credentials.getCredentialSource());
-    assertThat(newCredentials.getQuotaProjectId()).isEqualTo(credentials.getQuotaProjectId());
-    assertThat(newCredentials.getClientId()).isEqualTo(credentials.getClientId());
-    assertThat(newCredentials.getClientSecret()).isEqualTo(credentials.getClientSecret());
-    assertThat(newCredentials.getScopes()).isEqualTo(newScopes);
+    assertEquals(newCredentials.getAudience(), credentials.getAudience());
+    assertEquals(newCredentials.getSubjectTokenType(), credentials.getSubjectTokenType());
+    assertEquals(newCredentials.getTokenUrl(), credentials.getTokenUrl());
+    assertEquals(newCredentials.getTokenInfoUrl(), credentials.getTokenInfoUrl());
+    assertEquals(
+        newCredentials.getServiceAccountImpersonationUrl(),
+        credentials.getServiceAccountImpersonationUrl());
+    assertEquals(newCredentials.getCredentialSource(), credentials.getCredentialSource());
+    assertEquals(newCredentials.getQuotaProjectId(), credentials.getQuotaProjectId());
+    assertEquals(newCredentials.getClientId(), credentials.getClientId());
+    assertEquals(newCredentials.getClientSecret(), credentials.getClientSecret());
+    assertEquals(newCredentials.getScopes(), newScopes);
   }
 
   private AwsCredentialSource buildAwsCredentialSource(

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -88,7 +88,7 @@ public class AwsCredentialsTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
 
-    final AwsCredentials awsCredential =
+    AwsCredentials awsCredential =
         (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setTokenUrl(transportFactory.transport.getStsUrl())
@@ -107,7 +107,7 @@ public class AwsCredentialsTest {
 
     transportFactory.transport.setExpireTime(getDefaultExpireTime());
 
-    final AwsCredentials awsCredential =
+    AwsCredentials awsCredential =
         (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setTokenUrl(transportFactory.transport.getStsUrl())

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2020, Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static com.google.auth.TestUtils.getDefaultExpireTime;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonParser;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.AwsCredentials.AwsCredentialSource;
+import com.google.auth.oauth2.ExternalAccountCredentialsTest.MockExternalAccountCredentialsTransportFactory;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link AwsCredentials}. */
+@RunWith(JUnit4.class)
+public class AwsCredentialsTest {
+
+  private static final String GET_CALLER_IDENTITY_URL =
+      "https://sts.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15";
+
+  private static final Map<String, Object> AWS_CREDENTIAL_SOURCE_MAP =
+      new HashMap<String, Object>() {
+        {
+          put("region_url", "regionUrl");
+          put("url", "url");
+          put("regional_cred_verification_url", "regionalCredVerificationUrl");
+        }
+      };
+
+  private static final AwsCredentialSource AWS_CREDENTIAL_SOURCE =
+      new AwsCredentialSource(AWS_CREDENTIAL_SOURCE_MAP);
+
+  private static final AwsCredentials AWS_CREDENTIAL =
+      (AwsCredentials)
+          AwsCredentials.newBuilder()
+              .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+              .setAudience("audience")
+              .setSubjectTokenType("subjectTokenType")
+              .setTokenUrl("tokenUrl")
+              .setTokenInfoUrl("tokenInfoUrl")
+              .setCredentialSource(AWS_CREDENTIAL_SOURCE)
+              .build();
+
+  @Test
+  public void refreshAccessToken_withoutServiceAccountImpersonation() throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    final AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setTokenUrl(transportFactory.transport.getStsUrl())
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .build();
+
+    AccessToken accessToken = awsCredential.refreshAccessToken();
+    assertThat(accessToken.getTokenValue()).isEqualTo(transportFactory.transport.getAccessToken());
+  }
+
+  @Test
+  public void refreshAccessToken_withServiceAccountImpersonation() throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    transportFactory.transport.setExpireTime(getDefaultExpireTime());
+
+    final AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setTokenUrl(transportFactory.transport.getStsUrl())
+                .setServiceAccountImpersonationUrl(
+                    transportFactory.transport.getServiceAccountImpersonationUrl())
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .build();
+
+    AccessToken accessToken = awsCredential.refreshAccessToken();
+    assertThat(accessToken.getTokenValue()).isEqualTo(transportFactory.transport.getAccessToken());
+  }
+
+  @Test
+  public void retrieveSubjectToken() throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .build();
+
+    String subjectToken = awsCredential.retrieveSubjectToken();
+
+    JsonParser parser = OAuth2Utils.JSON_FACTORY.createJsonParser(subjectToken);
+    GenericJson json = parser.parseAndClose(GenericJson.class);
+
+    Map<String, String> headers = (Map<String, String>) json.get("headers");
+
+    assertThat(json.get("method")).isEqualTo("POST");
+    assertThat(json.get("url")).isEqualTo(GET_CALLER_IDENTITY_URL);
+    assertThat(headers.get("host")).isEqualTo(URI.create(GET_CALLER_IDENTITY_URL).getHost());
+    assertThat(headers.containsKey("x-amz-date")).isTrue();
+    assertThat(headers.get("x-amz-security-token")).isEqualTo("token");
+    assertThat(headers.get("x-goog-cloud-target-resource")).isEqualTo(awsCredential.getAudience());
+    assertThat(headers.get("Authorization")).isNotNull();
+  }
+
+  @Test
+  public void retrieveSubjectToken_noRegion_expectThrows() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    IOException response = new IOException();
+    transportFactory.transport.addResponseErrorSequence(response);
+
+    final AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .build();
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() throws Throwable {
+                awsCredential.retrieveSubjectToken();
+              }
+            });
+
+    assertThat(e.getMessage()).isEqualTo("Failed to retrieve AWS region.");
+  }
+
+  @Test
+  public void retrieveSubjectToken_noRole_expectThrows() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    IOException response = new IOException();
+    transportFactory.transport.addResponseErrorSequence(response);
+    transportFactory.transport.addResponseSequence(true, false);
+
+    final AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .build();
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() throws Throwable {
+                awsCredential.retrieveSubjectToken();
+              }
+            });
+
+    assertThat(e.getMessage()).isEqualTo("Failed to retrieve AWS IAM role.");
+  }
+
+  @Test
+  public void retrieveSubjectToken_noCredentials_expectThrows() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    IOException response = new IOException();
+    transportFactory.transport.addResponseErrorSequence(response);
+    transportFactory.transport.addResponseSequence(true, true, false);
+
+    final AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .build();
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() throws Throwable {
+                awsCredential.retrieveSubjectToken();
+              }
+            });
+
+    assertThat(e.getMessage()).isEqualTo("Failed to retrieve AWS credentials.");
+  }
+
+  @Test
+  public void getAwsSecurityCredentials_fromEnvironmentVariablesNoToken() throws IOException {
+    TestAwsCredentials testAwsCredentials = TestAwsCredentials.newBuilder(AWS_CREDENTIAL).build();
+    testAwsCredentials.setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId");
+    testAwsCredentials.setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
+
+    AwsSecurityCredentials credentials = testAwsCredentials.getAwsSecurityCredentials();
+
+    assertThat(credentials.getAccessKeyId()).isEqualTo("awsAccessKeyId");
+    assertThat(credentials.getSecretAccessKey()).isEqualTo("awsSecretAccessKey");
+    assertThat(credentials.getToken()).isNull();
+  }
+
+  @Test
+  public void getAwsSecurityCredentials_fromEnvironmentVariablesWithToken() throws IOException {
+    TestAwsCredentials testAwsCredentials = TestAwsCredentials.newBuilder(AWS_CREDENTIAL).build();
+    testAwsCredentials.setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId");
+    testAwsCredentials.setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
+    testAwsCredentials.setEnv("Token", "token");
+
+    AwsSecurityCredentials credentials = testAwsCredentials.getAwsSecurityCredentials();
+
+    assertThat(credentials.getAccessKeyId()).isEqualTo("awsAccessKeyId");
+    assertThat(credentials.getSecretAccessKey()).isEqualTo("awsSecretAccessKey");
+    assertThat(credentials.getToken()).isEqualTo("token");
+  }
+
+  @Test
+  public void getAwsSecurityCredentials_fromMetadataServer() throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .build();
+
+    AwsSecurityCredentials credentials = awsCredential.getAwsSecurityCredentials();
+
+    assertThat(credentials.getAccessKeyId()).isEqualTo("accessKeyId");
+    assertThat(credentials.getSecretAccessKey()).isEqualTo("secretAccessKey");
+    assertThat(credentials.getToken()).isEqualTo("token");
+  }
+
+  @Test
+  public void createdScoped_clonedCredentialWithAddedScopes() {
+    AwsCredentials credentials =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setServiceAccountImpersonationUrl("tokenInfoUrl")
+                .setQuotaProjectId("quotaProjectId")
+                .setClientId("clientId")
+                .setClientSecret("clientSecret")
+                .build();
+
+    List<String> newScopes = Arrays.asList("scope1", "scope2");
+
+    AwsCredentials newCredentials = (AwsCredentials) credentials.createScoped(newScopes);
+
+    assertThat(newCredentials.getAudience()).isEqualTo(credentials.getAudience());
+    assertThat(newCredentials.getSubjectTokenType()).isEqualTo(credentials.getSubjectTokenType());
+    assertThat(newCredentials.getTokenUrl()).isEqualTo(credentials.getTokenUrl());
+    assertThat(newCredentials.getTokenInfoUrl()).isEqualTo(credentials.getTokenInfoUrl());
+    assertThat(newCredentials.getServiceAccountImpersonationUrl())
+        .isEqualTo(credentials.getServiceAccountImpersonationUrl());
+    assertThat(newCredentials.getCredentialSource()).isEqualTo(credentials.getCredentialSource());
+    assertThat(newCredentials.getQuotaProjectId()).isEqualTo(credentials.getQuotaProjectId());
+    assertThat(newCredentials.getClientId()).isEqualTo(credentials.getClientId());
+    assertThat(newCredentials.getClientSecret()).isEqualTo(credentials.getClientSecret());
+    assertThat(newCredentials.getScopes()).isEqualTo(newScopes);
+  }
+
+  private AwsCredentialSource buildAwsCredentialSource(
+      MockExternalAccountCredentialsTransportFactory transportFactory) {
+    Map<String, Object> credentialSourceMap = new HashMap<>();
+    credentialSourceMap.put("region_url", transportFactory.transport.getAwsRegionEndpoint());
+    credentialSourceMap.put("url", transportFactory.transport.getAwsCredentialsEndpoint());
+    credentialSourceMap.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
+    return new AwsCredentialSource(credentialSourceMap);
+  }
+
+  /** Used to test the retrieval of AWS credentials from environment variables. */
+  private static class TestAwsCredentials extends AwsCredentials {
+
+    private final Map<String, String> environmentVariables = new HashMap<>();
+
+    TestAwsCredentials(
+        HttpTransportFactory transportFactory,
+        String audience,
+        String subjectTokenType,
+        String tokenUrl,
+        String tokenInfoUrl,
+        AwsCredentialSource credentialSource,
+        @Nullable String serviceAccountImpersonationUrl,
+        @Nullable String quotaProjectId,
+        @Nullable String clientId,
+        @Nullable String clientSecret,
+        @Nullable Collection<String> scopes) {
+      super(
+          transportFactory,
+          audience,
+          subjectTokenType,
+          tokenUrl,
+          tokenInfoUrl,
+          credentialSource,
+          serviceAccountImpersonationUrl,
+          quotaProjectId,
+          clientId,
+          clientSecret,
+          scopes);
+    }
+
+    public static TestAwsCredentials.Builder newBuilder(AwsCredentials awsCredentials) {
+      return new TestAwsCredentials.Builder(awsCredentials);
+    }
+
+    public static class Builder extends AwsCredentials.Builder {
+
+      protected Builder(AwsCredentials credentials) {
+        super(credentials);
+      }
+
+      @Override
+      public TestAwsCredentials build() {
+        return new TestAwsCredentials(
+            transportFactory,
+            audience,
+            subjectTokenType,
+            tokenUrl,
+            tokenInfoUrl,
+            (AwsCredentialSource) credentialSource,
+            serviceAccountImpersonationUrl,
+            quotaProjectId,
+            clientId,
+            clientSecret,
+            scopes);
+      }
+    }
+
+    @Override
+    String getEnv(String name) {
+      return environmentVariables.get(name);
+    }
+
+    void setEnv(String name, String value) {
+      environmentVariables.put(name, value);
+    }
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -100,7 +100,8 @@ public class AwsCredentialsTest {
                 .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
-    assertEquals(accessToken.getTokenValue(), transportFactory.transport.getAccessToken());
+
+    assertEquals(transportFactory.transport.getAccessToken(), accessToken.getTokenValue());
   }
 
   @Test
@@ -121,7 +122,8 @@ public class AwsCredentialsTest {
                 .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
-    assertEquals(accessToken.getTokenValue(), transportFactory.transport.getAccessToken());
+
+    assertEquals(transportFactory.transport.getAccessToken(), accessToken.getTokenValue());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
@@ -61,20 +61,23 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
       "urn:ietf:params:oauth:grant-type:token-exchange";
   private static final String CLOUD_PLATFORM_SCOPE =
       "https://www.googleapis.com/auth/cloud-platform";
+  private static final String ISSUED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
+  private static final String AWS_CREDENTIALS_URL = "https://www.aws-credentials.com";
+  private static final String AWS_REGION_URL = "https://www.aws-region.com";
   private static final String METADATA_SERVER_URL = "https://www.metadata.google.com";
   private static final String STS_URL = "https://www.sts.google.com";
   private static final String SERVICE_ACCOUNT_IMPERSONATION_URL =
       "https://iamcredentials.googleapis.com";
 
   private static final String SUBJECT_TOKEN = "subjectToken";
-  private static final String ISSUED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
   private static final String TOKEN_TYPE = "Bearer";
   private static final String ACCESS_TOKEN = "accessToken";
   private static final int EXPIRES_IN = 3600;
 
   private static final JsonFactory JSON_FACTORY = new JacksonFactory();
 
+  private Queue<Boolean> responseSequence = new ArrayDeque<>();
   private Queue<IOException> responseErrorSequence = new ArrayDeque<>();
   private Queue<String> refreshTokenSequence = new ArrayDeque<>();
   private Queue<List<String>> scopeSequence = new ArrayDeque<>();
@@ -83,6 +86,10 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
 
   public void addResponseErrorSequence(IOException... errors) {
     Collections.addAll(responseErrorSequence, errors);
+  }
+
+  public void addResponseSequence(Boolean... responses) {
+    Collections.addAll(responseSequence, responses);
   }
 
   public void addRefreshTokenSequence(String... refreshTokens) {
@@ -99,11 +106,35 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
         new MockLowLevelHttpRequest(url) {
           @Override
           public LowLevelHttpResponse execute() throws IOException {
-            if (METADATA_SERVER_URL.equals(url)) {
-              if (!responseErrorSequence.isEmpty()) {
-                throw responseErrorSequence.poll();
-              }
+            boolean successfulResponse = !responseSequence.isEmpty() && responseSequence.poll();
 
+            if (!responseErrorSequence.isEmpty() && !successfulResponse) {
+              throw responseErrorSequence.poll();
+            }
+
+            if (AWS_REGION_URL.equals(url)) {
+              return new MockLowLevelHttpResponse()
+                  .setContentType("text/html")
+                  .setContent("us-east-1b");
+            }
+            if (AWS_CREDENTIALS_URL.equals(url)) {
+              return new MockLowLevelHttpResponse()
+                  .setContentType("text/html")
+                  .setContent("roleName");
+            }
+            if ((AWS_CREDENTIALS_URL + "/" + "roleName").equals(url)) {
+              GenericJson response = new GenericJson();
+              response.setFactory(JSON_FACTORY);
+              response.put("AccessKeyId", "accessKeyId");
+              response.put("SecretAccessKey", "secretAccessKey");
+              response.put("Token", "token");
+
+              return new MockLowLevelHttpResponse()
+                  .setContentType(Json.MEDIA_TYPE)
+                  .setContent(response.toString());
+            }
+
+            if (METADATA_SERVER_URL.equals(url)) {
               String metadataRequestHeader = getFirstHeaderValue("Metadata-Flavor");
               if (!"Google".equals(metadataRequestHeader)) {
                 throw new IOException("Metadata request header not found.");
@@ -113,9 +144,6 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
                   .setContent(SUBJECT_TOKEN);
             }
             if (STS_URL.equals(url)) {
-              if (!responseErrorSequence.isEmpty()) {
-                throw responseErrorSequence.poll();
-              }
               Map<String, String> query = TestUtils.parseQuery(getContentAsString());
               assertThat(query.get("grant_type")).isEqualTo(EXPECTED_GRANT_TYPE);
               assertThat(query.get("subject_token_type")).isNotEmpty();
@@ -187,6 +215,14 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
 
   public String getMetadataUrl() {
     return METADATA_SERVER_URL;
+  }
+
+  public String getAwsCredentialsEndpoint() {
+    return AWS_CREDENTIALS_URL;
+  }
+
+  public String getAwsRegionEndpoint() {
+    return AWS_REGION_URL;
   }
 
   public String getStsUrl() {


### PR DESCRIPTION
Adds a AwsCredentials class that supports retrieving AWS credentials from both environment variables and the security-credentials endpoint. It handles generating the GetCallerIdentity signed request (delegated to AwsRequestSigner) and building the subject token to be passed to GCP STS.
