### PR TITLE
feat: support generic token formats in IdentityPoolCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -41,12 +41,14 @@ import com.google.api.client.json.JsonObjectParser;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.IdentityPoolCredentials.IdentityPoolCredentialSource.CredentialFormatType;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.CharStreams;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Paths;
@@ -223,19 +225,15 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
 
   private String parseToken(InputStream inputStream) throws IOException {
     if (identityPoolCredentialSource.credentialFormatType == CredentialFormatType.TEXT) {
-      BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
-      StringBuilder token = new StringBuilder();
-      String line;
-      while ((line = reader.readLine()) != null) {
-        token.append(line);
-      }
-      return token.toString();
+      BufferedReader reader =
+          new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+      return CharStreams.toString(reader);
     }
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     JsonObjectParser parser = new JsonObjectParser(jsonFactory);
     GenericJson fileContents =
-        parser.parseAndClose(inputStream, OAuth2Utils.UTF_8, GenericJson.class);
+        parser.parseAndClose(inputStream, StandardCharsets.UTF_8, GenericJson.class);
 
     if (!fileContents.containsKey(identityPoolCredentialSource.subjectTokenFieldName)) {
       throw new IOException("Invalid subject token field name. No subject token was found.");

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -96,9 +96,9 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
      * <p>If this is URL-based 3p credential, the metadata server URL can be retrieved using the
      * `url` key.
      *
-     * <p>The 3P credential can be provided in different formats, such as text or JSON. The format
-     * can be specified using the `format` header, which will return a map with keys `type` and
-     * `subject_token_field_name`. If the `type` is json, the `subject_token_field_name` must be
+     * <p>The third party credential can be provided in different formats, such as text or JSON. The
+     * format can be specified using the `format` header, which will return a map with keys `type`
+     * and `subject_token_field_name`. If the `type` is json, the `subject_token_field_name` must be
      * provided. If no format is provided, we expect the token to be in the raw text format.
      *
      * <p>Optional headers can be present, and should be keyed by `headers`.
@@ -129,7 +129,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
       Map<String, String> formatMap = (Map<String, String>) credentialSourceMap.get("format");
       if (formatMap != null && formatMap.containsKey("type")) {
         String type = formatMap.get("type");
-        if (!type.equals("text") && !type.equals("json")) {
+        if (type == null || (!type.equals("text") && !type.equals("json"))) {
           throw new IllegalArgumentException(
               String.format("Invalid credential source format type: %s.", type));
         }

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -40,7 +40,6 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.IdentityPoolCredentials.IdentityPoolCredentialSource.CredentialFormatType;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CharStreams;
 import java.io.BufferedReader;
 import java.io.File;
@@ -69,8 +68,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
    * The IdentityPool credential source. Dictates the retrieval method of the 3PI credential, which
    * can either be through a metadata server or a local file.
    */
-  @VisibleForTesting
-  static class IdentityPoolCredentialSource extends CredentialSource {
+  static class IdentityPoolCredentialSource extends ExternalAccountCredentials.CredentialSource {
 
     enum IdentityPoolCredentialSourceType {
       FILE,

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -111,7 +111,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
         credentialSourceType = IdentityPoolCredentialSourceType.URL;
       } else {
         throw new IllegalArgumentException(
-            "Missing credential source file location or URL. At " + "least one must be specified.");
+            "Missing credential source file location or URL. At least one must be specified.");
       }
 
       Map<String, String> headersMap = (Map<String, String>) credentialSourceMap.get("headers");

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -108,7 +108,8 @@ public class IdentityPoolCredentialsTest {
     assertEquals("subjectTokenType", newCredentials.getSubjectTokenType());
     assertEquals("tokenUrl", newCredentials.getTokenUrl());
     assertEquals("tokenInfoUrl", newCredentials.getTokenInfoUrl());
-    assertEquals("serviceAccountImpersonationUrl", newCredentials.getServiceAccountImpersonationUrl());
+    assertEquals(
+        "serviceAccountImpersonationUrl", newCredentials.getServiceAccountImpersonationUrl());
     assertEquals(FILE_CREDENTIAL_SOURCE, newCredentials.getCredentialSource());
     assertEquals(newScopes, newCredentials.getScopes());
     assertEquals("quotaProjectId", newCredentials.getQuotaProjectId());
@@ -207,7 +208,9 @@ public class IdentityPoolCredentialsTest {
               }
             });
 
-    assertEquals(String.format("Invalid credential location. The file at %s does not exist.", path), e.getMessage());
+    assertEquals(
+        String.format("Invalid credential location. The file at %s does not exist.", path),
+        e.getMessage());
   }
 
   @Test
@@ -280,8 +283,9 @@ public class IdentityPoolCredentialsTest {
               }
             });
 
-    assertEquals(String.format(
-        "Error getting subject token from metadata server: %s", response.getMessage()),
+    assertEquals(
+        String.format(
+            "Error getting subject token from metadata server: %s", response.getMessage()),
         e.getMessage());
   }
 
@@ -338,7 +342,8 @@ public class IdentityPoolCredentialsTest {
               }
             });
 
