### PR TITLE
refactor: migration tests in credentials module from JUnit4 to JUnit5 (#756)

### DIFF
--- a/credentials/javatests/com/google/auth/SigningExceptionTest.java
+++ b/credentials/javatests/com/google/auth/SigningExceptionTest.java
@@ -31,29 +31,28 @@
 
 package com.google.auth;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.auth.ServiceAccountSigner.SigningException;
-import java.io.IOException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SigningExceptionTest {
+class SigningExceptionTest {
 
   private static final String EXPECTED_MESSAGE = "message";
   private static final RuntimeException EXPECTED_CAUSE = new RuntimeException();
 
   @Test
-  public void constructor() {
+  void constructor() {
     SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
     assertEquals(EXPECTED_MESSAGE, signingException.getMessage());
     assertSame(EXPECTED_CAUSE, signingException.getCause());
   }
 
   @Test
-  public void equals_true() throws IOException {
+  void equals_true() {
     SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
     SigningException otherSigningException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
     assertTrue(signingException.equals(otherSigningException));
@@ -61,7 +60,7 @@ public class SigningExceptionTest {
   }
 
   @Test
-  public void equals_false_message() throws IOException {
+  void equals_false_message() {
     SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
     SigningException otherSigningException = new SigningException("otherMessage", EXPECTED_CAUSE);
     assertFalse(signingException.equals(otherSigningException));
@@ -69,7 +68,7 @@ public class SigningExceptionTest {
   }
 
   @Test
-  public void equals_false_cause() throws IOException {
+  void equals_false_cause() {
     SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
     SigningException otherSigningException =
         new SigningException("otherMessage", new RuntimeException());
@@ -78,7 +77,7 @@ public class SigningExceptionTest {
   }
 
   @Test
-  public void hashCode_equals() throws IOException {
+  void hashCode_equals() {
     SigningException signingException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
     SigningException otherSigningException = new SigningException(EXPECTED_MESSAGE, EXPECTED_CAUSE);
     assertEquals(signingException.hashCode(), otherSigningException.hashCode());

--- a/credentials/pom.xml
+++ b/credentials/pom.xml
@@ -50,8 +50,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
It belongs to #756 . It's the second iteration. That's why I don't use `fixed` notation for the issue.