### PR TITLE
feat!: updating google-auth-library-java min Java version to 1.8

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,7 +10,6 @@ branchProtectionRules:
       - linkage-monitor
       - lint
       - clirr
-      - units (7)
       - units (8)
       - units (11)
       - cla/google

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [7, 8, 11]
+        java: [8, 11]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "name": "google-auth-library",
   "name_pretty": "Google Auth Library",
   "client_documentation": "https://googleapis.dev/java/google-auth-library/latest/",
-  "release_level": "beta",
+  "release_level": "ga",
   "language": "java",
   "repo": "googleapis/google-auth-library-java",
   "repo_short": "google-auth-library-java",

--- a/pom.xml
+++ b/pom.xml
@@ -231,8 +231,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
@@ -421,44 +421,6 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>autovalue-java7</id>
-      <activation>
-        <jdk>1.7</jdk>
-        <file>
-          <exists>${basedir}/EnableAutoValue.txt</exists>
-        </file>
-      </activation>
-      <properties>
-        <!--
-        We need to back pin to 1.4 because it is the last version of auto-value
-        that was compiled for java 1.7.
-        -->
-        <auto-value.version>1.4</auto-value.version>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>com.google.auto.value</groupId>
-                  <artifactId>auto-value</artifactId>
-                  <version>${auto-value.version}</version>
-                </path>
-                <!--
-                There is currently no available version of auto-service-annotations
-                in maven central compiled for java 1.7, so we can't include it here.
-                If you're using IntelliJ please use a newer jdk and set the language
-                level to 1.7 for your dev work.
-                -->
-              </annotationProcessorPaths>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Release-As: 1.0.0

feat: updating google-auth-library-java min Java version to 1.8