### PR TITLE
fix: support AWS_DEFAULT_REGION env var

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -243,11 +243,17 @@ public class AwsCredentials extends ExternalAccountCredentials {
     return URLEncoder.encode(token.toString(), "UTF-8");
   }
 
-  private String getAwsRegion() throws IOException {
+  @VisibleForTesting
+  String getAwsRegion() throws IOException {
     // For AWS Lambda, the region is retrieved through the AWS_REGION environment variable.
     String region = getEnvironmentProvider().getEnv("AWS_REGION");
     if (region != null) {
       return region;
+    }
+
+    String defaultRegion = getEnvironmentProvider().getEnv("AWS_DEFAULT_REGION");
+    if (defaultRegion != null) {
+      return defaultRegion;
     }
 
     if (awsCredentialSource.regionUrl == null || awsCredentialSource.regionUrl.isEmpty()) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
@@ -74,6 +74,7 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
   private static final String TOKEN_TYPE = "Bearer";
   private static final String ACCESS_TOKEN = "accessToken";
   private static final String SERVICE_ACCOUNT_ACCESS_TOKEN = "serviceAccountAccessToken";
+  private static final String AWS_REGION = "us-east-1b";
   private static final Long EXPIRES_IN = 3600L;
 
   private static final JsonFactory JSON_FACTORY = new GsonFactory();
@@ -120,7 +121,7 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
             if (AWS_REGION_URL.equals(url)) {
               return new MockLowLevelHttpResponse()
                   .setContentType("text/html")
-                  .setContent("us-east-1b");
+                  .setContent(AWS_REGION);
             }
             if (AWS_CREDENTIALS_URL.equals(url)) {
               return new MockLowLevelHttpResponse()
@@ -243,6 +244,10 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
 
   public String getAwsRegionUrl() {
     return AWS_REGION_URL;
+  }
+
+  public String getAwsRegion() {
+    return AWS_REGION;
   }
 
   public String getStsUrl() {


### PR DESCRIPTION
AWS_DEFAULT_REGION env var should be checked after AWS_REGION. See b/182491887.
