### PR TITLE
fix: quotaProjectId should be applied for cached `getRequestMetadata(URI, Executor, RequestMetadataCallback)`

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -167,6 +167,11 @@ public class OAuth2Credentials extends Credentials {
     }
   }
 
+  /**
+   * Provide additional headers to return as request metadata.
+   *
+   * @return Map of additional headers.
+   */
   protected Map<String, List<String>> getAdditionalHeaders() {
     return EMPTY_EXTRA_HEADERS;
   }

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -170,7 +170,7 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Provide additional headers to return as request metadata.
    *
-   * @return Map of additional headers.
+   * @return additional headers
    */
   protected Map<String, List<String>> getAdditionalHeaders() {
     return EMPTY_EXTRA_HEADERS;

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -38,6 +38,7 @@ import com.google.auth.http.AuthHttpConstants;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -56,6 +57,7 @@ public class OAuth2Credentials extends Credentials {
 
   private static final long serialVersionUID = 4556936364828217687L;
   private static final long MINIMUM_TOKEN_MILLISECONDS = 60000L * 5L;
+  private static final Map<String, List<String>> EMPTY_EXTRA_HEADERS = Collections.emptyMap();
 
   // byte[] is serializable, so the lock variable can be final
   private final Object lock = new byte[0];
@@ -89,7 +91,7 @@ public class OAuth2Credentials extends Credentials {
    */
   protected OAuth2Credentials(AccessToken accessToken) {
     if (accessToken != null) {
-      useAccessToken(accessToken);
+      useAccessToken(accessToken, EMPTY_EXTRA_HEADERS);
     }
   }
 
@@ -154,13 +156,19 @@ public class OAuth2Credentials extends Credentials {
     synchronized (lock) {
       requestMetadata = null;
       temporaryAccess = null;
-      useAccessToken(Preconditions.checkNotNull(refreshAccessToken(), "new access token"));
+      useAccessToken(
+          Preconditions.checkNotNull(refreshAccessToken(), "new access token"),
+          getAdditionalHeaders());
       if (changeListeners != null) {
         for (CredentialsChangedListener listener : changeListeners) {
           listener.onChanged(this);
         }
       }
     }
+  }
+
+  protected Map<String, List<String>> getAdditionalHeaders() {
+    return EMPTY_EXTRA_HEADERS;
   }
 
   /**
@@ -177,12 +185,15 @@ public class OAuth2Credentials extends Credentials {
   }
 
   // Must be called under lock
-  private void useAccessToken(AccessToken token) {
+  private void useAccessToken(AccessToken token, Map<String, List<String>> additionalHeaders) {
     this.temporaryAccess = token;
     this.requestMetadata =
-        Collections.singletonMap(
-            AuthHttpConstants.AUTHORIZATION,
-            Collections.singletonList(OAuth2Utils.BEARER_PREFIX + token.getTokenValue()));
+        ImmutableMap.<String, List<String>>builder()
+            .put(
+                AuthHttpConstants.AUTHORIZATION,
+                Collections.singletonList(OAuth2Utils.BEARER_PREFIX + token.getTokenValue()))
+            .putAll(additionalHeaders)
+            .build();
   }
 
   // Must be called under lock

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -76,7 +76,6 @@ import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -601,8 +600,11 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
   @Override
   protected Map<String, List<String>> getAdditionalHeaders() {
-    return Collections.singletonMap(
-        QUOTA_PROJECT_ID_HEADER_KEY, Collections.singletonList(quotaProjectId));
+    Map<String, List<String>> headers = super.getAdditionalHeaders();
+    if (quotaProjectId != null) {
+      return addQuotaProjectIdToRequestMetadata(quotaProjectId, headers);
+    }
+    return headers;
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -76,6 +76,7 @@ import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -599,9 +600,9 @@ public class ServiceAccountCredentials extends GoogleCredentials
   }
 
   @Override
-  public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
-    Map<String, List<String>> requestMetadata = super.getRequestMetadata(uri);
-    return addQuotaProjectIdToRequestMetadata(quotaProjectId, requestMetadata);
+  protected Map<String, List<String>> getAdditionalHeaders() {
+    return Collections.singletonMap(
+        QUOTA_PROJECT_ID_HEADER_KEY, Collections.singletonList(quotaProjectId));
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -52,7 +52,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -279,8 +278,11 @@ public class UserCredentials extends GoogleCredentials implements QuotaProjectId
 
   @Override
   protected Map<String, List<String>> getAdditionalHeaders() {
-    return Collections.singletonMap(
-        QUOTA_PROJECT_ID_HEADER_KEY, Collections.singletonList(quotaProjectId));
+    Map<String, List<String>> headers = super.getAdditionalHeaders();
+    if (quotaProjectId != null) {
+      return addQuotaProjectIdToRequestMetadata(quotaProjectId, headers);
+    }
+    return headers;
   }
 
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -277,9 +278,9 @@ public class UserCredentials extends GoogleCredentials implements QuotaProjectId
   }
 
   @Override
-  public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
-    Map<String, List<String>> requestMetadata = super.getRequestMetadata(uri);
-    return addQuotaProjectIdToRequestMetadata(quotaProjectId, requestMetadata);
+  protected Map<String, List<String>> getAdditionalHeaders() {
+    return Collections.singletonMap(
+        QUOTA_PROJECT_ID_HEADER_KEY, Collections.singletonList(quotaProjectId));
   }
 
   @Override

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -625,6 +625,46 @@ public class UserCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
+  public void getRequestMetadataSetsQuotaProjectId() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
+    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+
+    UserCredentials userCredentials =
+        UserCredentials.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setClientSecret(CLIENT_SECRET)
+            .setRefreshToken(REFRESH_TOKEN)
+            .setQuotaProjectId("my-quota-project-id")
+            .setHttpTransportFactory(transportFactory)
+            .build();
+
+    Map<String, List<String>> metadata = userCredentials.getRequestMetadata();
+    assertTrue(metadata.containsKey("x-goog-user-project"));
+    List<String> headerValues = metadata.get("x-goog-user-project");
+    assertEquals(1, headerValues.size());
+    assertEquals("my-quota-project-id", headerValues.get(0));
+  }
+
+  @Test
+  public void getRequestMetadataNoQuotaProjectId() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
+    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+
+    UserCredentials userCredentials =
+        UserCredentials.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setClientSecret(CLIENT_SECRET)
+            .setRefreshToken(REFRESH_TOKEN)
+            .setHttpTransportFactory(transportFactory)
+            .build();
+
+    Map<String, List<String>> metadata = userCredentials.getRequestMetadata();
+    assertFalse(metadata.containsKey("x-goog-user-project"));
+  }
+
+  @Test
   public void getRequestMetadataWithCallback() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.fail;
 
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Clock;
+import com.google.auth.RequestMetadataCallback;
 import com.google.auth.TestUtils;
 import com.google.auth.http.AuthHttpConstants;
 import com.google.auth.oauth2.GoogleCredentialsTest.MockHttpTransportFactory;
@@ -56,6 +57,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -620,6 +622,41 @@ public class UserCredentialsTest extends BaseSerializationTest {
     assertEquals(userCredentials.getClientId(), restoredCredentials.getClientId());
     assertEquals(userCredentials.getClientSecret(), restoredCredentials.getClientSecret());
     assertEquals(userCredentials.getRefreshToken(), restoredCredentials.getRefreshToken());
+  }
+
+  @Test
+  public void getRequestMetadataWithCallback() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
+    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+
+    UserCredentials userCredentials =
+        UserCredentials.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setClientSecret(CLIENT_SECRET)
+            .setRefreshToken(REFRESH_TOKEN)
+            .setQuotaProjectId("my-quota-project-id")
+            .setHttpTransportFactory(transportFactory)
+            .build();
+    final Map<String, List<String>> plainMetadata = userCredentials.getRequestMetadata();
+    final AtomicBoolean success = new AtomicBoolean(false);
+    userCredentials.getRequestMetadata(
+        null,
+        null,
+        new RequestMetadataCallback() {
+          @Override
+          public void onSuccess(Map<String, List<String>> metadata) {
+            assertEquals(plainMetadata, metadata);
+            success.set(true);
+          }
+
+          @Override
+          public void onFailure(Throwable exception) {
+            fail("Should not throw a failure.");
+          }
+        });
+
+    assertTrue("Should have run onSuccess() callback", success.get());
   }
 
   static GenericJson writeUserJson(


### PR DESCRIPTION
Refactors the injection of the quota project id (and possibly other future headers) into the entrypoint that caches the request metadata (in OAuth2Credentials).

Fixes #507
