### PR TITLE
fix: timing of stale token refreshes on ComputeEngine

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -50,6 +50,7 @@ import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -70,6 +71,9 @@ import java.util.logging.Logger;
  */
 public class ComputeEngineCredentials extends GoogleCredentials
     implements ServiceAccountSigner, IdTokenProvider {
+
+  static final Duration COMPUTE_EXPIRATION_MARGIN = Duration.ofMinutes(3);
+  static final Duration COMPUTE_REFRESH_MARGIN = Duration.ofMinutes(4);
 
   private static final Logger LOGGER = Logger.getLogger(ComputeEngineCredentials.class.getName());
 
@@ -116,6 +120,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
       HttpTransportFactory transportFactory,
       Collection<String> scopes,
       Collection<String> defaultScopes) {
+    super(/* accessToken= */ null, COMPUTE_REFRESH_MARGIN, COMPUTE_EXPIRATION_MARGIN);
+
     this.transportFactory =
         firstNonNull(
             transportFactory,

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -72,6 +72,11 @@ import java.util.logging.Logger;
 public class ComputeEngineCredentials extends GoogleCredentials
     implements ServiceAccountSigner, IdTokenProvider {
 
+  // Decrease timing margins on GCE.
+  // This is needed because GCE VMs maintain their own OAuth cache that expires T-5mins, attempting
+  // to refresh a token before then, will yield the same stale token. To enable pre-emptive
+  // refreshes, the margins must be shortened. This shouldn't cause problems since the clock skew
+  // on the VM and metadata proxy should be non-existent.
   static final Duration COMPUTE_EXPIRATION_MARGIN = Duration.ofMinutes(3);
   static final Duration COMPUTE_REFRESH_MARGIN = Duration.ofMinutes(4);
 

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -211,6 +212,16 @@ public class GoogleCredentials extends OAuth2Credentials {
    */
   public GoogleCredentials(AccessToken accessToken) {
     super(accessToken);
+  }
+
+  /**
+   * Constructor with explicit access token and refresh times
+   *
+   * @param accessToken initial or temporary access token
+   */
+  protected GoogleCredentials(
+      AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
+    super(accessToken, refreshMargin, expirationMargin);
   }
 
   public static Builder newBuilder() {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockRequestMetadataCallback.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockRequestMetadataCallback.java
@@ -39,8 +39,8 @@ import java.util.concurrent.CountDownLatch;
 
 /** Mock RequestMetadataCallback */
 public final class MockRequestMetadataCallback implements RequestMetadataCallback {
-  Map<String, List<String>> metadata;
-  Throwable exception;
+  volatile Map<String, List<String>> metadata;
+  volatile Throwable exception;
   CountDownLatch latch = new CountDownLatch(1);
 
   /** Called when metadata is successfully produced. */

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
@@ -157,6 +157,17 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     }
     Map<String, List<String>> initialMetadata = callback.awaitResult();
 
+    // wait for background task to finish
+    for (int i = 0; i < 100; i++) {
+      synchronized (credentials.lock) {
+        if (credentials.refreshTask == null) {
+          break;
+        } else {
+          Thread.sleep(100);
+        }
+      }
+    }
+
     // Make sure that stale token is returned before configured expiration
     AccessToken newToken = new AccessToken(ACCESS_TOKEN + "-1", Date.from(actualExpiration));
     currentToken.set(newToken);

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
@@ -878,16 +878,9 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
       synchronized (credentials.lock) {
         if (credentials.refreshTask == null) {
           return;
-        } else if (credentials.refreshTask.isDone()) {
-          System.out.println("done?");
         }
       }
       Thread.sleep(100);
-    }
-    ListenableFutureTask<OAuthValue> t = credentials.refreshTask;
-    System.out.println(t);
-    if (t != null) {
-      System.out.println(t.isDone());
     }
     throw new TimeoutException("timed out waiting for refresh task to finish");
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/OAuth2CredentialsTest.java
@@ -168,7 +168,7 @@ public class OAuth2CredentialsTest extends BaseSerializationTest {
     // wait for background task to finish
     for (int i = 0; i < 100; i++) {
       synchronized (credentials.lock) {
-        if(credentials.refreshTask == null) {
+        if (credentials.refreshTask == null) {
           break;
         } else {
           Thread.sleep(100);


### PR DESCRIPTION
ComputeEngine metadata server has its own token caching mechanism that will return a cached token
until the last 5 minutes of its expiration. This has a negative interaction with stale token refreshes because 
stale token refresh kicks in T-6mins until T-5mins. This will cause every stale refresh to return the same 
stale token.

This PR updates the timing for ComputeEngineCredentials to start a stale refresh at T-4mins and consider 
the token expired at T-3 mins. The implementation is a bit noisy because it includes a change OAuth2Credentials 
to make the thresholds configureable and now that we targeting java8, I migrated to using java8 time data types.
