### PR TITLE
feat: allow scopes for self signed jwt

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtClaims.java
@@ -106,7 +106,9 @@ public abstract class JwtClaims implements Serializable {
    * @return true if all required fields have been set; false otherwise
    */
   public boolean isComplete() {
-    return getAudience() != null && getIssuer() != null && getSubject() != null;
+    boolean hasScopes =
+        getAdditionalClaims().containsKey("scope") && !getAdditionalClaims().get("scope").isEmpty();
+    return (getAudience() != null || hasScopes) && getIssuer() != null && getSubject() != null;
   }
 
   @AutoValue.Builder

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -1016,8 +1016,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
               + " providing uri to getRequestMetadata.");
     }
 
-    // If scopes are provided but we cannot use self signed JWT, then use scopes in the normal oauth
-    // way.
+    // If scopes are provided but we cannot use self signed JWT, then use scopes to get access
+    // token.
     if (!createScopedRequired() && !useJwtAccessWithScope) {
       return super.getRequestMetadata(uri);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -781,8 +781,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return lifetime;
   }
 
-  @VisibleForTesting
-  boolean getAlwaysUseJwtAccess() {
+  public boolean getAlwaysUseJwtAccess() {
     return alwaysUseJwtAccess;
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -54,7 +54,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -332,35 +331,17 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
     return true;
   }
 
-  /**
-   * Self signed JWT uses uri as audience, which should have the "https://{host}/" format. For
-   * instance, if the uri is "https://compute.googleapis.com/compute/v1/projects/", then this
-   * function returns "https://compute.googleapis.com/".
-   */
-  @VisibleForTesting
-  static URI getUriForSelfSignedJWT(URI uri) {
-    if (uri == null || uri.getScheme() == null || uri.getHost() == null) {
-      return uri;
-    }
-    try {
-      return new URI(uri.getScheme(), uri.getHost(), "/", null);
-    } catch (URISyntaxException unused) {
-      return uri;
-    }
-  }
-
   @Override
   public void getRequestMetadata(
       final URI uri, Executor executor, final RequestMetadataCallback callback) {
     // It doesn't use network. Only some CPU work on par with TLS handshake. So it's preferrable
     // to do it in the current thread, which is likely to be the network thread.
-    blockingGetToCallback(getUriForSelfSignedJWT(uri), callback);
+    blockingGetToCallback(uri, callback);
   }
 
   /** Provide the request metadata by putting an access JWT directly in the metadata. */
   @Override
   public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
-    uri = getUriForSelfSignedJWT(uri);
     if (uri == null) {
       if (defaultAudience != null) {
         uri = defaultAudience;

--- a/oauth2_http/javatests/com/google/auth/oauth2/JwtClaimsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/JwtClaimsTest.java
@@ -136,4 +136,16 @@ public class JwtClaimsTest {
     assertEquals("bar", mergedAdditionalClaims.get("foo"));
     assertEquals("qwer", mergedAdditionalClaims.get("asdf"));
   }
+
+  @Test
+  public void testIsComplete() {
+    // Test JwtClaim is complete if audience is not set but scope is provided.
+    JwtClaims claims =
+        JwtClaims.newBuilder()
+            .setIssuer("issuer-1")
+            .setSubject("subject-1")
+            .setAdditionalClaims(Collections.singletonMap("scope", "foo"))
+            .build();
+    assertTrue(claims.isComplete());
+  }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -1069,7 +1069,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
         String.format(
             "ServiceAccountCredentials{clientId=%s, clientEmail=%s, privateKeyId=%s, "
                 + "transportFactoryClassName=%s, tokenServerUri=%s, scopes=%s, defaultScopes=%s, serviceAccountUser=%s, "
-                + "quotaProjectId=%s, lifetime=3600, alwaysUseJwtAccess=false}",
+                + "quotaProjectId=%s, lifetime=3600, useJWTAccessWithScope=false}",
             CLIENT_ID,
             CLIENT_EMAIL,
             PRIVATE_KEY_ID,
@@ -1335,7 +1335,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setServiceAccountUser(USER)
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setAlwaysUseJwtAccess(true)
+            .setUseJWTAccessWithScope(true)
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -1355,7 +1355,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setServiceAccountUser(USER)
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setAlwaysUseJwtAccess(true)
+            .setUseJWTAccessWithScope(true)
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -1375,7 +1375,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setServiceAccountUser(USER)
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setAlwaysUseJwtAccess(true)
+            .setUseJWTAccessWithScope(true)
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
@@ -1395,7 +1395,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setProjectId(PROJECT_ID)
             .setQuotaProjectId("my-quota-project-id")
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setAlwaysUseJwtAccess(true)
+            .setUseJWTAccessWithScope(true)
             .build();
 
     final AtomicBoolean success = new AtomicBoolean(false);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -1463,8 +1463,10 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(CLIENT_EMAIL, signature.getPayload().getSubject());
     if (expectedScopeClaim != null) {
       assertEquals(expectedScopeClaim, signature.getPayload().get("scope"));
+      assertFalse(signature.getPayload().containsKey("aud"));
     } else {
       assertEquals(JWT_AUDIENCE, signature.getPayload().getAudience());
+      assertFalse(signature.getPayload().containsKey("scope"));
     }
     assertEquals(PRIVATE_KEY_ID, signature.getHeader().getKeyId());
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -106,7 +106,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   private static final String PROJECT_ID = "project-id";
   private static final Collection<String> EMPTY_SCOPES = Collections.emptyList();
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
-  private static final String JWT_AUDIENCE = "http://googleapis.com/testapi/v1/foo";
+  private static final String JWT_AUDIENCE = "http://googleapis.com/";
   private static final HttpTransportFactory DUMMY_TRANSPORT_FACTORY =
       new MockTokenServerTransportFactory();
   public static final String DEFAULT_ID_TOKEN =
@@ -419,12 +419,12 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             null);
 
     try {
-      credentials.getRequestMetadata(CALL_URI);
+      credentials.getRequestMetadata(null);
       fail("Should not be able to get token without scopes");
     } catch (IOException e) {
       assertTrue(
           "expected to fail with exception",
-          e.getMessage().contains("Scopes are not configured for service account"));
+          e.getMessage().contains("Scopes and uri are not configured for service account"));
     }
 
     GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
@@ -1069,7 +1069,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
         String.format(
             "ServiceAccountCredentials{clientId=%s, clientEmail=%s, privateKeyId=%s, "
                 + "transportFactoryClassName=%s, tokenServerUri=%s, scopes=%s, defaultScopes=%s, serviceAccountUser=%s, "
-                + "quotaProjectId=%s, lifetime=3600, useJWTAccessWithScope=false}",
+                + "quotaProjectId=%s, lifetime=3600, useJwtAccessWithScope=false}",
             CLIENT_ID,
             CLIENT_EMAIL,
             PRIVATE_KEY_ID,
@@ -1232,6 +1232,29 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
+  public void getUriForSelfSignedJWT() {
+    assertNull(ServiceAccountCredentials.getUriForSelfSignedJWT(null));
+
+    URI uri = URI.create("https://compute.googleapis.com/compute/v1/projects/");
+    URI expected = URI.create("https://compute.googleapis.com/");
+    assertEquals(expected, ServiceAccountCredentials.getUriForSelfSignedJWT(uri));
+  }
+
+  @Test
+  public void getUriForSelfSignedJWT_noHost() {
+    URI uri = URI.create("file:foo");
+    URI expected = URI.create("file:foo");
+    assertEquals(expected, ServiceAccountCredentials.getUriForSelfSignedJWT(uri));
+  }
+
+  @Test
+  public void getUriForSelfSignedJWT_forStaticAudience_returnsURI() {
+    URI uri = URI.create("compute.googleapis.com");
+    URI expected = URI.create("compute.googleapis.com");
+    assertEquals(expected, ServiceAccountCredentials.getUriForSelfSignedJWT(uri));
+  }
+
+  @Test
   public void getRequestMetadataSetsQuotaProjectId() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID, "unused-client-secret");
@@ -1335,7 +1358,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setServiceAccountUser(USER)
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setUseJWTAccessWithScope(true)
+            .setUseJwtAccessWithScope(true)
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -1351,11 +1374,9 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setClientEmail(CLIENT_EMAIL)
             .setPrivateKey(privateKey)
             .setPrivateKeyId(PRIVATE_KEY_ID)
-            .setScopes(null, SCOPES)
             .setServiceAccountUser(USER)
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setUseJWTAccessWithScope(true)
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
@@ -1375,7 +1396,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setServiceAccountUser(USER)
             .setProjectId(PROJECT_ID)
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setUseJWTAccessWithScope(true)
+            .setUseJwtAccessWithScope(true)
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(null);
@@ -1395,7 +1416,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setProjectId(PROJECT_ID)
             .setQuotaProjectId("my-quota-project-id")
             .setHttpTransportFactory(new MockTokenServerTransportFactory())
-            .setUseJWTAccessWithScope(true)
+            .setUseJwtAccessWithScope(true)
+            .setScopes(SCOPES)
             .build();
 
     final AtomicBoolean success = new AtomicBoolean(false);
@@ -1406,7 +1428,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
           @Override
           public void onSuccess(Map<String, List<String>> metadata) {
             try {
-              verifyJwtAccess(metadata, null);
+              verifyJwtAccess(metadata, "dummy.scope");
             } catch (IOException e) {
               fail("Should not throw a failure");
             }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountJwtAccessCredentialsTest.java
@@ -92,7 +92,6 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   private static final String JWT_ACCESS_PREFIX =
       ServiceAccountJwtAccessCredentials.JWT_ACCESS_PREFIX;
   private static final URI CALL_URI = URI.create("http://googleapis.com/testapi/v1/foo");
-  private static final URI CALL_URI_AUDIENCE = URI.create("http://googleapis.com/");
   private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
   private static final String QUOTA_PROJECT = "sample-quota-project-id";
 
@@ -173,29 +172,6 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
   }
 
   @Test
-  public void getUriForSelfSignedJWT() {
-    assertNull(ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(null));
-
-    URI uri = URI.create("https://compute.googleapis.com/compute/v1/projects/");
-    URI expected = URI.create("https://compute.googleapis.com/");
-    assertEquals(expected, ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(uri));
-  }
-
-  @Test
-  public void getUriForSelfSignedJWT_noHost() {
-    URI uri = URI.create("file:foo");
-    URI expected = URI.create("file:foo");
-    assertEquals(expected, ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(uri));
-  }
-
-  @Test
-  public void getUriForSelfSignedJWT_forStaticAudience_returnsURI() {
-    URI uri = URI.create("compute.googleapis.com");
-    URI expected = URI.create("compute.googleapis.com");
-    assertEquals(expected, ServiceAccountJwtAccessCredentials.getUriForSelfSignedJWT(uri));
-  }
-
-  @Test
   public void hasRequestMetadata_returnsTrue() throws IOException {
     Credentials credentials =
         ServiceAccountJwtAccessCredentials.fromPkcs8(
@@ -224,7 +200,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
 
-    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, CALL_URI_AUDIENCE, SA_PRIVATE_KEY_ID);
+    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, CALL_URI, SA_PRIVATE_KEY_ID);
   }
 
   @Test
@@ -329,7 +305,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
     credentials.getRequestMetadata(CALL_URI, executor, callback);
     assertEquals(0, executor.numTasks());
     assertNotNull(callback.metadata);
-    verifyJwtAccess(callback.metadata, SA_CLIENT_EMAIL, CALL_URI_AUDIENCE, SA_PRIVATE_KEY_ID);
+    verifyJwtAccess(callback.metadata, SA_CLIENT_EMAIL, CALL_URI, SA_PRIVATE_KEY_ID);
   }
 
   @Test
