### PR TITLE
Migration tests in appengine module from JUnit4 to JUnit5 (#756)

### DIFF
--- a/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
+++ b/appengine/javatests/com/google/auth/appengine/AppEngineCredentialsTest.java
@@ -31,13 +31,13 @@
 
 package com.google.auth.appengine;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
@@ -51,13 +51,10 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /** Unit tests for AppEngineCredentials */
-@RunWith(JUnit4.class)
-public class AppEngineCredentialsTest extends BaseSerializationTest {
+class AppEngineCredentialsTest extends BaseSerializationTest {
 
   private static Collection<String> SCOPES =
       Collections.unmodifiableCollection(Arrays.asList("scope1", "scope2"));
@@ -65,7 +62,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   private static final String EXPECTED_ACCOUNT = "serviceAccount";
 
   @Test
-  public void constructor_usesAppIdentityService() throws IOException {
+  void constructor_usesAppIdentityService() throws IOException {
     String expectedAccessToken = "ExpectedAccessToken";
 
     MockAppIdentityService appIdentity = new MockAppIdentityService();
@@ -83,7 +80,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void refreshAccessToken_sameAs() throws IOException {
+  void refreshAccessToken_sameAs() throws IOException {
     String expectedAccessToken = "ExpectedAccessToken";
 
     MockAppIdentityService appIdentity = new MockAppIdentityService();
@@ -100,7 +97,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void getAccount_sameAs() throws IOException {
+  void getAccount_sameAs() {
     MockAppIdentityService appIdentity = new MockAppIdentityService();
     appIdentity.setServiceAccountName(EXPECTED_ACCOUNT);
     AppEngineCredentials credentials =
@@ -112,7 +109,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void sign_sameAs() throws IOException {
+  void sign_sameAs() {
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
     MockAppIdentityService appIdentity = new MockAppIdentityService();
     appIdentity.setSignature(expectedSignature);
@@ -125,7 +122,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void createScoped_clonesWithScopes() throws IOException {
+  void createScoped_clonesWithScopes() throws IOException {
     String expectedAccessToken = "ExpectedAccessToken";
     Collection<String> emptyScopes = Collections.emptyList();
 
@@ -138,11 +135,10 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
             .setAppIdentityService(appIdentity)
             .build();
     assertTrue(credentials.createScopedRequired());
-    try {
-      credentials.getRequestMetadata(CALL_URI);
-      fail("Should not be able to use credential without scopes.");
-    } catch (Exception expected) {
-    }
+    assertThrows(
+        Exception.class,
+        () -> credentials.getRequestMetadata(CALL_URI),
+        "Should not be able to use credential without scopes.");
     assertEquals(0, appIdentity.getGetAccessTokenCallCount());
 
     GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
@@ -155,7 +151,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void equals_true() throws IOException {
+  void equals_true() {
     Collection<String> emptyScopes = Collections.emptyList();
     MockAppIdentityService appIdentity = new MockAppIdentityService();
 
@@ -175,7 +171,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void equals_false_scopes() throws IOException {
+  void equals_false_scopes() {
     Collection<String> emptyScopes = Collections.emptyList();
     Collection<String> scopes = Collections.singleton("SomeScope");
     MockAppIdentityService appIdentity = new MockAppIdentityService();
@@ -195,7 +191,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void toString_containsFields() throws IOException {
+  void toString_containsFields() {
     String expectedToString =
         String.format(
             "AppEngineCredentials{scopes=[%s], scopesRequired=%b, appIdentityServiceClassName=%s}",
@@ -213,7 +209,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void hashCode_equals() throws IOException {
+  void hashCode_equals() {
     Collection<String> emptyScopes = Collections.emptyList();
     MockAppIdentityService appIdentity = new MockAppIdentityService();
     AppEngineCredentials credentials =
@@ -230,7 +226,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void serialize() throws IOException, ClassNotFoundException {
+  void serialize() throws IOException, ClassNotFoundException {
     Collection<String> scopes = Collections.singleton("SomeScope");
     MockAppIdentityService appIdentity = new MockAppIdentityService();
     AppEngineCredentials credentials =
@@ -249,14 +245,7 @@ public class AppEngineCredentialsTest extends BaseSerializationTest {
     assertNotNull(token);
     String expectedValue = "Bearer " + token;
     List<String> authorizations = metadata.get("Authorization");
-    assertNotNull("Authorization headers not found", authorizations);
-    boolean found = false;
-    for (String authorization : authorizations) {
-      if (expectedValue.equals(authorization)) {
-        found = true;
-        break;
-      }
-    }
-    assertTrue("Bearer token not found", found);
+    assertNotNull(authorizations, "Authorization headers not found");
+    assertTrue(authorizations.contains(expectedValue), "Bearer token not found");
   }
 }

--- a/appengine/pom.xml
+++ b/appengine/pom.xml
@@ -68,8 +68,8 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.google.http.version>1.40.1</project.google.http.version>
     <project.junit.version>4.13.2</project.junit.version>
+    <project.junit.bom.version>5.8.1</project.junit.bom.version>
     <project.guava.version>31.0.1-android</project.guava.version>
     <project.appengine.version>1.9.91</project.appengine.version>
     <project.findbugs.version>3.0.2</project.findbugs.version>
@@ -71,6 +72,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${project.junit.bom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>com.google.auth</groupId>
         <artifactId>google-auth-library-credentials</artifactId>


### PR DESCRIPTION
It belongs to #756  . It's the first iteration. That's why I don't use `fixed` notation for the issue.
