### PR TITLE
feat: add quota project ID to requestMetadata if present

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -48,19 +48,21 @@ import com.google.auth.oauth2.AwsCredentials.AwsCredentialSource;
 import com.google.auth.oauth2.IdentityPoolCredentials.IdentityPoolCredentialSource;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
  * Base external account credentials class.
  *
- * <p>Handles initializing 3PI credentials, calls to STS and service account impersonation.
+ * <p>Handles initializing third-party credentials, calls to STS and service account impersonation.
  */
 public abstract class ExternalAccountCredentials extends GoogleCredentials
     implements QuotaProjectIdProvider {
@@ -146,6 +148,12 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     this.clientSecret = clientSecret;
     this.scopes =
         (scopes == null || scopes.isEmpty()) ? Arrays.asList(CLOUD_PLATFORM_SCOPE) : scopes;
+  }
+
+  @Override
+  public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
+    Map<String, List<String>> requestMetadata = super.getRequestMetadata(uri);
+    return addQuotaProjectIdToRequestMetadata(quotaProjectId, requestMetadata);
   }
 
   /**

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -32,22 +32,27 @@
 package com.google.auth.oauth2;
 
 import static com.google.auth.TestUtils.getDefaultExpireTime;
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
-import com.google.api.client.util.GenericData;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
-import com.google.auth.oauth2.IdentityPoolCredentials.IdentityPoolCredentialSource;
+import com.google.auth.oauth2.ExternalAccountCredentialsTest.TestExternalAccountCredentials.TestCredentialSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
@@ -58,11 +63,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ExternalAccountCredentialsTest {
 
-  private static final String AUDIENCE = "audience";
-  private static final String SUBJECT_TOKEN_TYPE = "subjectTokenType";
-  private static final String TOKEN_INFO_URL = "tokenInfoUrl";
   private static final String STS_URL = "https://www.sts.google.com";
-  private static final String CREDENTIAL = "credential";
   private static final String ACCESS_TOKEN = "eya23tfgdfga2123as";
   private static final String CLOUD_PLATFORM_SCOPE =
       "https://www.googleapis.com/auth/cloud-platform";
@@ -71,16 +72,6 @@ public class ExternalAccountCredentialsTest {
 
     MockExternalAccountCredentialsTransport transport =
         new MockExternalAccountCredentialsTransport();
-
-    private static final Map<String, Object> FILE_CREDENTIAL_SOURCE_MAP =
-        new HashMap<String, Object>() {
-          {
-            put("file", "file");
-          }
-        };
-
-    private static final IdentityPoolCredentialSource FILE_CREDENTIAL_SOURCE =
-        new IdentityPoolCredentialSource(FILE_CREDENTIAL_SOURCE_MAP);
 
     @Override
     public HttpTransport create() {
@@ -97,13 +88,24 @@ public class ExternalAccountCredentialsTest {
 
   @Test
   public void fromStream_identityPoolCredentials() throws IOException {
-    GenericJson json = buildDefaultIdentityPoolCredential();
+    GenericJson json = buildJsonIdentityPoolCredential();
     TestUtils.jsonToInputStream(json);
 
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromStream(TestUtils.jsonToInputStream(json));
 
-    assertThat(credential).isInstanceOf(IdentityPoolCredentials.class);
+    assertTrue(credential instanceof IdentityPoolCredentials);
+  }
+
+  @Test
+  public void fromStream_awsCredentials() throws IOException {
+    GenericJson json = buildJsonAwsCredential();
+    TestUtils.jsonToInputStream(json);
+
+    ExternalAccountCredentials credential =
+        ExternalAccountCredentials.fromStream(TestUtils.jsonToInputStream(json));
+
+    assertTrue(credential instanceof AwsCredentials);
   }
 
   @Test
@@ -136,14 +138,28 @@ public class ExternalAccountCredentialsTest {
   public void fromJson_identityPoolCredentials() {
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(
-            buildDefaultIdentityPoolCredential(), OAuth2Utils.HTTP_TRANSPORT_FACTORY);
-    assertThat(credential).isInstanceOf(IdentityPoolCredentials.class);
+            buildJsonIdentityPoolCredential(), OAuth2Utils.HTTP_TRANSPORT_FACTORY);
 
-    assertThat(credential.getAudience()).isEqualTo(AUDIENCE);
-    assertThat(credential.getSubjectTokenType()).isEqualTo(SUBJECT_TOKEN_TYPE);
-    assertThat(credential.getTokenUrl()).isEqualTo(STS_URL);
-    assertThat(credential.getTokenInfoUrl()).isEqualTo(TOKEN_INFO_URL);
-    assertThat(credential.getCredentialSource()).isNotNull();
+    assertTrue(credential instanceof IdentityPoolCredentials);
+    assertEquals("audience", credential.getAudience());
+    assertEquals("subjectTokenType", credential.getSubjectTokenType());
+    assertEquals(STS_URL, credential.getTokenUrl());
+    assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
+    assertNotNull(credential.getCredentialSource());
+  }
+
+  @Test
+  public void fromJson_awsCredentials() {
+    ExternalAccountCredentials credential =
+        ExternalAccountCredentials.fromJson(
+            buildJsonAwsCredential(), OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+
+    assertTrue(credential instanceof AwsCredentials);
+    assertEquals("audience", credential.getAudience());
+    assertEquals("subjectTokenType", credential.getSubjectTokenType());
+    assertEquals(STS_URL, credential.getTokenUrl());
+    assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
+    assertNotNull(credential.getCredentialSource());
   }
 
   @Test
@@ -175,26 +191,26 @@ public class ExternalAccountCredentialsTest {
   @Test
   public void exchange3PICredentialForAccessToken() throws IOException {
     ExternalAccountCredentials credential =
-        ExternalAccountCredentials.fromJson(buildDefaultIdentityPoolCredential(), transportFactory);
+        ExternalAccountCredentials.fromJson(buildJsonIdentityPoolCredential(), transportFactory);
 
     StsTokenExchangeRequest stsTokenExchangeRequest =
-        StsTokenExchangeRequest.newBuilder(CREDENTIAL, SUBJECT_TOKEN_TYPE).build();
+        StsTokenExchangeRequest.newBuilder("credential", "subjectTokenType").build();
 
     AccessToken accessToken =
         credential.exchange3PICredentialForAccessToken(stsTokenExchangeRequest);
 
-    assertThat(accessToken.getTokenValue()).isEqualTo(transportFactory.transport.getAccessToken());
+    assertEquals(transportFactory.transport.getAccessToken(), accessToken.getTokenValue());
 
     Map<String, List<String>> headers = transportFactory.transport.getRequest().getHeaders();
 
-    assertThat(headers.containsKey("content-type")).isTrue();
-    assertThat(headers.get("content-type").get(0)).isEqualTo("application/x-www-form-urlencoded");
+    assertTrue(headers.containsKey("content-type"));
+    assertEquals("application/x-www-form-urlencoded", headers.get("content-type").get(0));
   }
 
   @Test
   public void exchange3PICredentialForAccessToken_throws() throws IOException {
     final ExternalAccountCredentials credential =
-        ExternalAccountCredentials.fromJson(buildDefaultIdentityPoolCredential(), transportFactory);
+        ExternalAccountCredentials.fromJson(buildJsonIdentityPoolCredential(), transportFactory);
 
     String errorCode = "invalidRequest";
     String errorDescription = "errorDescription";
@@ -203,7 +219,7 @@ public class ExternalAccountCredentialsTest {
         TestUtils.buildHttpResponseException(errorCode, errorDescription, errorUri));
 
     final StsTokenExchangeRequest stsTokenExchangeRequest =
-        StsTokenExchangeRequest.newBuilder(CREDENTIAL, SUBJECT_TOKEN_TYPE).build();
+        StsTokenExchangeRequest.newBuilder("credential", "subjectTokenType").build();
 
     OAuthException e =
         assertThrows(
@@ -215,14 +231,14 @@ public class ExternalAccountCredentialsTest {
               }
             });
 
-    assertThat(e.getErrorCode()).isEqualTo(errorCode);
-    assertThat(e.getErrorDescription()).isEqualTo(errorDescription);
-    assertThat(e.getErrorUri()).isEqualTo(errorUri);
+    assertEquals(errorCode, e.getErrorCode());
+    assertEquals(errorDescription, e.getErrorDescription());
+    assertEquals(errorUri, e.getErrorUri());
   }
 
   @Test
   public void attemptServiceAccountImpersonation() throws IOException {
-    GenericJson defaultCredential = buildDefaultIdentityPoolCredential();
+    GenericJson defaultCredential = buildJsonIdentityPoolCredential();
     defaultCredential.put(
         "service_account_impersonation_url",
         transportFactory.transport.getServiceAccountImpersonationUrl());
@@ -235,39 +251,122 @@ public class ExternalAccountCredentialsTest {
 
     AccessToken returnedToken = credential.attemptServiceAccountImpersonation(accessToken);
 
-    assertThat(returnedToken.getTokenValue())
-        .isEqualTo(transportFactory.transport.getAccessToken());
-    assertThat(returnedToken.getTokenValue()).isNotEqualTo(accessToken.getTokenValue());
+    assertEquals(transportFactory.transport.getAccessToken(), returnedToken.getTokenValue());
+    assertNotEquals(accessToken.getTokenValue(), returnedToken.getTokenValue());
 
     // Validate request content.
     MockLowLevelHttpRequest request = transportFactory.transport.getRequest();
     Map<String, String> actualRequestContent = TestUtils.parseQuery(request.getContentAsString());
 
-    GenericData expectedRequestContent = new GenericData().set("scope", CLOUD_PLATFORM_SCOPE);
-    assertThat(actualRequestContent).isEqualTo(expectedRequestContent);
+    Map<String, String> expectedRequestContent = new HashMap<>();
+    expectedRequestContent.put("scope", CLOUD_PLATFORM_SCOPE);
+    assertEquals(expectedRequestContent, actualRequestContent);
   }
 
   @Test
   public void attemptServiceAccountImpersonation_noUrl() throws IOException {
     ExternalAccountCredentials credential =
-        ExternalAccountCredentials.fromJson(buildDefaultIdentityPoolCredential(), transportFactory);
+        ExternalAccountCredentials.fromJson(buildJsonIdentityPoolCredential(), transportFactory);
 
     AccessToken accessToken = new AccessToken(ACCESS_TOKEN, new Date());
     AccessToken returnedToken = credential.attemptServiceAccountImpersonation(accessToken);
 
-    assertThat(returnedToken).isEqualTo(accessToken);
+    assertEquals(accessToken, returnedToken);
   }
 
-  private GenericJson buildDefaultIdentityPoolCredential() {
+  @Test
+  public void getRequestMetadata_withQuotaProjectId() throws IOException {
+    TestExternalAccountCredentials testCredentials =
+        new TestExternalAccountCredentials(
+            transportFactory,
+            "audience",
+            "subjectTokenType",
+            "tokenUrl",
+            "tokenInfoUrl",
+            new TestCredentialSource(new HashMap<String, Object>()),
+            /* serviceAccountImpersonationUrl= */ null,
+            "quotaProjectId",
+            /* clientId= */ null,
+            /* clientSecret= */ null,
+            /* scopes= */ null);
+
+    Map<String, List<String>> requestMetadata =
+        testCredentials.getRequestMetadata(URI.create("http://googleapis.com/foo/bar"));
+
+    assertEquals("quotaProjectId", requestMetadata.get("x-goog-user-project").get(0));
+  }
+
+  private GenericJson buildJsonIdentityPoolCredential() {
     GenericJson json = new GenericJson();
-    json.put("audience", AUDIENCE);
-    json.put("subject_token_type", SUBJECT_TOKEN_TYPE);
+    json.put("audience", "audience");
+    json.put("subject_token_type", "subjectTokenType");
     json.put("token_url", STS_URL);
-    json.put("token_info_url", TOKEN_INFO_URL);
+    json.put("token_info_url", "tokenInfoUrl");
 
     Map<String, String> map = new HashMap<>();
     map.put("file", "file");
     json.put("credential_source", map);
     return json;
+  }
+
+  private GenericJson buildJsonAwsCredential() {
+    GenericJson json = new GenericJson();
+    json.put("audience", "audience");
+    json.put("subject_token_type", "subjectTokenType");
+    json.put("token_url", STS_URL);
+    json.put("token_info_url", "tokenInfoUrl");
+
+    Map<String, String> map = new HashMap<>();
+    map.put("environment_id", "aws1");
+    map.put("region_url", "regionUrl");
+    map.put("url", "url");
+    map.put("regional_cred_verification_url", "regionalCredVerificationUrl");
+    json.put("credential_source", map);
+
+    return json;
+  }
+
+  static class TestExternalAccountCredentials extends ExternalAccountCredentials {
+    static class TestCredentialSource extends ExternalAccountCredentials.CredentialSource {
+      protected TestCredentialSource(Map<String, Object> credentialSourceMap) {
+        super(credentialSourceMap);
+      }
+    }
+
+    protected TestExternalAccountCredentials(
+        HttpTransportFactory transportFactory,
+        String audience,
+        String subjectTokenType,
+        String tokenUrl,
+        String tokenInfoUrl,
+        CredentialSource credentialSource,
+        @Nullable String serviceAccountImpersonationUrl,
+        @Nullable String quotaProjectId,
+        @Nullable String clientId,
+        @Nullable String clientSecret,
+        @Nullable Collection<String> scopes) {
+      super(
+          transportFactory,
+          audience,
+          subjectTokenType,
+          tokenUrl,
+          tokenInfoUrl,
+          credentialSource,
+          serviceAccountImpersonationUrl,
+          quotaProjectId,
+          clientId,
+          clientSecret,
+          scopes);
+    }
+
+    @Override
+    public AccessToken refreshAccessToken() {
+      return new AccessToken("accessToken", new Date());
+    }
+
+    @Override
+    public String retrieveSubjectToken() {
+      return "subjectToken";
+    }
   }
 }


### PR DESCRIPTION
This PR does the following:
- Adds quota project ID to requestMetadata when present
- Removes use of Truth & adds missing tests for AwsCredentials in ExternalAccountCredentialsTest