### PR TITLE
fix: remove 1 hour limit for the impersonated token

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -218,9 +218,6 @@ public class ImpersonatedCredentials extends GoogleCredentials
     if (this.scopes == null) {
       throw new IllegalStateException(SCOPE_EMPTY_ERROR);
     }
-    if (this.lifetime > ONE_HOUR_IN_SECONDS) {
-      throw new IllegalStateException(LIFETIME_EXCEEDED_ERROR);
-    }
   }
 
   @Override

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -110,7 +110,6 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
       Arrays.asList("https://www.googleapis.com/auth/devstorage.read_only");
   private static final String ACCESS_TOKEN = "1/MkSJoj1xsli0AccessToken_NKPY2";
   private static final int VALID_LIFETIME = 300;
-  private static final int INVALID_LIFETIME = 3800;
   private static JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
 
   private static final String RFC3339 = "yyyy-MM-dd'T'HH:mm:ss'Z'";
@@ -195,24 +194,6 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     } catch (IOException expected) {
       assertEquals("Error requesting access token", expected.getMessage());
       assertTrue(expected.getCause().getMessage().contains(expectedMessage));
-    }
-  }
-
-  @Test()
-  public void credential_with_invalid_lifetime() throws IOException, IllegalStateException {
-
-    GoogleCredentials sourceCredentials = getSourceCredentials();
-    try {
-      ImpersonatedCredentials targetCredentials =
-          ImpersonatedCredentials.create(
-              sourceCredentials, IMPERSONATED_CLIENT_EMAIL, null, SCOPES, INVALID_LIFETIME);
-      targetCredentials.refreshAccessToken().getTokenValue();
-      fail(
-          String.format(
-              "Should throw exception with message containing '%s'",
-              "lifetime must be less than or equal to 3600"));
-    } catch (IllegalStateException expected) {
-      assertTrue(expected.getMessage().contains("lifetime must be less than or equal to 3600"));
     }
   }
 


### PR DESCRIPTION
Cloud IAM now supports extended 12h lifespan for access token:
https://cloud.google.com/iam/docs/creating-short-lived-service-account-credentials#sa-credentials-oauth

A separate PR should be made to allow developers to specify the desired lifespan of the granted token.
