### PR TITLE
fix: disabling self-signed jwt for domain wide delegation

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -1018,8 +1018,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
     // If scopes are provided but we cannot use self signed JWT, then use scopes to get access
     // token.
-    if (!createScopedRequired() && !useJwtAccessWithScope
-        || serviceAccountUser != null && serviceAccountUser.length() > 0) {
+    if ((!createScopedRequired() && !useJwtAccessWithScope)
+        || (serviceAccountUser != null && serviceAccountUser.length() > 0)) {
       return super.getRequestMetadata(uri);
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -1018,7 +1018,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
     // If scopes are provided but we cannot use self signed JWT, then use scopes to get access
     // token.
-    if (!createScopedRequired() && !useJwtAccessWithScope) {
+    if (!createScopedRequired() && !useJwtAccessWithScope
+        || serviceAccountUser != null && serviceAccountUser.length() > 0) {
       return super.getRequestMetadata(uri);
     }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/TokenVerifierTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/TokenVerifierTest.java
@@ -242,8 +242,6 @@ public class TokenVerifierTest {
   @Test
   public void verifyServiceAccountRs256Token()
       throws TokenVerifier.VerificationException, IOException {
-    HttpTransportFactory httpTransportFactory =
-        mockTransport(SERVICE_ACCOUNT_CERT_URL, readResourceAsString("service_account_keys.json"));
     TokenVerifier tokenVerifier =
         TokenVerifier.newBuilder()
             .setClock(FIXED_CLOCK)


### PR DESCRIPTION
The self-signed JWT is not supported with domain delegation. Therefore disabling the self-signed JWT in that case. 
