### PR TITLE
feat: downscoping with credential access boundaries

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.api.client.json.GenericJson;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/**
+ * Defines an upper bound of permissions available for a GCP credential via {@link
+ * AccessBoundaryRule}s.
+ *
+ * <p>See <a href='https://cloud.google.com/iam/docs/downscoping-short-lived-credentials'>for more
+ * information.</a>
+ */
+public final class CredentialAccessBoundary {
+
+  private static final int RULES_SIZE_LIMIT = 10;
+
+  private final List<AccessBoundaryRule> accessBoundaryRules;
+
+  CredentialAccessBoundary(List<AccessBoundaryRule> accessBoundaryRules) {
+    checkNotNull(accessBoundaryRules);
+    checkArgument(
+        !accessBoundaryRules.isEmpty(), "At least one access boundary rule must be provided.");
+    checkArgument(
+        accessBoundaryRules.size() < RULES_SIZE_LIMIT,
+        String.format(
+            "The provided list has more than %s access boundary rules.", RULES_SIZE_LIMIT));
+    this.accessBoundaryRules = accessBoundaryRules;
+  }
+
+  /**
+   * Internal method that returns the JSON string representation of the credential access boundary.
+   */
+  String toJson() {
+    List<GenericJson> rules = new ArrayList<>();
+    for (AccessBoundaryRule rule : accessBoundaryRules) {
+      GenericJson ruleJson = new GenericJson();
+      ruleJson.setFactory(OAuth2Utils.JSON_FACTORY);
+
+      ruleJson.put("availableResource", rule.getAvailableResource());
+      ruleJson.put("availablePermissions", rule.getAvailablePermissions());
+
+      AccessBoundaryRule.AvailabilityCondition availabilityCondition =
+          rule.getAvailabilityCondition();
+      if (availabilityCondition != null) {
+        GenericJson availabilityConditionJson = new GenericJson();
+        availabilityConditionJson.setFactory(OAuth2Utils.JSON_FACTORY);
+
+        availabilityConditionJson.put("expression", availabilityCondition.getExpression());
+        if (availabilityCondition.getTitle() != null) {
+          availabilityConditionJson.put("title", availabilityCondition.getTitle());
+        }
+        if (availabilityCondition.getDescription() != null) {
+          availabilityConditionJson.put("description", availabilityCondition.getDescription());
+        }
+
+        ruleJson.put("availabilityCondition", availabilityConditionJson);
+      }
+      rules.add(ruleJson);
+    }
+    GenericJson accessBoundaryRulesJson = new GenericJson();
+    accessBoundaryRulesJson.setFactory(OAuth2Utils.JSON_FACTORY);
+    accessBoundaryRulesJson.put("accessBoundaryRules", rules);
+
+    GenericJson json = new GenericJson();
+    json.setFactory(OAuth2Utils.JSON_FACTORY);
+    json.put("accessBoundary", accessBoundaryRulesJson);
+    return json.toString();
+  }
+
+  public List<AccessBoundaryRule> getAccessBoundaryRules() {
+    return accessBoundaryRules;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private List<AccessBoundaryRule> accessBoundaryRules;
+
+    private Builder() {}
+
+    /**
+     * Sets the list of {@link AccessBoundaryRule}'s.
+     *
+     * <p>This list must not exceed 10 rules.
+     */
+    public Builder setRules(List<AccessBoundaryRule> rule) {
+      accessBoundaryRules = new ArrayList<>(checkNotNull(rule));
+      return this;
+    }
+
+    public CredentialAccessBoundary.Builder addRule(AccessBoundaryRule rule) {
+      if (accessBoundaryRules == null) {
+        accessBoundaryRules = new ArrayList<>();
+      }
+      accessBoundaryRules.add(checkNotNull(rule));
+      return this;
+    }
+
+    public CredentialAccessBoundary build() {
+      return new CredentialAccessBoundary(accessBoundaryRules);
+    }
+  }
+
+  /**
+   * Defines an upper bound of permissions on a particular resource.
+   *
+   * <p>The following snippet shows an AccessBoundaryRule that applies to the Cloud Storage bucket
+   * bucket-one to set the upper bound of permissions to those defined by the
+   * roles/storage.objectViewer role.
+   *
+   * <pre><code>
+   * AccessBoundaryRule rule = AccessBoundaryRule.newBuilder()
+   *   .setAvailableResource("//storage.googleapis.com/projects/_/buckets/bucket-one")
+   *   .addAvailablePermission("inRole:roles/storage.objectViewer")
+   *   .build();
+   * </code></pre>
+   */
+  public static final class AccessBoundaryRule {
+
+    private final String availableResource;
+    private final List<String> availablePermissions;
+
+    @Nullable private final AvailabilityCondition availabilityCondition;
+
+    AccessBoundaryRule(
+        String availableResource,
+        List<String> availablePermissions,
+        @Nullable AvailabilityCondition availabilityCondition) {
+      this.availableResource = checkNotNull(availableResource);
+      this.availablePermissions = new ArrayList<>(checkNotNull(availablePermissions));
+      this.availabilityCondition = availabilityCondition;
+
+      checkArgument(!availableResource.isEmpty(), "The provided availableResource is empty.");
+      checkArgument(
+          !availablePermissions.isEmpty(), "The list of provided availablePermissions is empty.");
+      for (String permission : availablePermissions) {
+        if (permission == null) {
+          throw new IllegalArgumentException("One of the provided available permissions is null.");
+        }
+        if (permission.isEmpty()) {
+          throw new IllegalArgumentException("One of the provided available permissions is empty.");
+        }
+      }
+    }
+
+    public String getAvailableResource() {
+      return availableResource;
+    }
+
+    public List<String> getAvailablePermissions() {
+      return availablePermissions;
+    }
+
+    @Nullable
+    public AvailabilityCondition getAvailabilityCondition() {
+      return availabilityCondition;
+    }
+
+    public static Builder newBuilder() {
+      return new Builder();
+    }
+
+    public static class Builder {
+      private String availableResource;
+      private List<String> availablePermissions;
+
+      @Nullable private AvailabilityCondition availabilityCondition;
+
+      private Builder() {}
+
+      /**
+       * Sets the available resource, which is the full resource name of the GCP resource to allow
+       * access to.
+       *
+       * <p>For example: "//storage.googleapis.com/projects/_/buckets/example".
+       */
+      public Builder setAvailableResource(String availableResource) {
+        this.availableResource = availableResource;
+        return this;
+      }
+
+      /**
+       * Sets the list of permissions that can be used on the resource. This should be a list of IAM
+       * roles prefixed by inRole.
+       *
+       * <p>For example: {"inRole:roles/storage.objectViewer"}.
+       */
+      public Builder setAvailablePermissions(List<String> availablePermissions) {
+        this.availablePermissions = new ArrayList<>(checkNotNull(availablePermissions));
+        return this;
+      }
+
+      /**
+       * Adds a permission that can be used on the resource. This should be an IAM role prefixed by
+       * inRole.
+       *
+       * <p>For example: "inRole:roles/storage.objectViewer".
+       */
+      public Builder addAvailablePermission(String availablePermission) {
+        if (availablePermissions == null) {
+          availablePermissions = new ArrayList<>();
+        }
+        availablePermissions.add(availablePermission);
+        return this;
+      }
+
+      /**
+       * Sets the availability condition which is an IAM condition that defines constraints to apply
+       * to the token expressed in CEL format.
+       */
+      public Builder setAvailabilityCondition(AvailabilityCondition availabilityCondition) {
+        this.availabilityCondition = availabilityCondition;
+        return this;
+      }
+
+      public AccessBoundaryRule build() {
+        return new AccessBoundaryRule(
+            availableResource, availablePermissions, availabilityCondition);
+      }
+    }
+
+    /**
+     * An optional condition that can be used as part of a {@link AccessBoundaryRule} to further
+     * restrict permissions.
+     *
+     * <p>For example, you can define an AvailabilityCondition that applies to a set of Cloud
+     * Storage objects whose names start with auth:
+     *
+     * <pre><code>
+     * AvailabilityCondition availabilityCondition = AvailabilityCondition.newBuilder()
+     *   .setExpression("resource.name.startsWith('projects/_/buckets/bucket-123/objects/auth')")
+     *   .build();
+     * </code></pre>
+     */
+    public static final class AvailabilityCondition {
+      private final String expression;
+
+      @Nullable private final String title;
+      @Nullable private final String description;
+
+      AvailabilityCondition(
+          String expression, @Nullable String title, @Nullable String description) {
+        this.expression = checkNotNull(expression);
+        this.title = title;
+        this.description = description;
+
+        checkArgument(!expression.isEmpty(), "The provided expression is empty.");
+      }
+
+      public String getExpression() {
+        return expression;
+      }
+
+      @Nullable
+      public String getTitle() {
+        return title;
+      }
+
+      @Nullable
+      public String getDescription() {
+        return description;
+      }
+
+      public static Builder newBuilder() {
+        return new Builder();
+      }
+
+      public static final class Builder {
+        private String expression;
+
+        @Nullable private String title;
+        @Nullable private String description;
+
+        private Builder() {}
+
+        /**
+         * Sets the required expression which must be defined in Common Expression Language (CEL)
+         * format.
+         *
+         * <p>This expression specifies the Cloud Storage object where permissions are available.
+         * See <a href='https://cloud.google.com/iam/docs/conditions-overview#cel'>for more
+         * information.</a>
+         */
+        public Builder setExpression(String expression) {
+          this.expression = expression;
+          return this;
+        }
+
+        /** Sets the optional title that identifies the purpose of the condition. */
+        public Builder setTitle(String title) {
+          this.title = title;
+          return this;
+        }
+
+        /** Sets the description that details the purpose of the condition. */
+        public Builder setDescription(String description) {
+          this.description = description;
+          return this;
+        }
+
+        public AvailabilityCondition build() {
+          return new AvailabilityCondition(expression, title, description);
+        }
+      }
+    }
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
@@ -129,7 +129,20 @@ public final class DownscopedCredentials extends OAuth2Credentials {
             .setInternalOptions(credentialAccessBoundary.toJson())
             .build();
 
-    return handler.exchangeToken().getAccessToken();
+    AccessToken downscopedAccessToken = handler.exchangeToken().getAccessToken();
+
+    // The STS endpoint will only return the expiration time for the downscoped token if the
+    // original access token represents a service account.
+    // The downscoped token's expiration time will always match the source credential expiration.
+    // When no expires_in is returned, we can copy the source credential's expiration time.
+    if (downscopedAccessToken.getExpirationTime() == null) {
+      AccessToken sourceAccessToken = this.sourceCredential.getAccessToken();
+      if (sourceAccessToken.getExpirationTime() != null) {
+        return new AccessToken(
+            downscopedAccessToken.getTokenValue(), sourceAccessToken.getExpirationTime());
+      }
+    }
+    return downscopedAccessToken;
   }
 
   public GoogleCredentials getSourceCredentials() {

--- a/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * DownscopedCredentials enables the ability to downscope, or restrict, the Identity and Access
+ * Management (IAM) permissions that a short-lived credential can use for Cloud Storage.
+ *
+ * <p>To downscope permissions you must define a {@link CredentialAccessBoundary} which specifies
+ * the upper bound of permissions that the credential can access. You must also provide a source
+ * credential which will be used to acquire the downscoped credential.
+ *
+ * <p>See <a href='https://cloud.google.com/iam/docs/downscoping-short-lived-credentials'>for more
+ * information.</a>
+ *
+ * <p>Usage:
+ *
+ * <pre><code>
+ * GoogleCredentials sourceCredentials = GoogleCredentials.getApplicationDefault();
+ *
+ * CredentialAccessBoundary.AccessBoundaryRule rule =
+ *     CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+ *         .setAvailableResource(
+ *             "//storage.googleapis.com/projects/_/buckets/bucket")
+ *         .addAvailablePermission("inRole:roles/storage.objectViewer")
+ *         .build();
+ *
+ * DownscopedCredentials downscopedCredentials =
+ *     DownscopedCredentials.newBuilder()
+ *         .setSourceCredential(credentials)
+ *         .setCredentialAccessBoundary(
+ *             CredentialAccessBoundary.newBuilder().addRule(rule).build())
+ *         .build();
+ *
+ * AccessToken accessToken = downscopedCredentials.refreshAccessToken();
+ *
+ * OAuth2Credentials credentials = OAuth2Credentials.create(accessToken);
+ *
+ * Storage storage =
+ * StorageOptions.newBuilder().setCredentials(credentials).build().getService();
+ *
+ * Blob blob = storage.get(BlobId.of("bucket", "object"));
+ * System.out.printf("Blob %s retrieved.", blob.getBlobId());
+ * </code></pre>
+ *
+ * Note that {@link OAuth2CredentialsWithRefresh} can instead be used to consume the downscoped
+ * token, allowing for automatic token refreshes by providing a {@link
+ * OAuth2CredentialsWithRefresh.OAuth2RefreshHandler}.
+ */
+public final class DownscopedCredentials extends OAuth2Credentials {
+
+  private static final String TOKEN_EXCHANGE_ENDPOINT = "https://sts.googleapis.com/v1/token";
+
+  private static final String CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  private final GoogleCredentials sourceCredential;
+  private final CredentialAccessBoundary credentialAccessBoundary;
+  private final transient HttpTransportFactory transportFactory;
+
+  private DownscopedCredentials(
+      GoogleCredentials sourceCredential,
+      CredentialAccessBoundary credentialAccessBoundary,
+      HttpTransportFactory transportFactory) {
+    this.transportFactory =
+        firstNonNull(
+            transportFactory,
+            getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
+    this.sourceCredential =
+        checkNotNull(sourceCredential.createScoped(Arrays.asList(CLOUD_PLATFORM_SCOPE)));
+    this.credentialAccessBoundary = checkNotNull(credentialAccessBoundary);
+  }
+
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    try {
+      this.sourceCredential.refreshIfExpired();
+    } catch (IOException e) {
+      throw new IOException("Unable to refresh the provided source credential.", e);
+    }
+
+    StsTokenExchangeRequest request =
+        StsTokenExchangeRequest.newBuilder(
+                sourceCredential.getAccessToken().getTokenValue(),
+                OAuth2Utils.TOKEN_TYPE_ACCESS_TOKEN)
+            .setRequestTokenType(OAuth2Utils.TOKEN_TYPE_ACCESS_TOKEN)
+            .build();
+
+    StsRequestHandler handler =
+        StsRequestHandler.newBuilder(
+                TOKEN_EXCHANGE_ENDPOINT, request, transportFactory.create().createRequestFactory())
+            .setInternalOptions(credentialAccessBoundary.toJson())
+            .build();
+
+    return handler.exchangeToken().getAccessToken();
+  }
+
+  public GoogleCredentials getSourceCredentials() {
+    return sourceCredential;
+  }
+
+  public CredentialAccessBoundary getCredentialAccessBoundary() {
+    return credentialAccessBoundary;
+  }
+
+  @VisibleForTesting
+  HttpTransportFactory getTransportFactory() {
+    return transportFactory;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder extends OAuth2Credentials.Builder {
+
+    private GoogleCredentials sourceCredential;
+    private CredentialAccessBoundary credentialAccessBoundary;
+    private HttpTransportFactory transportFactory;
+
+    private Builder() {}
+
+    public Builder setSourceCredential(GoogleCredentials sourceCredential) {
+      this.sourceCredential = sourceCredential;
+      return this;
+    }
+
+    public Builder setCredentialAccessBoundary(CredentialAccessBoundary credentialAccessBoundary) {
+      this.credentialAccessBoundary = credentialAccessBoundary;
+      return this;
+    }
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      this.transportFactory = transportFactory;
+      return this;
+    }
+
+    public DownscopedCredentials build() {
+      return new DownscopedCredentials(
+          sourceCredential, credentialAccessBoundary, transportFactory);
+    }
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.IOException;
+
+/**
+ * A refreshable alternative to {@link OAuth2Credentials}.
+ *
+ * <p>To enable automatic token refreshes, you must provide an {@link OAuth2RefreshHandler}.
+ */
+public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
+
+  /** Interface for the refresh handler. */
+  public interface OAuth2RefreshHandler {
+    AccessToken refreshAccessToken() throws IOException;
+  }
+
+  private final OAuth2RefreshHandler refreshHandler;
+
+  protected OAuth2CredentialsWithRefresh(
+      AccessToken accessToken, OAuth2RefreshHandler refreshHandler) {
+    super(accessToken);
+    this.refreshHandler = checkNotNull(refreshHandler);
+  }
+
+  /** Refreshes the access token using the provided {@link OAuth2RefreshHandler}. */
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    // Delegate refresh to the provided refresh handler.
+    return refreshHandler.refreshAccessToken();
+  }
+
+  /** Returns the provided {@link OAuth2RefreshHandler}. */
+  public OAuth2RefreshHandler getRefreshHandler() {
+    return refreshHandler;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder extends OAuth2Credentials.Builder {
+
+    private OAuth2RefreshHandler refreshHandler;
+
+    private Builder() {}
+
+    @Override
+    public Builder setAccessToken(AccessToken token) {
+      super.setAccessToken(token);
+      return this;
+    }
+
+    public Builder setRefreshHandler(OAuth2RefreshHandler handler) {
+      this.refreshHandler = handler;
+      return this;
+    }
+
+    public OAuth2CredentialsWithRefresh build() {
+      return new OAuth2CredentialsWithRefresh(getAccessToken(), refreshHandler);
+    }
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
@@ -52,6 +52,13 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
   protected OAuth2CredentialsWithRefresh(
       AccessToken accessToken, OAuth2RefreshHandler refreshHandler) {
     super(accessToken);
+
+    // If no expirationTime is provided, the token will never be refreshed.
+    if (accessToken != null && accessToken.getExpirationTime() == null) {
+      throw new IllegalArgumentException(
+          "The provided access token must contain the expiration time.");
+    }
+
     this.refreshHandler = checkNotNull(refreshHandler);
   }
 
@@ -77,12 +84,17 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
 
     private Builder() {}
 
+    /**
+     * Sets the {@link AccessToken} to be consumed. It must contain an expiration time otherwise an
+     * {@link IllegalArgumentException} will be thrown.
+     */
     @Override
     public Builder setAccessToken(AccessToken token) {
       super.setAccessToken(token);
       return this;
     }
 
+    /** Sets the {@link OAuth2RefreshHandler} to be used for token refreshes. */
     public Builder setRefreshHandler(OAuth2RefreshHandler handler) {
       this.refreshHandler = handler;
       return this;

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -57,6 +57,8 @@ import java.util.Map;
 class OAuth2Utils {
   static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
 
+  static final String TOKEN_TYPE_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token";
+
   static final URI TOKEN_SERVER_URI = URI.create("https://oauth2.googleapis.com/token");
   static final URI TOKEN_REVOKE_URI = URI.create("https://oauth2.googleapis.com/revoke");
   static final URI USER_AUTH_URI = URI.create("https://accounts.google.com/o/oauth2/auth");

--- a/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
+++ b/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
@@ -53,8 +53,6 @@ import javax.annotation.Nullable;
 final class StsRequestHandler {
   private static final String TOKEN_EXCHANGE_GRANT_TYPE =
       "urn:ietf:params:oauth:grant-type:token-exchange";
-  private static final String REQUESTED_TOKEN_TYPE =
-      "urn:ietf:params:oauth:token-type:access_token";
   private static final String PARSE_ERROR_PREFIX = "Error parsing token response.";
 
   private final String tokenExchangeEndpoint;
@@ -140,7 +138,9 @@ final class StsRequestHandler {
     // Set the requested token type, which defaults to
     // urn:ietf:params:oauth:token-type:access_token.
     String requestTokenType =
-        request.hasRequestedTokenType() ? request.getRequestedTokenType() : REQUESTED_TOKEN_TYPE;
+        request.hasRequestedTokenType()
+            ? request.getRequestedTokenType()
+            : OAuth2Utils.TOKEN_TYPE_ACCESS_TOKEN;
     tokenRequest.set("requested_token_type", requestTokenType);
 
     // Add other optional params, if possible.

--- a/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
+++ b/oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java
@@ -168,13 +168,14 @@ final class StsRequestHandler {
     String issuedTokenType =
         OAuth2Utils.validateString(responseData, "issued_token_type", PARSE_ERROR_PREFIX);
     String tokenType = OAuth2Utils.validateString(responseData, "token_type", PARSE_ERROR_PREFIX);
-    Long expiresInSeconds =
-        OAuth2Utils.validateLong(responseData, "expires_in", PARSE_ERROR_PREFIX);
 
     StsTokenExchangeResponse.Builder builder =
-        StsTokenExchangeResponse.newBuilder(
-            accessToken, issuedTokenType, tokenType, expiresInSeconds);
+        StsTokenExchangeResponse.newBuilder(accessToken, issuedTokenType, tokenType);
 
+    if (responseData.containsKey("expires_in")) {
+      builder.setExpiresInSeconds(
+          OAuth2Utils.validateLong(responseData, "expires_in", PARSE_ERROR_PREFIX));
+    }
     if (responseData.containsKey("refresh_token")) {
       builder.setRefreshToken(
           OAuth2Utils.validateString(responseData, "refresh_token", PARSE_ERROR_PREFIX));

--- a/oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeResponse.java
+++ b/oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeResponse.java
@@ -46,8 +46,8 @@ final class StsTokenExchangeResponse {
   private final AccessToken accessToken;
   private final String issuedTokenType;
   private final String tokenType;
-  private final Long expiresInSeconds;
 
+  @Nullable private final Long expiresInSeconds;
   @Nullable private final String refreshToken;
   @Nullable private final List<String> scopes;
 
@@ -55,22 +55,25 @@ final class StsTokenExchangeResponse {
       String accessToken,
       String issuedTokenType,
       String tokenType,
-      Long expiresInSeconds,
+      @Nullable Long expiresInSeconds,
       @Nullable String refreshToken,
       @Nullable List<String> scopes) {
     checkNotNull(accessToken);
-    this.expiresInSeconds = checkNotNull(expiresInSeconds);
-    long expiresAtMilliseconds = System.currentTimeMillis() + expiresInSeconds * 1000L;
-    this.accessToken = new AccessToken(accessToken, new Date(expiresAtMilliseconds));
+
+    this.expiresInSeconds = expiresInSeconds;
+    Long expiresAtMilliseconds =
+        expiresInSeconds == null ? null : System.currentTimeMillis() + expiresInSeconds * 1000L;
+    Date date = expiresAtMilliseconds == null ? null : new Date(expiresAtMilliseconds);
+    this.accessToken = new AccessToken(accessToken, date);
+
     this.issuedTokenType = checkNotNull(issuedTokenType);
     this.tokenType = checkNotNull(tokenType);
     this.refreshToken = refreshToken;
     this.scopes = scopes;
   }
 
-  public static Builder newBuilder(
-      String accessToken, String issuedTokenType, String tokenType, Long expiresIn) {
-    return new Builder(accessToken, issuedTokenType, tokenType, expiresIn);
+  public static Builder newBuilder(String accessToken, String issuedTokenType, String tokenType) {
+    return new Builder(accessToken, issuedTokenType, tokenType);
   }
 
   public AccessToken getAccessToken() {
@@ -85,6 +88,7 @@ final class StsTokenExchangeResponse {
     return tokenType;
   }
 
+  @Nullable
   public Long getExpiresInSeconds() {
     return expiresInSeconds;
   }
@@ -106,17 +110,20 @@ final class StsTokenExchangeResponse {
     private final String accessToken;
     private final String issuedTokenType;
     private final String tokenType;
-    private final Long expiresInSeconds;
 
+    @Nullable private Long expiresInSeconds;
     @Nullable private String refreshToken;
     @Nullable private List<String> scopes;
 
-    private Builder(
-        String accessToken, String issuedTokenType, String tokenType, Long expiresInSeconds) {
+    private Builder(String accessToken, String issuedTokenType, String tokenType) {
       this.accessToken = accessToken;
       this.issuedTokenType = issuedTokenType;
       this.tokenType = tokenType;
+    }
+
+    public StsTokenExchangeResponse.Builder setExpiresInSeconds(long expiresInSeconds) {
       this.expiresInSeconds = expiresInSeconds;
+      return this;
     }
 
     public StsTokenExchangeResponse.Builder setRefreshToken(String refreshToken) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/CredentialAccessBoundaryTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/CredentialAccessBoundaryTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import com.google.auth.oauth2.CredentialAccessBoundary.AccessBoundaryRule;
+import com.google.auth.oauth2.CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link CredentialAccessBoundary} and encompassing classes. */
+@RunWith(JUnit4.class)
+public class CredentialAccessBoundaryTest {
+
+  @Test
+  public void credentialAccessBoundary() {
+    AvailabilityCondition availabilityCondition =
+        AvailabilityCondition.newBuilder().setExpression("expression").build();
+
+    AccessBoundaryRule firstRule =
+        AccessBoundaryRule.newBuilder()
+            .setAvailableResource("firstResource")
+            .addAvailablePermission("firstPermission")
+            .setAvailabilityCondition(availabilityCondition)
+            .build();
+
+    AccessBoundaryRule secondRule =
+        AccessBoundaryRule.newBuilder()
+            .setAvailableResource("secondResource")
+            .addAvailablePermission("secondPermission")
+            .build();
+
+    CredentialAccessBoundary credentialAccessBoundary =
+        CredentialAccessBoundary.newBuilder()
+            .setRules(Arrays.asList(firstRule, secondRule))
+            .build();
+
+    assertEquals(2, credentialAccessBoundary.getAccessBoundaryRules().size());
+
+    AccessBoundaryRule first = credentialAccessBoundary.getAccessBoundaryRules().get(0);
+    assertEquals(firstRule, first);
+    assertEquals("firstResource", first.getAvailableResource());
+    assertEquals(1, first.getAvailablePermissions().size());
+    assertEquals("firstPermission", first.getAvailablePermissions().get(0));
+    assertEquals(availabilityCondition, first.getAvailabilityCondition());
+    assertEquals("expression", first.getAvailabilityCondition().getExpression());
+    assertNull(first.getAvailabilityCondition().getTitle());
+    assertNull(first.getAvailabilityCondition().getDescription());
+
+    AccessBoundaryRule second = credentialAccessBoundary.getAccessBoundaryRules().get(1);
+    assertEquals(secondRule, second);
+    assertEquals("secondResource", second.getAvailableResource());
+    assertEquals(1, second.getAvailablePermissions().size());
+    assertEquals("secondPermission", second.getAvailablePermissions().get(0));
+    assertNull(second.getAvailabilityCondition());
+  }
+
+  @Test
+  public void credentialAccessBoundary_nullRules_throws() {
+    try {
+      CredentialAccessBoundary.newBuilder().build();
+      fail("Should fail.");
+    } catch (NullPointerException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void credentialAccessBoundary_withoutRules_throws() {
+    try {
+      CredentialAccessBoundary.newBuilder().setRules(new ArrayList<AccessBoundaryRule>()).build();
+      fail("Should fail.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("At least one access boundary rule must be provided.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void credentialAccessBoundary_ruleCountExceeded_throws() {
+    AccessBoundaryRule rule =
+        AccessBoundaryRule.newBuilder()
+            .setAvailableResource("resource")
+            .addAvailablePermission("permission")
+            .build();
+
+    CredentialAccessBoundary.Builder builder = CredentialAccessBoundary.newBuilder();
+    for (int i = 0; i <= 10; i++) {
+      builder.addRule(rule);
+    }
+
+    try {
+      builder.build();
+      fail("Should fail.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("The provided list has more than 10 access boundary rules.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void credentialAccessBoundary_toJson() {
+    AvailabilityCondition availabilityCondition =
+        AvailabilityCondition.newBuilder()
+            .setExpression("expression")
+            .setTitle("title")
+            .setDescription("description")
+            .build();
+
+    AccessBoundaryRule firstRule =
+        AccessBoundaryRule.newBuilder()
+            .setAvailableResource("firstResource")
+            .addAvailablePermission("firstPermission")
+            .setAvailabilityCondition(availabilityCondition)
+            .build();
+
+    AccessBoundaryRule secondRule =
+        AccessBoundaryRule.newBuilder()
+            .setAvailableResource("secondResource")
+            .setAvailablePermissions(Arrays.asList("firstPermission", "secondPermission"))
+            .build();
+
+    CredentialAccessBoundary credentialAccessBoundary =
+        CredentialAccessBoundary.newBuilder()
+            .setRules(Arrays.asList(firstRule, secondRule))
+            .build();
+
+    String expectedJson =
+        "{\"accessBoundary\":{\"accessBoundaryRules\":"
+            + "[{\"availableResource\":\"firstResource\","
+            + "\"availablePermissions\":[\"firstPermission\"],"
+            + "\"availabilityCondition\":{\"expression\":\"expression\","
+            + "\"title\":\"title\",\"description\":\"description\"}},"
+            + "{\"availableResource\":\"secondResource\","
+            + "\"availablePermissions\":[\"firstPermission\","
+            + "\"secondPermission\"]}]}}";
+    assertEquals(expectedJson, credentialAccessBoundary.toJson());
+  }
+
+  @Test
+  public void accessBoundaryRule_allFields() {
+    AvailabilityCondition availabilityCondition =
+        AvailabilityCondition.newBuilder().setExpression("expression").build();
+
+    AccessBoundaryRule rule =
+        AccessBoundaryRule.newBuilder()
+            .setAvailableResource("resource")
+            .addAvailablePermission("firstPermission")
+            .addAvailablePermission("secondPermission")
+            .setAvailabilityCondition(availabilityCondition)
+            .build();
+
+    assertEquals("resource", rule.getAvailableResource());
+    assertEquals(2, rule.getAvailablePermissions().size());
+    assertEquals("firstPermission", rule.getAvailablePermissions().get(0));
+    assertEquals("secondPermission", rule.getAvailablePermissions().get(1));
+    assertEquals(availabilityCondition, rule.getAvailabilityCondition());
+  }
+
+  @Test
+  public void accessBoundaryRule_requiredFields() {
+    AccessBoundaryRule rule =
+        AccessBoundaryRule.newBuilder()
+            .setAvailableResource("resource")
+            .setAvailablePermissions(Collections.singletonList("firstPermission"))
+            .build();
+
+    assertEquals("resource", rule.getAvailableResource());
+    assertEquals(1, rule.getAvailablePermissions().size());
+    assertEquals("firstPermission", rule.getAvailablePermissions().get(0));
+    assertNull(rule.getAvailabilityCondition());
+  }
+
+  @Test
+  public void accessBoundaryRule_withEmptyAvailableResource_throws() {
+    try {
+      AccessBoundaryRule.newBuilder()
+          .setAvailableResource("")
+          .addAvailablePermission("permission")
+          .build();
+      fail("Should fail.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("The provided availableResource is empty.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void accessBoundaryRule_withoutAvailableResource_throws() {
+    try {
+      AccessBoundaryRule.newBuilder().addAvailablePermission("permission").build();
+      fail("Should fail.");
+    } catch (NullPointerException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void accessBoundaryRule_withoutAvailablePermissions_throws() {
+    try {
+      AccessBoundaryRule.newBuilder().setAvailableResource("resource").build();
+      fail("Should fail.");
+    } catch (NullPointerException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void accessBoundaryRule_withEmptyAvailablePermissions_throws() {
+    try {
+      AccessBoundaryRule.newBuilder()
+          .setAvailableResource("resource")
+          .setAvailablePermissions(new ArrayList<String>())
+          .build();
+      fail("Should fail.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("The list of provided availablePermissions is empty.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void accessBoundaryRule_withNullAvailablePermissions_throws() {
+    try {
+      AccessBoundaryRule.newBuilder()
+          .setAvailableResource("resource")
+          .addAvailablePermission(null)
+          .build();
+      fail("Should fail.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("One of the provided available permissions is null.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void accessBoundaryRule_withEmptyAvailablePermission_throws() {
+    try {
+      AccessBoundaryRule.newBuilder()
+          .setAvailableResource("resource")
+          .addAvailablePermission("")
+          .build();
+      fail("Should fail.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("One of the provided available permissions is empty.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void availabilityCondition_allFields() {
+    AvailabilityCondition availabilityCondition =
+        AvailabilityCondition.newBuilder()
+            .setExpression("expression")
+            .setTitle("title")
+            .setDescription("description")
+            .build();
+
+    assertEquals("expression", availabilityCondition.getExpression());
+    assertEquals("title", availabilityCondition.getTitle());
+    assertEquals("description", availabilityCondition.getDescription());
+  }
+
+  @Test
+  public void availabilityCondition_expressionOnly() {
+    AvailabilityCondition availabilityCondition =
+        AvailabilityCondition.newBuilder().setExpression("expression").build();
+
+    assertEquals("expression", availabilityCondition.getExpression());
+    assertNull(availabilityCondition.getTitle());
+    assertNull(availabilityCondition.getDescription());
+  }
+
+  @Test
+  public void availabilityCondition_nullExpression_throws() {
+    try {
+      AvailabilityCondition.newBuilder().setExpression(null).build();
+      fail("Should fail.");
+    } catch (NullPointerException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void availabilityCondition_emptyExpression_throws() {
+    try {
+      AvailabilityCondition.newBuilder().setExpression("").build();
+      fail("Should fail.");
+    } catch (IllegalArgumentException e) {
+      assertEquals("The provided expression is empty.", e.getMessage());
+    }
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/DownscopedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DownscopedCredentialsTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.auth.TestUtils;
+import com.google.auth.http.HttpTransportFactory;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link DownscopedCredentials}. */
+@RunWith(JUnit4.class)
+public class DownscopedCredentialsTest {
+
+  private static final String SA_PRIVATE_KEY_PKCS8 =
+      "-----BEGIN PRIVATE KEY-----\n"
+          + "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBALX0PQoe1igW12i"
+          + "kv1bN/r9lN749y2ijmbc/mFHPyS3hNTyOCjDvBbXYbDhQJzWVUikh4mvGBA07qTj79Xc3yBDfKP2IeyYQIFe0t0"
+          + "zkd7R9Zdn98Y2rIQC47aAbDfubtkU1U72t4zL11kHvoa0/RuFZjncvlr42X7be7lYh4p3NAgMBAAECgYASk5wDw"
+          + "4Az2ZkmeuN6Fk/y9H+Lcb2pskJIXjrL533vrDWGOC48LrsThMQPv8cxBky8HFSEklPpkfTF95tpD43iVwJRB/Gr"
+          + "CtGTw65IfJ4/tI09h6zGc4yqvIo1cHX/LQ+SxKLGyir/dQM925rGt/VojxY5ryJR7GLbCzxPnJm/oQJBANwOCO6"
+          + "D2hy1LQYJhXh7O+RLtA/tSnT1xyMQsGT+uUCMiKS2bSKx2wxo9k7h3OegNJIu1q6nZ6AbxDK8H3+d0dUCQQDTrP"
+          + "SXagBxzp8PecbaCHjzNRSQE2in81qYnrAFNB4o3DpHyMMY6s5ALLeHKscEWnqP8Ur6X4PvzZecCWU9BKAZAkAut"
+          + "LPknAuxSCsUOvUfS1i87ex77Ot+w6POp34pEX+UWb+u5iFn2cQacDTHLV1LtE80L8jVLSbrbrlH43H0DjU5AkEA"
+          + "gidhycxS86dxpEljnOMCw8CKoUBd5I880IUahEiUltk7OLJYS/Ts1wbn3kPOVX3wyJs8WBDtBkFrDHW2ezth2QJ"
+          + "ADj3e1YhMVdjJW5jqwlD/VNddGjgzyunmiZg0uOXsHXbytYmsA545S8KRQFaJKFXYYFo2kOjqOiC1T2cAzMDjCQ"
+          + "==\n-----END PRIVATE KEY-----\n";
+
+  private static final CredentialAccessBoundary CREDENTIAL_ACCESS_BOUNDARY =
+      CredentialAccessBoundary.newBuilder()
+          .addRule(
+              CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+                  .setAvailableResource("//storage.googleapis.com/projects/_/buckets/bucket")
+                  .addAvailablePermission("inRole:roles/storage.objectViewer")
+                  .build())
+          .build();
+
+  static class MockStsTransportFactory implements HttpTransportFactory {
+
+    MockStsTransport transport = new MockStsTransport();
+
+    @Override
+    public HttpTransport create() {
+      return transport;
+    }
+  }
+
+  @Test
+  public void refreshAccessToken() throws IOException {
+    MockStsTransportFactory transportFactory = new MockStsTransportFactory();
+
+    GoogleCredentials sourceCredentials = getSourceCredentials(/* canRefresh= */ true);
+
+    DownscopedCredentials downscopedCredentials =
+        DownscopedCredentials.newBuilder()
+            .setSourceCredential(sourceCredentials)
+            .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
+            .setHttpTransportFactory(transportFactory)
+            .build();
+
+    AccessToken accessToken = downscopedCredentials.refreshAccessToken();
+
+    assertEquals(transportFactory.transport.getAccessToken(), accessToken.getTokenValue());
+
+    // Validate CAB specific params.
+    Map<String, String> query =
+        TestUtils.parseQuery(transportFactory.transport.getRequest().getContentAsString());
+    assertNotNull(query.get("options"));
+    assertEquals(CREDENTIAL_ACCESS_BOUNDARY.toJson(), query.get("options"));
+    assertEquals(
+        "urn:ietf:params:oauth:token-type:access_token", query.get("requested_token_type"));
+  }
+
+  @Test
+  public void refreshAccessToken_cantRefreshSourceCredentials_throws() throws IOException {
+    MockStsTransportFactory transportFactory = new MockStsTransportFactory();
+
+    GoogleCredentials sourceCredentials = getSourceCredentials(/* canRefresh= */ false);
+
+    DownscopedCredentials downscopedCredentials =
+        DownscopedCredentials.newBuilder()
+            .setSourceCredential(sourceCredentials)
+            .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
+            .setHttpTransportFactory(transportFactory)
+            .build();
+
+    try {
+      downscopedCredentials.refreshAccessToken();
+      fail("Should fail as the source credential should not be able to be refreshed.");
+    } catch (IOException e) {
+      assertEquals("Unable to refresh the provided source credential.", e.getMessage());
+    }
+  }
+
+  @Test
+  public void builder_noSourceCredential_throws() {
+    try {
+      DownscopedCredentials.newBuilder()
+          .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+          .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
+          .build();
+      fail("Should fail as the source credential is null.");
+    } catch (NullPointerException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void builder_noCredentialAccessBoundary_throws() throws IOException {
+    try {
+      DownscopedCredentials.newBuilder()
+          .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+          .setSourceCredential(getSourceCredentials(/* canRefresh= */ true))
+          .build();
+      fail("Should fail as no access boundary was provided.");
+    } catch (NullPointerException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void builder_noTransport_defaults() throws IOException {
+    GoogleCredentials sourceCredentials = getSourceCredentials(/* canRefresh= */ true);
+    DownscopedCredentials credentials =
+        DownscopedCredentials.newBuilder()
+            .setSourceCredential(sourceCredentials)
+            .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
+            .build();
+
+    GoogleCredentials scopedSourceCredentials =
+        sourceCredentials.createScoped("https://www.googleapis.com/auth/cloud-platform");
+    assertEquals(scopedSourceCredentials, credentials.getSourceCredentials());
+    assertEquals(CREDENTIAL_ACCESS_BOUNDARY, credentials.getCredentialAccessBoundary());
+    assertEquals(OAuth2Utils.HTTP_TRANSPORT_FACTORY, credentials.getTransportFactory());
+  }
+
+  private static GoogleCredentials getSourceCredentials(boolean canRefresh) throws IOException {
+    GoogleCredentialsTest.MockTokenServerTransportFactory transportFactory =
+        new GoogleCredentialsTest.MockTokenServerTransportFactory();
+
+    String email = "service-account@google.com";
+
+    ServiceAccountCredentials sourceCredentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientEmail(email)
+            .setPrivateKey(ServiceAccountCredentials.privateKeyFromPkcs8(SA_PRIVATE_KEY_PKCS8))
+            .setPrivateKeyId("privateKeyId")
+            .setProjectId("projectId")
+            .setHttpTransportFactory(transportFactory)
+            .build();
+
+    transportFactory.transport.addServiceAccount(email, "accessToken");
+
+    if (!canRefresh) {
+      transportFactory.transport.setError(new IOException());
+    }
+
+    return sourceCredentials;
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/DownscopedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DownscopedCredentialsTest.java
@@ -39,6 +39,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
 import java.io.IOException;
+import java.util.Date;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,7 +86,8 @@ public class DownscopedCredentialsTest {
   public void refreshAccessToken() throws IOException {
     MockStsTransportFactory transportFactory = new MockStsTransportFactory();
 
-    GoogleCredentials sourceCredentials = getSourceCredentials(/* canRefresh= */ true);
+    GoogleCredentials sourceCredentials =
+        getServiceAccountSourceCredentials(/* canRefresh= */ true);
 
     DownscopedCredentials downscopedCredentials =
         DownscopedCredentials.newBuilder()
@@ -108,10 +110,39 @@ public class DownscopedCredentialsTest {
   }
 
   @Test
+  public void refreshAccessToken_userCredentials_expectExpiresInCopied() throws IOException {
+    // STS only returns expires_in if the source access token belongs to a service account.
+    // For other source credential types, we can copy the source credentials expiration as
+    // the generated downscoped token will always have the same expiration time as the source
+    // credentials.
+
+    MockStsTransportFactory transportFactory = new MockStsTransportFactory();
+    transportFactory.transport.setReturnExpiresIn(false);
+
+    GoogleCredentials sourceCredentials = getUserSourceCredentials();
+
+    DownscopedCredentials downscopedCredentials =
+        DownscopedCredentials.newBuilder()
+            .setSourceCredential(sourceCredentials)
+            .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
+            .setHttpTransportFactory(transportFactory)
+            .build();
+
+    AccessToken accessToken = downscopedCredentials.refreshAccessToken();
+
+    assertEquals(transportFactory.transport.getAccessToken(), accessToken.getTokenValue());
+
+    // Validate that the expires_in has been copied from the source credential.
+    assertEquals(
+        sourceCredentials.getAccessToken().getExpirationTime(), accessToken.getExpirationTime());
+  }
+
+  @Test
   public void refreshAccessToken_cantRefreshSourceCredentials_throws() throws IOException {
     MockStsTransportFactory transportFactory = new MockStsTransportFactory();
 
-    GoogleCredentials sourceCredentials = getSourceCredentials(/* canRefresh= */ false);
+    GoogleCredentials sourceCredentials =
+        getServiceAccountSourceCredentials(/* canRefresh= */ false);
 
     DownscopedCredentials downscopedCredentials =
         DownscopedCredentials.newBuilder()
@@ -146,7 +177,7 @@ public class DownscopedCredentialsTest {
     try {
       DownscopedCredentials.newBuilder()
           .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-          .setSourceCredential(getSourceCredentials(/* canRefresh= */ true))
+          .setSourceCredential(getServiceAccountSourceCredentials(/* canRefresh= */ true))
           .build();
       fail("Should fail as no access boundary was provided.");
     } catch (NullPointerException e) {
@@ -156,7 +187,8 @@ public class DownscopedCredentialsTest {
 
   @Test
   public void builder_noTransport_defaults() throws IOException {
-    GoogleCredentials sourceCredentials = getSourceCredentials(/* canRefresh= */ true);
+    GoogleCredentials sourceCredentials =
+        getServiceAccountSourceCredentials(/* canRefresh= */ true);
     DownscopedCredentials credentials =
         DownscopedCredentials.newBuilder()
             .setSourceCredential(sourceCredentials)
@@ -170,7 +202,8 @@ public class DownscopedCredentialsTest {
     assertEquals(OAuth2Utils.HTTP_TRANSPORT_FACTORY, credentials.getTransportFactory());
   }
 
-  private static GoogleCredentials getSourceCredentials(boolean canRefresh) throws IOException {
+  private static GoogleCredentials getServiceAccountSourceCredentials(boolean canRefresh)
+      throws IOException {
     GoogleCredentialsTest.MockTokenServerTransportFactory transportFactory =
         new GoogleCredentialsTest.MockTokenServerTransportFactory();
 
@@ -192,5 +225,20 @@ public class DownscopedCredentialsTest {
     }
 
     return sourceCredentials;
+  }
+
+  private static GoogleCredentials getUserSourceCredentials() {
+    GoogleCredentialsTest.MockTokenServerTransportFactory transportFactory =
+        new GoogleCredentialsTest.MockTokenServerTransportFactory();
+    transportFactory.transport.addClient("clientId", "clientSecret");
+    transportFactory.transport.addRefreshToken("refreshToken", "accessToken");
+    AccessToken accessToken = new AccessToken("accessToken", new Date());
+    return UserCredentials.newBuilder()
+        .setClientId("clientId")
+        .setClientSecret("clientSecret")
+        .setRefreshToken("refreshToken")
+        .setAccessToken(accessToken)
+        .setHttpTransportFactory(transportFactory)
+        .build();
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITDownscopingTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITDownscopingTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.Credentials;
+import com.google.auth.http.HttpCredentialsAdapter;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Integration tests for Downscoping with Credential Access Boundaries via {@link
+ * DownscopedCredentials}.
+ *
+ * <p>The only requirements for this test suite to run is to set the environment variable
+ * GOOGLE_APPLICATION_CREDENTIALS to point to the same service account configured in the setup
+ * script (downscoping-with-cab-setup.sh).
+ */
+public final class ITDownscopingTest {
+
+  // Output copied from the setup script (downscoping-with-cab-setup.sh).
+  private static final String GCS_BUCKET_NAME = "cab-int-bucket-cbi3qrv5";
+  private static final String GCS_OBJECT_NAME_WITH_PERMISSION = "cab-first-cbi3qrv5.txt";
+  private static final String GCS_OBJECT_NAME_WITHOUT_PERMISSION = "cab-second-cbi3qrv5.txt";
+
+  // This Credential Access Boundary enables the objectViewer permission to the specified object in
+  // the specified bucket.
+  private static final CredentialAccessBoundary CREDENTIAL_ACCESS_BOUNDARY =
+      CredentialAccessBoundary.newBuilder()
+          .addRule(
+              CredentialAccessBoundary.AccessBoundaryRule.newBuilder()
+                  .setAvailableResource(
+                      String.format(
+                          "//storage.googleapis.com/projects/_/buckets/%s", GCS_BUCKET_NAME))
+                  .addAvailablePermission("inRole:roles/storage.objectViewer")
+                  .setAvailabilityCondition(
+                      CredentialAccessBoundary.AccessBoundaryRule.AvailabilityCondition.newBuilder()
+                          .setExpression(
+                              String.format(
+                                  "resource.name.startsWith('projects/_/buckets/%s/objects/%s')",
+                                  GCS_BUCKET_NAME, GCS_OBJECT_NAME_WITH_PERMISSION))
+                          .build())
+                  .build())
+          .build();
+
+  /**
+   * A downscoped credential is obtained from a service account credential with permissions to
+   * access an object in the GCS bucket configured. We should only have access to retrieve this
+   * object.
+   *
+   * <p>We confirm this by: 1. Validating that we can successfully retrieve this object with the
+   * downscoped token. 2. Validating that we do not have permission to retrieve a different object
+   * in the same bucket.
+   */
+  @Test
+  public void downscoping_serviceAccountSourceWithRefresh() throws IOException {
+    OAuth2CredentialsWithRefresh.OAuth2RefreshHandler refreshHandler =
+        new OAuth2CredentialsWithRefresh.OAuth2RefreshHandler() {
+          @Override
+          public AccessToken refreshAccessToken() throws IOException {
+
+            ServiceAccountCredentials credentials =
+                (ServiceAccountCredentials)
+                    GoogleCredentials.getApplicationDefault()
+                        .createScoped("https://www.googleapis.com/auth/cloud-platform");
+
+            DownscopedCredentials downscopedCredentials =
+                DownscopedCredentials.newBuilder()
+                    .setSourceCredential(credentials)
+                    .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
+                    .build();
+
+            return downscopedCredentials.refreshAccessToken();
+          }
+        };
+
+    OAuth2CredentialsWithRefresh credentials =
+        OAuth2CredentialsWithRefresh.newBuilder().setRefreshHandler(refreshHandler).build();
+
+    // Attempt to retrieve the object that the downscoped token has access to.
+    retrieveObjectFromGcs(credentials, GCS_OBJECT_NAME_WITH_PERMISSION);
+
+    // Attempt to retrieve the object that the downscoped token does not have access to. This should
+    // fail.
+    try {
+      retrieveObjectFromGcs(credentials, GCS_OBJECT_NAME_WITHOUT_PERMISSION);
+      fail("Call to GCS should have failed.");
+    } catch (HttpResponseException e) {
+      assertEquals(403, e.getStatusCode());
+    }
+  }
+
+  private void retrieveObjectFromGcs(Credentials credentials, String objectName)
+      throws IOException {
+    String url =
+        String.format(
+            "https://storage.googleapis.com/storage/v1/b/%s/o/%s", GCS_BUCKET_NAME, objectName);
+
+    HttpCredentialsAdapter credentialsAdapter = new HttpCredentialsAdapter(credentials);
+    HttpRequestFactory requestFactory =
+        new NetHttpTransport().createRequestFactory(credentialsAdapter);
+    HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
+
+    JsonObjectParser parser = new JsonObjectParser(GsonFactory.getDefaultInstance());
+    request.setParser(parser);
+
+    HttpResponse response = request.execute();
+    assertTrue(response.isSuccessStatusCode());
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockStsTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockStsTransport.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.LowLevelHttpRequest;
+import com.google.api.client.http.LowLevelHttpResponse;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.Json;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.api.client.testing.http.MockHttpTransport;
+import com.google.api.client.testing.http.MockLowLevelHttpRequest;
+import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import com.google.auth.TestUtils;
+import java.io.IOException;
+import java.util.Map;
+
+/** Transport that mocks a basic STS endpoint. */
+public class MockStsTransport extends MockHttpTransport {
+
+  private static final String EXPECTED_GRANT_TYPE =
+      "urn:ietf:params:oauth:grant-type:token-exchange";
+  private static final String ISSUED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
+  private static final String STS_URL = "https://sts.googleapis.com/v1/token";
+  private static final String ACCESS_TOKEN = "accessToken";
+  private static final Long EXPIRES_IN = 3600L;
+
+  private MockLowLevelHttpRequest request;
+
+  @Override
+  public LowLevelHttpRequest buildRequest(final String method, final String url) {
+    this.request =
+        new MockLowLevelHttpRequest(url) {
+          @Override
+          public LowLevelHttpResponse execute() throws IOException {
+            if (!STS_URL.equals(url)) {
+              return makeErrorResponse();
+            }
+
+            Map<String, String> query = TestUtils.parseQuery(getContentAsString());
+            assertEquals(EXPECTED_GRANT_TYPE, query.get("grant_type"));
+            assertNotNull(query.get("subject_token_type"));
+            assertNotNull(query.get("subject_token"));
+
+            GenericJson response = new GenericJson();
+            response.setFactory(new GsonFactory());
+            response.put("token_type", "Bearer");
+            response.put("expires_in", EXPIRES_IN);
+            response.put("access_token", ACCESS_TOKEN);
+            response.put("issued_token_type", ISSUED_TOKEN_TYPE);
+
+            return new MockLowLevelHttpResponse()
+                .setContentType(Json.MEDIA_TYPE)
+                .setContent(response.toPrettyString());
+          }
+        };
+    return this.request;
+  }
+
+  private MockLowLevelHttpResponse makeErrorResponse() {
+    MockLowLevelHttpResponse errorResponse = new MockLowLevelHttpResponse();
+    errorResponse.setStatusCode(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    errorResponse.setContentType(Json.MEDIA_TYPE);
+    errorResponse.setContent("{\"error\":\"error\"}");
+    return errorResponse;
+  }
+
+  public MockLowLevelHttpRequest getRequest() {
+    return request;
+  }
+
+  public String getAccessToken() {
+    return ACCESS_TOKEN;
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsWithRefreshTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsWithRefreshTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Date;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link OAuth2CredentialsWithRefresh}. */
+@RunWith(JUnit4.class)
+public class OAuth2CredentialsWithRefreshTest {
+
+  private static final AccessToken ACCESS_TOKEN = new AccessToken("accessToken", new Date());
+
+  @Test
+  public void builder() {
+    OAuth2CredentialsWithRefresh.OAuth2RefreshHandler refreshHandler =
+        new OAuth2CredentialsWithRefresh.OAuth2RefreshHandler() {
+          @Override
+          public AccessToken refreshAccessToken() {
+            return null;
+          }
+        };
+    OAuth2CredentialsWithRefresh credential =
+        OAuth2CredentialsWithRefresh.newBuilder()
+            .setAccessToken(ACCESS_TOKEN)
+            .setRefreshHandler(refreshHandler)
+            .build();
+
+    assertEquals(ACCESS_TOKEN, credential.getAccessToken());
+    assertEquals(refreshHandler, credential.getRefreshHandler());
+  }
+
+  @Test
+  public void builder_noAccessToken() {
+    OAuth2CredentialsWithRefresh.newBuilder()
+        .setRefreshHandler(
+            new OAuth2CredentialsWithRefresh.OAuth2RefreshHandler() {
+              @Override
+              public AccessToken refreshAccessToken() {
+                return null;
+              }
+            })
+        .build();
+  }
+
+  @Test
+  public void builder_noRefreshHandler_throws() {
+    try {
+      OAuth2CredentialsWithRefresh.newBuilder().setAccessToken(ACCESS_TOKEN).build();
+      fail("Should fail as a refresh handler must be provided.");
+    } catch (NullPointerException e) {
+      // Expected.
+    }
+  }
+
+  @Test
+  public void refreshAccessToken_delegateToRefreshHandler() throws IOException {
+    final AccessToken refreshedToken = new AccessToken("refreshedAccessToken", new Date());
+    OAuth2CredentialsWithRefresh credentials =
+        OAuth2CredentialsWithRefresh.newBuilder()
+            .setAccessToken(ACCESS_TOKEN)
+            .setRefreshHandler(
+                new OAuth2CredentialsWithRefresh.OAuth2RefreshHandler() {
+                  @Override
+                  public AccessToken refreshAccessToken() {
+                    return refreshedToken;
+                  }
+                })
+            .build();
+
+    AccessToken accessToken = credentials.refreshAccessToken();
+
+    assertEquals(refreshedToken, accessToken);
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsWithRefreshTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsWithRefreshTest.java
@@ -89,6 +89,18 @@ public class OAuth2CredentialsWithRefreshTest {
   }
 
   @Test
+  public void builder_noExpirationTimeInAccessToken_throws() {
+    try {
+      OAuth2CredentialsWithRefresh.newBuilder()
+          .setAccessToken(new AccessToken("accessToken", null))
+          .build();
+      fail("Should fail as a refresh handler must be provided.");
+    } catch (IllegalArgumentException e) {
+      // Expected.
+    }
+  }
+
+  @Test
   public void refreshAccessToken_delegateToRefreshHandler() throws IOException {
     final AccessToken refreshedToken = new AccessToken("refreshedAccessToken", new Date());
     OAuth2CredentialsWithRefresh credentials =

--- a/scripts/downscoping-with-cab-setup.sh
+++ b/scripts/downscoping-with-cab-setup.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Copyright 2021 Google LLC
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of Google LLC nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This script is used to generate the project configurations needed to
+# end-to-end test Downscoping with Credential Access Boundaries in the Auth
+# library.
+#
+# In order to run this script, you need to fill in the project_id and
+# service_account_email variables.
+#
+# This script needs to be run once. It will do the following:
+# 1. Sets the current project to the one specified.
+# 2. Creates a GCS bucket in the specified project.
+# 3. Gives the specified service account the objectAdmin role for this bucket.
+# 4. Creates two text files to be uploaded to the created bucket.
+# 5. Uploads both text files.
+# 6. Prints out the identifiers (bucket ID, first object ID, second object ID)
+#    to be used in the accompanying tests.
+# 7. Deletes the created text files in the current directory.
+#
+# The same service account used for this setup script should be used for
+# the integration tests.
+#
+# It is safe to run the setup script again. A new bucket is created along with
+# new objects. If run multiple times, it is advisable to delete
+# unused buckets.
+
+suffix=""
+
+function generate_random_string () {
+  local valid_chars=abcdefghijklmnopqrstuvwxyz0123456789
+  for i in {1..8} ; do
+    suffix+="${valid_chars:RANDOM%${#valid_chars}:1}"
+    done
+}
+
+generate_random_string
+
+bucket_id="cab-int-bucket-"${suffix}
+first_object="cab-first-"${suffix}.txt
+second_object="cab-second-"${suffix}.txt
+
+# Fill in.
+project_id=""
+service_account_email=""
+
+gcloud config set project ${project_id}
+
+# Create the GCS bucket.
+gsutil mb -b on -l us-east1 gs://${bucket_id}
+
+# Give the specified service account the objectAdmin role for this bucket.
+gsutil iam ch serviceAccount:${service_account_email}:objectAdmin gs://${bucket_id}
+
+# Create both objects.
+echo "first" >> ${first_object}
+echo "second" >> ${second_object}
+
+# Upload the created objects to the bucket.
+gsutil cp ${first_object} gs://${bucket_id}
+gsutil cp ${second_object} gs://${bucket_id}
+
+echo "Bucket ID: "${bucket_id}
+echo "First object ID: "${first_object}
+echo "Second object ID: "${second_object}
+
+# Cleanup.
+rm ${first_object}
+rm ${second_object}


### PR DESCRIPTION
See go/cab-client. This feature is publicly documented [here](https://cloud.google.com/iam/docs/downscoping-short-lived-credentials). 

Summary:

- Adds a new DownscopedCredentials class that enables the ability to downscope, or restrict, the IAM permissions that a short-lived credential can use for Cloud Storage. This is done by defining a CredentialAccessBoundary which specifies the upper bound of permissions the downscoped credential will be able to access. 
- OAuth2CredentialsWithRefresh enables access token refresh via a developer defined refresh handler.
- With CAB, STS may not always return an expires_in. The STS utility has been updated to reflect this. When not returned, the expires_in is copied from the source credential, when available.
- Includes integration tests with a one time use setup script (already ran).
- Samples/documentation will be provided in a separate PR. 