### PR TITLE
fix: use orginal url as audience for self signed jwt if scheme or host is null

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -339,7 +339,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    */
   @VisibleForTesting
   static URI getUriForSelfSignedJWT(URI uri) {
-    if (uri == null|| (uri.getScheme() == null && uri.getHost() == null)) {
+    if (uri == null || (uri.getScheme() == null && uri.getHost() == null)) {
       return uri;
     }
     try {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -339,7 +339,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    */
   @VisibleForTesting
   static URI getUriForSelfSignedJWT(URI uri) {
-    if (uri == null || (uri.getScheme() == null && uri.getHost() == null)) {
+    if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
       return uri;
     }
     try {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -339,7 +339,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
    */
   @VisibleForTesting
   static URI getUriForSelfSignedJWT(URI uri) {
-    if (uri == null) {
+    if (uri == null|| (uri.getScheme() == null && uri.getHost() == null)) {
       return uri;
     }
     try {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -183,8 +183,6 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
 
   @Test
   public void getUriForSelfSignedJWT_forStaticAudience_returnsURI() {
-    assertNull(ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(null));
-
     URI uri = URI.create("compute.googleapis.com");
     URI expected = URI.create("compute.googleapis.com");
     assertEquals(expected, ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(uri));

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -182,6 +182,13 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
+  public void getUriForSelfSignedJWT_noHost() {
+    URI uri = URI.create("file:foo");
+    URI expected = URI.create("file:foo");
+    assertEquals(expected, ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(uri));
+  }
+
+  @Test
   public void getUriForSelfSignedJWT_forStaticAudience_returnsURI() {
     URI uri = URI.create("compute.googleapis.com");
     URI expected = URI.create("compute.googleapis.com");

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -182,6 +182,15 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
+  public void getUriForSelfSignedJWT_forStaticAudience_returnsURI() {
+    assertNull(ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(null));
+
+    URI uri = URI.create("compute.googleapis.com");
+    URI expected = URI.create("compute.googleapis.com");
+    assertEquals(expected, ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(uri));
+  }
+
+  @Test
   public void hasRequestMetadata_returnsTrue() throws IOException {
     Credentials credentials =
         ServiceAccountJwtAccessCredentials.fromPkcs8(


### PR DESCRIPTION
`getUriForSelfSignedJWT(URI uri)` is used to convert `"https://compute.googleapis.com/compute/v1/projects/"` to `"https://compute.googleapis.com/"`, so if the uri's scheme or host is null (for instance when user provided an uri like `compute.googleapis.com`), it should return the original uri.
