### PR TITLE
chore: add integration.cfg to excludes list in synth.py

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -25,4 +25,6 @@ java.common_templates(excludes=[
     "samples/**",
     ".github/workflows/approve-readme.yaml",
     ".github/workflows/samples.yaml",
+    '.kokoro/nightly/integration.cfg',
+    '.kokoro/presubmit/integration.cfg',
 ])


### PR DESCRIPTION
Add integration.cfg files to excludes list in synth.py to prevent synthtool from removing the GCS_BUCKET environment variable.