-    assertEquals("Missing credential source file location or URL. At least one must be specified.",
+    assertEquals(
+        "Missing credential source file location or URL. At least one must be specified.",
         e.getMessage());
   }
 
@@ -383,7 +388,8 @@ public class IdentityPoolCredentialsTest {
               }
             });
 
-    assertEquals("When specifying a JSON credential type, the subject_token_field_name must be set.",
+    assertEquals(
+        "When specifying a JSON credential type, the subject_token_field_name must be set.",
         e.getMessage());
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -370,6 +370,28 @@ public class IdentityPoolCredentialsTest {
   }
 
   @Test
+  public void identityPoolCredentialSource_nullFormatType() {
+    final Map<String, Object> credentialSourceMap = new HashMap<>();
+    credentialSourceMap.put("url", "url");
+
+    Map<String, String> format = new HashMap<>();
+    format.put("type", null);
+    credentialSourceMap.put("format", format);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() {
+                new IdentityPoolCredentialSource(credentialSourceMap);
+              }
+            });
+
+    assertEquals("Invalid credential source format type: null.", e.getMessage());
+  }
+
+  @Test
   public void identityPoolCredentialSource_subjectTokenFieldNameUnset() {
     final Map<String, Object> credentialSourceMap = new HashMap<>();
     credentialSourceMap.put("url", "url");

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
@@ -80,6 +80,7 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
   private Queue<List<String>> scopeSequence = new ArrayDeque<>();
   private MockLowLevelHttpRequest request;
   private String expireTime;
+  private String metadataServerContentType;
 
   public void addResponseErrorSequence(IOException... errors) {
     Collections.addAll(responseErrorSequence, errors);
@@ -107,6 +108,15 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
               String metadataRequestHeader = getFirstHeaderValue("Metadata-Flavor");
               if (!"Google".equals(metadataRequestHeader)) {
                 throw new IOException("Metadata request header not found.");
+              }
+
+              if (metadataServerContentType != null && metadataServerContentType.equals("json")) {
+                GenericJson response = new GenericJson();
+                response.setFactory(JSON_FACTORY);
+                response.put("subjectToken", SUBJECT_TOKEN);
+                return new MockLowLevelHttpResponse()
+                    .setContentType(Json.MEDIA_TYPE)
+                    .setContent(response.toString());
               }
               return new MockLowLevelHttpResponse()
                   .setContentType("text/html")
@@ -199,5 +209,9 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
 
   public void setExpireTime(String expireTime) {
     this.expireTime = expireTime;
+  }
+
+  public void setMetadataServerContentType(String contentType) {
+    this.metadataServerContentType = contentType;
   }
 }


### PR DESCRIPTION
We need to support generic formats for `IdentityPoolCredentials` (text/json). The environments we support use both formats - K8s (file-sourced) returns the token as text, and Azure (url-sourced) returns the token in JSON format. 

The credential source now supports a `format` entry:
```
"credential_source": {
  "format": {
    "type": "json",
    "subject_token_field_name": "subject_token"
  }
}
```

If no format is provided, we default to text. 