@@ -678,7 +654,7 @@ public class ServiceAccountJwtAccessCredentialsTest extends BaseSerializationTes
 
     assertNotNull(credentials);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
-    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, CALL_URI_AUDIENCE, SA_PRIVATE_KEY_ID);
+    verifyJwtAccess(metadata, SA_CLIENT_EMAIL, CALL_URI, SA_PRIVATE_KEY_ID);
   }
 
   @Test


### PR DESCRIPTION
This PR allows self signed jwt to use scopes. 
AIP: https://google.aip.dev/auth/4111
googlers see: go/yoshi-self-signed-jwt-phase-2

In ServiceAccountCredentials, this PR now uses JwtCredentials instead of ServiceAccountJwtCredentials. As a result, this PR reverted the changes made to ServiceAccountJwtCredentials in #572 #642 so the ServiceAccountJwtCredentials is the same as what it was before phrase 1. 

The current behavior for ServiceAccountCredentials is:
```
if (hasScopes):
    if (useJwtAccessWithScope):
        // create a self signed JWT with "scope" set to the scope
    else:
        // call oauth token endpoint
else:
        // create a self signed JWT with modified uri as the audience
``` 

Follow up PRs:
(1) gax-java: https://github.com/googleapis/gax-java/pull/1420
(2) gapic-generator-java: it will be a very simple change, same as https://github.com/arithmetic1728/java-kms/pull/2/files. Since Gapic clients will always sets scopes, once self signed JWT is enabled in the future, it will always use self signed JWT with scope claim.

This PR has been tested with cloudkms: https://github.com/arithmetic1728/java-kms/pull/2/files