### PR TITLE
chore: use ImpersonatedCredentials for service account impersonation for 3pi

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -138,8 +138,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
       stsTokenExchangeRequest.setScopes(new ArrayList<>(scopes));
     }
 
-    AccessToken accessToken = exchange3PICredentialForAccessToken(stsTokenExchangeRequest.build());
-    return attemptServiceAccountImpersonation(accessToken);
+    return exchange3PICredentialForAccessToken(stsTokenExchangeRequest.build());
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -193,8 +193,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
       stsTokenExchangeRequest.setScopes(new ArrayList<>(scopes));
     }
 
-    AccessToken accessToken = exchange3PICredentialForAccessToken(stsTokenExchangeRequest.build());
-    return attemptServiceAccountImpersonation(accessToken);
+    return exchange3PICredentialForAccessToken(stsTokenExchangeRequest.build());
   }
 
   @Override

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -65,6 +65,9 @@ public class AwsCredentialsTest {
   private static final String GET_CALLER_IDENTITY_URL =
       "https://sts.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15";
 
+  private static final String SERVICE_ACCOUNT_IMPERSONATION_URL =
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/testn@test.iam.gserviceaccount.com:generateAccessToken";
+
   private static final Map<String, Object> AWS_CREDENTIAL_SOURCE_MAP =
       new HashMap<String, Object>() {
         {
@@ -125,7 +128,8 @@ public class AwsCredentialsTest {
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
-    assertEquals(transportFactory.transport.getAccessToken(), accessToken.getTokenValue());
+    assertEquals(
+        transportFactory.transport.getServiceAccountAccessToken(), accessToken.getTokenValue());
   }
 
   @Test
@@ -293,7 +297,7 @@ public class AwsCredentialsTest {
     AwsCredentials credentials =
         (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setServiceAccountImpersonationUrl("tokenInfoUrl")
+                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
                 .setQuotaProjectId("quotaProjectId")
                 .setClientId("clientId")
                 .setClientSecret("clientSecret")

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -62,9 +62,6 @@ import org.junit.runners.JUnit4;
 public class ExternalAccountCredentialsTest {
 
   private static final String STS_URL = "https://www.sts.google.com";
-  private static final String ACCESS_TOKEN = "eya23tfgdfga2123as";
-  private static final String CLOUD_PLATFORM_SCOPE =
-      "https://www.googleapis.com/auth/cloud-platform";
 
   static class MockExternalAccountCredentialsTransportFactory implements HttpTransportFactory {
 
@@ -171,6 +168,25 @@ public class ExternalAccountCredentialsTest {
                 /* json= */ null, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
           }
         });
+  }
+
+  @Test
+  public void fromJson_invalidServiceAccountImpersonationUrl_throws() {
+    final GenericJson json = buildJsonIdentityPoolCredential();
+    json.put("service_account_impersonation_url", "invalid_url");
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            new ThrowingRunnable() {
+              @Override
+              public void run() {
+                ExternalAccountCredentials.fromJson(json, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+              }
+            });
+    assertEquals(
+        "Unable to determine target principal from service account impersonation URL.",
+        e.getMessage());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -231,7 +231,9 @@ public class GoogleCredentialsTest {
         new MockExternalAccountCredentialsTransportFactory();
     InputStream identityPoolCredentialStream =
         IdentityPoolCredentialsTest.writeIdentityPoolCredentialsStream(
-            transportFactory.transport.getStsUrl(), transportFactory.transport.getMetadataUrl());
+            transportFactory.transport.getStsUrl(),
+            transportFactory.transport.getMetadataUrl(),
+            /* serviceAccountImpersonationUrl= */ null);
 
     GoogleCredentials credentials =
         GoogleCredentials.fromStream(identityPoolCredentialStream, transportFactory);


### PR DESCRIPTION
When the service_account_impersonation_url is provided, we must exchange the external account GCP access token for a service account impersonated token.

This PR removes the duplicated code in ExternalAccountCredentials that makes the IAM generateAccessToken call and delegates it to ImpersonatedCredentials.
