### PR TITLE
chore: add GCS_BUCKET env var

### DIFF
--- a/.kokoro/nightly/integration.cfg
+++ b/.kokoro/nightly/integration.cfg
@@ -35,3 +35,8 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
 }
+
+env_vars: {
+  key: "GCS_BUCKET"
+  value: "byoid-it-bucket"
+}

--- a/.kokoro/presubmit/integration.cfg
+++ b/.kokoro/presubmit/integration.cfg
@@ -31,3 +31,8 @@ env_vars: {
   key: "SECRET_MANAGER_KEYS"
   value: "java-it-service-account"
 }
+
+env_vars: {
+  key: "GCS_BUCKET"
+  value: "byoid-it-bucket"
+}


### PR DESCRIPTION
Fixes #618 ☕️

GCS_BUCKET env needed [here](https://github.com/googleapis/google-auth-library-java/blob/master/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java#L204) but set up got removed with synthtool update [here](https://github.com/googleapis/google-auth-library-java/commit/a5150b5b677cbb7e5f03e3ba9b43c5d7b030015e#diff-eb8df92b5a330fd9043fb3f02dd7c8f35196ac8484cd0ea1798f95ecbe395f92L39)
