### PR TITLE
chore: migrate tests in oauth2_http module from JUnit4 to JUnit5 - second iteration (#756)

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -31,13 +31,13 @@
 
 package com.google.auth.oauth2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.LowLevelHttpRequest;
@@ -65,13 +65,10 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /** Test case for {@link DefaultCredentialsProvider}. */
-@RunWith(JUnit4.class)
-public class DefaultCredentialsProviderTest {
+class DefaultCredentialsProviderTest {
 
   private static final String USER_CLIENT_SECRET = "jakuaL9YyieakhECKL2SwZcu";
   private static final String USER_CLIENT_ID = "ya29.1.AADtN_UtlxN3PuGAxrN2XQnZTVRvDyVWnYq4I6dws";
@@ -101,36 +98,36 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_noCredentials_throws() throws Exception {
+  void getDefaultCredentials_noCredentials_throws() {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected.");
-    } catch (IOException e) {
-      String message = e.getMessage();
-      assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> testProvider.getDefaultCredentials(transportFactory),
+            "No credential expected.");
+    String message = exception.getMessage();
+    assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
   }
 
   @Test
-  public void getDefaultCredentials_noCredentialsSandbox_throwsNonSecurity() throws Exception {
+  void getDefaultCredentials_noCredentialsSandbox_throwsNonSecurity() {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setFileSandbox(true);
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected.");
-    } catch (IOException e) {
-      String message = e.getMessage();
-      assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> testProvider.getDefaultCredentials(transportFactory),
+            "No credential expected.");
+    String message = exception.getMessage();
+    assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
   }
 
   @Test
-  public void getDefaultCredentials_envValidSandbox_throwsNonSecurity() throws Exception {
+  void getDefaultCredentials_envValidSandbox_throwsNonSecurity() throws Exception {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     InputStream userStream =
         UserCredentialsTest.writeUserStream(
@@ -141,43 +138,39 @@ public class DefaultCredentialsProviderTest {
     testProvider.addFile(userPath, userStream);
     testProvider.setEnv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR, userPath);
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected.");
-    } catch (IOException e) {
-      String message = e.getMessage();
-      assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> testProvider.getDefaultCredentials(transportFactory),
+            "No credential expected.");
+    String message = exception.getMessage();
+    assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
   }
 
   @Test
-  public void getDefaultCredentials_noCredentials_singleGceTestRequest() {
+  void getDefaultCredentials_noCredentials_singleGceTestRequest() {
     MockRequestCountingTransportFactory transportFactory =
         new MockRequestCountingTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected.");
-    } catch (IOException expected) {
-      // Expected
-    }
+    assertThrows(
+        IOException.class,
+        () -> testProvider.getDefaultCredentials(transportFactory),
+        "No credential expected.");
     assertEquals(
         transportFactory.transport.getRequestCount(),
         ComputeEngineCredentials.MAX_COMPUTE_PING_TRIES);
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected.");
-    } catch (IOException expected) {
-      // Expected
-    }
+    assertThrows(
+        IOException.class,
+        () -> testProvider.getDefaultCredentials(transportFactory),
+        "No credential expected.");
     assertEquals(
         transportFactory.transport.getRequestCount(),
         ComputeEngineCredentials.MAX_COMPUTE_PING_TRIES);
   }
 
   @Test
-  public void getDefaultCredentials_caches() throws IOException {
+  void getDefaultCredentials_caches() throws IOException {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
 
@@ -189,43 +182,42 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_appEngineClassWithoutRuntime_NotFoundError() {
+  void getDefaultCredentials_appEngineClassWithoutRuntime_NotFoundError() {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.addType(
         DefaultCredentialsProvider.APP_ENGINE_SIGNAL_CLASS, MockOffAppEngineSystemProperty.class);
     testProvider.setProperty("isOnGAEStandard7", "true");
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected when not on App Engine.");
-    } catch (IOException e) {
-      String message = e.getMessage();
-      assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> testProvider.getDefaultCredentials(transportFactory),
+            "No credential expected when not on App Engine.");
+    String message = exception.getMessage();
+    assertTrue(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
   }
 
   @Test
-  public void getDefaultCredentials_appEngineRuntimeWithoutClass_throwsHelpfulLoadError() {
+  void getDefaultCredentials_appEngineRuntimeWithoutClass_throwsHelpfulLoadError() {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.addType(
         DefaultCredentialsProvider.APP_ENGINE_SIGNAL_CLASS, MockAppEngineSystemProperty.class);
     testProvider.setProperty("isOnGAEStandard7", "true");
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("Credential expected to fail to load if credential class not present.");
-    } catch (IOException e) {
-      String message = e.getMessage();
-      assertFalse(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
-      assertTrue(message.contains("Check that the App Engine SDK is deployed."));
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> testProvider.getDefaultCredentials(transportFactory),
+            "Credential expected to fail to load if credential class not present.");
+    String message = exception.getMessage();
+    assertFalse(message.contains(DefaultCredentialsProvider.HELP_PERMALINK));
+    assertTrue(message.contains("Check that the App Engine SDK is deployed."));
   }
 
   @Test
-  public void getDefaultCredentials_appEngineSkipWorks_retrievesCloudShellCredential()
-      throws IOException {
+  void getDefaultCredentials_appEngineSkipWorks_retrievesCloudShellCredential() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.addType(
@@ -239,7 +231,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_compute_providesToken() throws IOException {
+  void getDefaultCredentials_compute_providesToken() throws IOException {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setAccessToken(ACCESS_TOKEN);
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
@@ -252,7 +244,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_cloudshell() throws IOException {
+  void getDefaultCredentials_cloudshell() throws IOException {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.CLOUD_SHELL_ENV_VAR, "4");
@@ -264,7 +256,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_cloudshell_withComputCredentialsPresent() throws IOException {
+  void getDefaultCredentials_cloudshell_withComputCredentialsPresent() throws IOException {
     MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
     transportFactory.transport.setAccessToken(ACCESS_TOKEN);
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
@@ -277,24 +269,24 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_envMissingFile_throws() {
+  void getDefaultCredentials_envMissingFile_throws() {
     final String invalidPath = "/invalid/path";
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR, invalidPath);
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("Non existent credential should throw exception");
-    } catch (IOException e) {
-      String message = e.getMessage();
-      assertTrue(message.contains(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR));
-      assertTrue(message.contains(invalidPath));
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> testProvider.getDefaultCredentials(transportFactory),
+            "Non existent credential should throw exception");
+    String message = exception.getMessage();
+    assertTrue(message.contains(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR));
+    assertTrue(message.contains(invalidPath));
   }
 
   @Test
-  public void getDefaultCredentials_envServiceAccount_providesToken() throws IOException {
+  void getDefaultCredentials_envServiceAccount_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     InputStream serviceAccountStream =
@@ -314,7 +306,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_envUser_providesToken() throws IOException {
+  void getDefaultCredentials_envUser_providesToken() throws IOException {
     InputStream userStream =
         UserCredentialsTest.writeUserStream(
             USER_CLIENT_ID, USER_CLIENT_SECRET, REFRESH_TOKEN, QUOTA_PROJECT);
@@ -327,23 +319,21 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_envNoGceCheck_noGceRequest() throws IOException {
+  void getDefaultCredentials_envNoGceCheck_noGceRequest() {
     MockRequestCountingTransportFactory transportFactory =
         new MockRequestCountingTransportFactory();
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.NO_GCE_CHECK_ENV_VAR, "true");
 
-    try {
-      testProvider.getDefaultCredentials(transportFactory);
-      fail("No credential expected.");
-    } catch (IOException expected) {
-      // Expected
-    }
+    assertThrows(
+        IOException.class,
+        () -> testProvider.getDefaultCredentials(transportFactory),
+        "No credential expected.");
     assertEquals(transportFactory.transport.getRequestCount(), 0);
   }
 
   @Test
-  public void getDefaultCredentials_envGceMetadataHost_setsMetadataServerUrl() {
+  void getDefaultCredentials_envGceMetadataHost_setsMetadataServerUrl() {
     String testUrl = "192.0.2.0";
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.GCE_METADATA_HOST_ENV_VAR, testUrl);
@@ -351,7 +341,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_envGceMetadataHost_setsTokenServerUrl() {
+  void getDefaultCredentials_envGceMetadataHost_setsTokenServerUrl() {
     String testUrl = "192.0.2.0";
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.GCE_METADATA_HOST_ENV_VAR, testUrl);
@@ -361,7 +351,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_wellKnownFileEnv_providesToken() throws IOException {
+  void getDefaultCredentials_wellKnownFileEnv_providesToken() throws IOException {
     File cloudConfigDir = getTempDirectory();
     InputStream userStream =
         UserCredentialsTest.writeUserStream(
@@ -376,7 +366,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_wellKnownFileNonWindows_providesToken() throws IOException {
+  void getDefaultCredentials_wellKnownFileNonWindows_providesToken() throws IOException {
     File homeDir = getTempDirectory();
     File configDir = new File(homeDir, ".config");
     File cloudConfigDir = new File(configDir, DefaultCredentialsProvider.CLOUDSDK_CONFIG_DIRECTORY);
@@ -394,7 +384,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_wellKnownFileWindows_providesToken() throws IOException {
+  void getDefaultCredentials_wellKnownFileWindows_providesToken() throws IOException {
     File homeDir = getTempDirectory();
     File cloudConfigDir = new File(homeDir, DefaultCredentialsProvider.CLOUDSDK_CONFIG_DIRECTORY);
     InputStream userStream =
@@ -411,7 +401,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_envAndWellKnownFile_envPrecedence() throws IOException {
+  void getDefaultCredentials_envAndWellKnownFile_envPrecedence() throws IOException {
     final String refreshTokenEnv = "2/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
     final String accessTokenEnv = "2/MkSJoj1xsli0AccessToken_NKPY2";
     final String refreshTokenWkf = "3/Tl6awhpFjkMkSJoj1xsli0H2eL5YsMgU_NKPY2TyGWY";
@@ -466,7 +456,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_wellKnownFile_logsGcloudWarning() throws IOException {
+  void getDefaultCredentials_wellKnownFile_logsGcloudWarning() throws IOException {
     LogRecord message = getCredentialsAndReturnLogMessage(false);
     assertNotNull(message);
     assertEquals(Level.WARNING, message.getLevel());
@@ -474,7 +464,7 @@ public class DefaultCredentialsProviderTest {
   }
 
   @Test
-  public void getDefaultCredentials_wellKnownFile_suppressGcloudWarning() throws IOException {
+  void getDefaultCredentials_wellKnownFile_suppressGcloudWarning() throws IOException {
     LogRecord message = getCredentialsAndReturnLogMessage(true);
     assertNull(message);
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/DownscopedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DownscopedCredentialsTest.java
@@ -31,9 +31,9 @@
 
 package com.google.auth.oauth2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.auth.TestUtils;
@@ -41,13 +41,10 @@ import com.google.auth.http.HttpTransportFactory;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link DownscopedCredentials}. */
-@RunWith(JUnit4.class)
-public class DownscopedCredentialsTest {
+class DownscopedCredentialsTest {
 
   private static final String SA_PRIVATE_KEY_PKCS8 =
       "-----BEGIN PRIVATE KEY-----\n"
@@ -83,7 +80,7 @@ public class DownscopedCredentialsTest {
   }
 
   @Test
-  public void refreshAccessToken() throws IOException {
+  void refreshAccessToken() throws IOException {
     MockStsTransportFactory transportFactory = new MockStsTransportFactory();
 
     GoogleCredentials sourceCredentials =
@@ -110,7 +107,7 @@ public class DownscopedCredentialsTest {
   }
 
   @Test
-  public void refreshAccessToken_userCredentials_expectExpiresInCopied() throws IOException {
+  void refreshAccessToken_userCredentials_expectExpiresInCopied() throws IOException {
     // STS only returns expires_in if the source access token belongs to a service account.
     // For other source credential types, we can copy the source credentials expiration as
     // the generated downscoped token will always have the same expiration time as the source
@@ -138,7 +135,7 @@ public class DownscopedCredentialsTest {
   }
 
   @Test
-  public void refreshAccessToken_cantRefreshSourceCredentials_throws() throws IOException {
+  void refreshAccessToken_cantRefreshSourceCredentials_throws() throws IOException {
     MockStsTransportFactory transportFactory = new MockStsTransportFactory();
 
     GoogleCredentials sourceCredentials =
@@ -151,42 +148,42 @@ public class DownscopedCredentialsTest {
             .setHttpTransportFactory(transportFactory)
             .build();
 
-    try {
-      downscopedCredentials.refreshAccessToken();
-      fail("Should fail as the source credential should not be able to be refreshed.");
-    } catch (IOException e) {
-      assertEquals("Unable to refresh the provided source credential.", e.getMessage());
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            downscopedCredentials::refreshAccessToken,
+            "Should fail as the source credential should not be able to be refreshed.");
+    assertEquals("Unable to refresh the provided source credential.", exception.getMessage());
   }
 
   @Test
-  public void builder_noSourceCredential_throws() {
-    try {
-      DownscopedCredentials.newBuilder()
-          .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-          .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
-          .build();
-      fail("Should fail as the source credential is null.");
-    } catch (NullPointerException e) {
-      // Expected.
-    }
+  void builder_noSourceCredential_throws() {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          DownscopedCredentials.newBuilder()
+              .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+              .setCredentialAccessBoundary(CREDENTIAL_ACCESS_BOUNDARY)
+              .build();
+        },
+        "Should fail as the source credential is null.");
   }
 
   @Test
-  public void builder_noCredentialAccessBoundary_throws() throws IOException {
-    try {
-      DownscopedCredentials.newBuilder()
-          .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-          .setSourceCredential(getServiceAccountSourceCredentials(/* canRefresh= */ true))
-          .build();
-      fail("Should fail as no access boundary was provided.");
-    } catch (NullPointerException e) {
-      // Expected.
-    }
+  void builder_noCredentialAccessBoundary_throws() throws IOException {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          DownscopedCredentials.newBuilder()
+              .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+              .setSourceCredential(getServiceAccountSourceCredentials(/* canRefresh= */ true))
+              .build();
+        },
+        "Should fail as no access boundary was provided.");
   }
 
   @Test
-  public void builder_noTransport_defaults() throws IOException {
+  void builder_noTransport_defaults() throws IOException {
     GoogleCredentials sourceCredentials =
         getServiceAccountSourceCredentials(/* canRefresh= */ true);
     DownscopedCredentials credentials =

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -31,11 +31,11 @@
 
 package com.google.auth.oauth2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.GenericJson;
@@ -53,13 +53,10 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Tests for {@link ExternalAccountCredentials}. */
-@RunWith(JUnit4.class)
 public class ExternalAccountCredentialsTest {
 
   private static final String STS_URL = "https://sts.googleapis.com";
@@ -77,13 +74,13 @@ public class ExternalAccountCredentialsTest {
 
   private MockExternalAccountCredentialsTransportFactory transportFactory;
 
-  @Before
-  public void setup() {
+  @BeforeEach
+  void setup() {
     transportFactory = new MockExternalAccountCredentialsTransportFactory();
   }
 
   @Test
-  public void fromStream_identityPoolCredentials() throws IOException {
+  void fromStream_identityPoolCredentials() throws IOException {
     GenericJson json = buildJsonIdentityPoolCredential();
 
     ExternalAccountCredentials credential =
@@ -93,7 +90,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void fromStream_awsCredentials() throws IOException {
+  void fromStream_awsCredentials() throws IOException {
     GenericJson json = buildJsonAwsCredential();
 
     ExternalAccountCredentials credential =
@@ -103,56 +100,57 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void fromStream_invalidStream_throws() throws IOException {
+  void fromStream_invalidStream_throws() {
     GenericJson json = buildJsonAwsCredential();
 
     json.put("audience", new HashMap<>());
 
-    try {
-      ExternalAccountCredentials.fromStream(TestUtils.jsonToInputStream(json));
-      fail("Should fail.");
-    } catch (CredentialFormatException e) {
-      assertEquals("An invalid input stream was provided.", e.getMessage());
-    }
+    CredentialFormatException exception =
+        assertThrows(
+            CredentialFormatException.class,
+            () -> ExternalAccountCredentials.fromStream(TestUtils.jsonToInputStream(json)),
+            "Should fail.");
+    assertEquals("An invalid input stream was provided.", exception.getMessage());
   }
 
   @Test
-  public void fromStream_nullTransport_throws() throws IOException {
-    try {
-      ExternalAccountCredentials.fromStream(
-          new ByteArrayInputStream("foo".getBytes()), /* transportFactory= */ null);
-      fail("NullPointerException should be thrown.");
-    } catch (NullPointerException e) {
-      // Expected.
-    }
+  void fromStream_nullTransport_throws() {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          ExternalAccountCredentials.fromStream(
+              new ByteArrayInputStream("foo".getBytes()), /* transportFactory= */ null);
+        },
+        "NullPointerException should be thrown.");
   }
 
   @Test
-  public void fromStream_nullStream_throws() throws IOException {
-    try {
-      ExternalAccountCredentials.fromStream(
-          /* credentialsStream= */ null, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
-      fail("NullPointerException should be thrown.");
-    } catch (NullPointerException e) {
-      // Expected.
-    }
+  void fromStream_nullStream_throws() {
+    assertThrows(
+        NullPointerException.class,
+        () -> {
+          ExternalAccountCredentials.fromStream(
+              /* credentialsStream= */ null, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+        },
+        "NullPointerException should be thrown.");
   }
 
   @Test
-  public void fromStream_invalidWorkloadAudience_throws() throws IOException {
-    try {
-      GenericJson json = buildJsonIdentityPoolWorkforceCredential();
-      json.put("audience", "invalidAudience");
-      ExternalAccountCredentials credential =
-          ExternalAccountCredentials.fromStream(TestUtils.jsonToInputStream(json));
-      fail("CredentialFormatException should be thrown.");
-    } catch (CredentialFormatException e) {
-      assertEquals("An invalid input stream was provided.", e.getMessage());
-    }
+  void fromStream_invalidWorkloadAudience_throws() throws IOException {
+    CredentialFormatException exception =
+        assertThrows(
+            CredentialFormatException.class,
+            () -> {
+              GenericJson json = buildJsonIdentityPoolWorkforceCredential();
+              json.put("audience", "invalidAudience");
+              ExternalAccountCredentials.fromStream(TestUtils.jsonToInputStream(json));
+            },
+            "CredentialFormatException should be thrown.");
+    assertEquals("An invalid input stream was provided.", exception.getMessage());
   }
 
   @Test
-  public void fromJson_identityPoolCredentialsWorkload() {
+  void fromJson_identityPoolCredentialsWorkload() {
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(
             buildJsonIdentityPoolCredential(), OAuth2Utils.HTTP_TRANSPORT_FACTORY);
@@ -168,7 +166,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void fromJson_identityPoolCredentialsWorkforce() {
+  void fromJson_identityPoolCredentialsWorkforce() {
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(
             buildJsonIdentityPoolWorkforceCredential(), OAuth2Utils.HTTP_TRANSPORT_FACTORY);
@@ -186,7 +184,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void fromJson_awsCredentials() throws IOException {
+  void fromJson_awsCredentials() {
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(
             buildJsonAwsCredential(), OAuth2Utils.HTTP_TRANSPORT_FACTORY);
@@ -200,43 +198,40 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void fromJson_nullJson_throws() {
-    try {
-      ExternalAccountCredentials.fromJson(/* json= */ null, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
-      fail("Exception should be thrown.");
-    } catch (NullPointerException e) {
-      // Expected.
-    }
+  void fromJson_nullJson_throws() {
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            ExternalAccountCredentials.fromJson(
+                /* json= */ null, OAuth2Utils.HTTP_TRANSPORT_FACTORY),
+        "Exception should be thrown.");
   }
 
   @Test
-  public void fromJson_invalidServiceAccountImpersonationUrl_throws() {
+  void fromJson_invalidServiceAccountImpersonationUrl_throws() {
     GenericJson json = buildJsonIdentityPoolCredential();
     json.put("service_account_impersonation_url", "https://iamcredentials.googleapis.com");
 
-    try {
-      ExternalAccountCredentials.fromJson(json, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
-      fail("Exception should be thrown.");
-    } catch (IllegalArgumentException e) {
-      assertEquals(
-          "Unable to determine target principal from service account impersonation URL.",
-          e.getMessage());
-    }
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> ExternalAccountCredentials.fromJson(json, OAuth2Utils.HTTP_TRANSPORT_FACTORY),
+            "Exception should be thrown.");
+    assertEquals(
+        "Unable to determine target principal from service account impersonation URL.",
+        exception.getMessage());
   }
 
   @Test
-  public void fromJson_nullTransport_throws() {
-    try {
-      ExternalAccountCredentials.fromJson(
-          new HashMap<String, Object>(), /* transportFactory= */ null);
-      fail("Exception should be thrown.");
-    } catch (NullPointerException e) {
-      // Expected.
-    }
+  void fromJson_nullTransport_throws() {
+    assertThrows(
+        NullPointerException.class,
+        () -> ExternalAccountCredentials.fromJson(new HashMap<>(), /* transportFactory= */ null),
+        "Exception should be thrown.");
   }
 
   @Test
-  public void fromJson_invalidWorkforceAudiences_throws() {
+  void fromJson_invalidWorkforceAudiences_throws() {
     List<String> invalidAudiences =
         Arrays.asList(
             "//iam.googleapis.com/locations/global/workloadIdentityPools/pool/providers/provider",
@@ -249,65 +244,71 @@ public class ExternalAccountCredentialsTest {
             "//iam.googleapis.com/locations/global/workforce/providers");
 
     for (String audience : invalidAudiences) {
-      try {
-        GenericJson json = buildJsonIdentityPoolCredential();
-        json.put("audience", audience);
-        json.put("workforce_pool_user_project", "userProject");
+      IllegalArgumentException exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> {
+                GenericJson json = buildJsonIdentityPoolCredential();
+                json.put("audience", audience);
+                json.put("workforce_pool_user_project", "userProject");
 
-        ExternalAccountCredentials.fromJson(json, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
-        fail("Exception should be thrown.");
-      } catch (IllegalArgumentException e) {
-        assertEquals(
-            "The workforce_pool_user_project parameter should only be provided for a Workforce Pool configuration.",
-            e.getMessage());
-      }
+                ExternalAccountCredentials.fromJson(json, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+              },
+              "Exception should be thrown.");
+      assertEquals(
+          "The workforce_pool_user_project parameter should only be provided for a Workforce Pool configuration.",
+          exception.getMessage());
     }
   }
 
   @Test
-  public void constructor_invalidTokenUrl() {
-    try {
-      new TestExternalAccountCredentials(
-          transportFactory,
-          "audience",
-          "subjectTokenType",
-          "tokenUrl",
-          new TestCredentialSource(new HashMap<String, Object>()),
-          STS_URL,
-          /* serviceAccountImpersonationUrl= */ null,
-          "quotaProjectId",
-          /* clientId= */ null,
-          /* clientSecret= */ null,
-          /* scopes= */ null);
-      fail("Should have failed since an invalid token URL was passed.");
-    } catch (IllegalArgumentException e) {
-      assertEquals("The provided token URL is invalid.", e.getMessage());
-    }
+  void constructor_invalidTokenUrl() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new TestExternalAccountCredentials(
+                  transportFactory,
+                  "audience",
+                  "subjectTokenType",
+                  "tokenUrl",
+                  new TestCredentialSource(new HashMap<String, Object>()),
+                  STS_URL,
+                  /* serviceAccountImpersonationUrl= */ null,
+                  "quotaProjectId",
+                  /* clientId= */ null,
+                  /* clientSecret= */ null,
+                  /* scopes= */ null);
+            },
+            "Should have failed since an invalid token URL was passed.");
+    assertEquals("The provided token URL is invalid.", exception.getMessage());
   }
 
   @Test
-  public void constructor_invalidServiceAccountImpersonationUrl() {
-    try {
-      new TestExternalAccountCredentials(
-          transportFactory,
-          "audience",
-          "subjectTokenType",
-          "tokenUrl",
-          new TestCredentialSource(new HashMap<String, Object>()),
-          /* tokenInfoUrl= */ null,
-          "serviceAccountImpersonationUrl",
-          "quotaProjectId",
-          /* clientId= */ null,
-          /* clientSecret= */ null,
-          /* scopes= */ null);
-      fail("Should have failed since an invalid token URL was passed.");
-    } catch (IllegalArgumentException e) {
-      assertEquals("The provided token URL is invalid.", e.getMessage());
-    }
+  void constructor_invalidServiceAccountImpersonationUrl() {
+    IllegalArgumentException exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new TestExternalAccountCredentials(
+                  transportFactory,
+                  "audience",
+                  "subjectTokenType",
+                  "tokenUrl",
+                  new TestCredentialSource(new HashMap<>()),
+                  /* tokenInfoUrl= */ null,
+                  "serviceAccountImpersonationUrl",
+                  "quotaProjectId",
+                  /* clientId= */ null,
+                  /* clientSecret= */ null,
+                  /* scopes= */ null);
+            },
+            "Should have failed since an invalid token URL was passed.");
+    assertEquals("The provided token URL is invalid.", exception.getMessage());
   }
 
   @Test
-  public void exchangeExternalCredentialForAccessToken() throws IOException {
+  void exchangeExternalCredentialForAccessToken() throws IOException {
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(buildJsonIdentityPoolCredential(), transportFactory);
 
@@ -326,7 +327,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void exchangeExternalCredentialForAccessToken_withInternalOptions() throws IOException {
+  void exchangeExternalCredentialForAccessToken_withInternalOptions() throws IOException {
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(buildJsonIdentityPoolCredential(), transportFactory);
 
@@ -350,7 +351,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void exchangeExternalCredentialForAccessToken_withServiceAccountImpersonation()
+  void exchangeExternalCredentialForAccessToken_withServiceAccountImpersonation()
       throws IOException {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
@@ -373,7 +374,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void exchangeExternalCredentialForAccessToken_throws() throws IOException {
+  void exchangeExternalCredentialForAccessToken_throws() throws IOException {
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(buildJsonIdentityPoolCredential(), transportFactory);
 
@@ -386,18 +387,18 @@ public class ExternalAccountCredentialsTest {
     StsTokenExchangeRequest stsTokenExchangeRequest =
         StsTokenExchangeRequest.newBuilder("credential", "subjectTokenType").build();
 
-    try {
-      credential.exchangeExternalCredentialForAccessToken(stsTokenExchangeRequest);
-      fail("Exception should be thrown.");
-    } catch (OAuthException e) {
-      assertEquals(errorCode, e.getErrorCode());
-      assertEquals(errorDescription, e.getErrorDescription());
-      assertEquals(errorUri, e.getErrorUri());
-    }
+    OAuthException exception =
+        assertThrows(
+            OAuthException.class,
+            () -> credential.exchangeExternalCredentialForAccessToken(stsTokenExchangeRequest),
+            "Exception should be thrown.");
+    assertEquals(errorCode, exception.getErrorCode());
+    assertEquals(errorDescription, exception.getErrorDescription());
+    assertEquals(errorUri, exception.getErrorUri());
   }
 
   @Test
-  public void getRequestMetadata_withQuotaProjectId() throws IOException {
+  void getRequestMetadata_withQuotaProjectId() throws IOException {
     TestExternalAccountCredentials testCredentials =
         new TestExternalAccountCredentials(
             transportFactory,
@@ -419,7 +420,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void validateTokenUrl_validUrls() {
+  void validateTokenUrl_validUrls() {
     List<String> validUrls =
         Arrays.asList(
             "https://sts.googleapis.com",
@@ -438,7 +439,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void validateTokenUrl_invalidUrls() {
+  void validateTokenUrl_invalidUrls() {
     List<String> invalidUrls =
         Arrays.asList(
             "https://iamcredentials.googleapis.com",
@@ -462,17 +463,17 @@ public class ExternalAccountCredentialsTest {
             "https://us-east-1.sts.googleapis.com.evil.com");
 
     for (String url : invalidUrls) {
-      try {
-        ExternalAccountCredentials.validateTokenUrl(url);
-        fail("Should have failed since an invalid URL was passed.");
-      } catch (IllegalArgumentException e) {
-        assertEquals("The provided token URL is invalid.", e.getMessage());
-      }
+      IllegalArgumentException exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> ExternalAccountCredentials.validateTokenUrl(url),
+              "Should have failed since an invalid URL was passed.");
+      assertEquals("The provided token URL is invalid.", exception.getMessage());
     }
   }
 
   @Test
-  public void validateServiceAccountImpersonationUrls_validUrls() {
+  void validateServiceAccountImpersonationUrls_validUrls() {
     List<String> validUrls =
         Arrays.asList(
             "https://iamcredentials.googleapis.com",
@@ -492,7 +493,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void validateServiceAccountImpersonationUrls_invalidUrls() {
+  void validateServiceAccountImpersonationUrls_invalidUrls() {
     List<String> invalidUrls =
         Arrays.asList(
             "https://sts.googleapis.com",
@@ -516,12 +517,13 @@ public class ExternalAccountCredentialsTest {
             "https://us-east-1.iamcredentials.googleapis.com.evil.com");
 
     for (String url : invalidUrls) {
-      try {
-        ExternalAccountCredentials.validateServiceAccountImpersonationInfoUrl(url);
-        fail("Should have failed since an invalid URL was passed.");
-      } catch (IllegalArgumentException e) {
-        assertEquals("The provided service account impersonation URL is invalid.", e.getMessage());
-      }
+      IllegalArgumentException exception =
+          assertThrows(
+              IllegalArgumentException.class,
+              () -> ExternalAccountCredentials.validateServiceAccountImpersonationInfoUrl(url),
+              "Should have failed since an invalid URL was passed.");
+      assertEquals(
+          "The provided service account impersonation URL is invalid.", exception.getMessage());
     }
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -31,11 +31,11 @@
 
 package com.google.auth.oauth2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.testing.http.MockHttpTransport;
@@ -54,12 +54,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
 /** Test case for {@link GoogleCredentials}. */
-@RunWith(JUnit4.class)
 public class GoogleCredentialsTest {
 
   private static final String SA_CLIENT_EMAIL =
@@ -104,39 +101,30 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void getApplicationDefault_nullTransport_throws() throws IOException {
-    try {
-      GoogleCredentials.getApplicationDefault(null);
-      fail();
-    } catch (NullPointerException expected) {
-      // Expected
-    }
+  void getApplicationDefault_nullTransport_throws() {
+    assertThrows(NullPointerException.class, () -> GoogleCredentials.getApplicationDefault(null));
   }
 
   @Test
-  public void fromStream_nullTransport_throws() throws IOException {
+  void fromStream_nullTransport_throws() {
     InputStream stream = new ByteArrayInputStream("foo".getBytes());
-    try {
-      GoogleCredentials.fromStream(stream, null);
-      fail("Should throw if HttpTransportFactory is null");
-    } catch (NullPointerException expected) {
-      // Expected
-    }
+    assertThrows(
+        NullPointerException.class,
+        () -> GoogleCredentials.fromStream(stream, null),
+        "Should throw if HttpTransportFactory is null");
   }
 
   @Test
-  public void fromStream_nullStream_throws() throws IOException {
+  void fromStream_nullStream_throws() {
     MockHttpTransportFactory transportFactory = new MockHttpTransportFactory();
-    try {
-      GoogleCredentials.fromStream(null, transportFactory);
-      fail("Should throw if InputStream is null");
-    } catch (NullPointerException expected) {
-      // Expected
-    }
+    assertThrows(
+        NullPointerException.class,
+        () -> GoogleCredentials.fromStream(null, transportFactory),
+        "Should throw if InputStream is null");
   }
 
   @Test
-  public void fromStream_serviceAccount_providesToken() throws IOException {
+  void fromStream_serviceAccount_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
     InputStream serviceAccountStream =
@@ -157,7 +145,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_serviceAccountNoClientId_throws() throws IOException {
+  void fromStream_serviceAccountNoClientId_throws() throws IOException {
     InputStream serviceAccountStream =
         ServiceAccountCredentialsTest.writeServiceAccountStream(
             null, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
@@ -166,7 +154,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_serviceAccountNoClientEmail_throws() throws IOException {
+  void fromStream_serviceAccountNoClientEmail_throws() throws IOException {
     InputStream serviceAccountStream =
         ServiceAccountCredentialsTest.writeServiceAccountStream(
             SA_CLIENT_ID, null, SA_PRIVATE_KEY_PKCS8, SA_PRIVATE_KEY_ID);
@@ -175,7 +163,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_serviceAccountNoPrivateKey_throws() throws IOException {
+  void fromStream_serviceAccountNoPrivateKey_throws() throws IOException {
     InputStream serviceAccountStream =
         ServiceAccountCredentialsTest.writeServiceAccountStream(
             SA_CLIENT_ID, SA_CLIENT_EMAIL, null, SA_PRIVATE_KEY_ID);
@@ -184,7 +172,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_serviceAccountNoPrivateKeyId_throws() throws IOException {
+  void fromStream_serviceAccountNoPrivateKeyId_throws() throws IOException {
     InputStream serviceAccountStream =
         ServiceAccountCredentialsTest.writeServiceAccountStream(
             SA_CLIENT_ID, SA_CLIENT_EMAIL, SA_PRIVATE_KEY_PKCS8, null);
@@ -193,7 +181,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_user_providesToken() throws IOException {
+  void fromStream_user_providesToken() throws IOException {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(USER_CLIENT_ID, USER_CLIENT_SECRET);
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
@@ -209,7 +197,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_userNoClientId_throws() throws IOException {
+  void fromStream_userNoClientId_throws() throws IOException {
     InputStream userStream =
         UserCredentialsTest.writeUserStream(null, USER_CLIENT_SECRET, REFRESH_TOKEN, QUOTA_PROJECT);
 
@@ -217,7 +205,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_userNoClientSecret_throws() throws IOException {
+  void fromStream_userNoClientSecret_throws() throws IOException {
     InputStream userStream =
         UserCredentialsTest.writeUserStream(USER_CLIENT_ID, null, REFRESH_TOKEN, QUOTA_PROJECT);
 
@@ -225,7 +213,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_userNoRefreshToken_throws() throws IOException {
+  void fromStream_userNoRefreshToken_throws() throws IOException {
     InputStream userStream =
         UserCredentialsTest.writeUserStream(
             USER_CLIENT_ID, USER_CLIENT_SECRET, null, QUOTA_PROJECT);
@@ -234,7 +222,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_identityPoolCredentials_providesToken() throws IOException {
+  void fromStream_identityPoolCredentials_providesToken() throws IOException {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     InputStream identityPoolCredentialStream =
@@ -253,7 +241,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_awsCredentials_providesToken() throws IOException {
+  void fromStream_awsCredentials_providesToken() throws IOException {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
 
@@ -273,7 +261,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_Impersonation_providesToken_WithQuotaProject() throws IOException {
+  void fromStream_Impersonation_providesToken_WithQuotaProject() throws IOException {
     MockTokenServerTransportFactory transportFactoryForSource =
         new MockTokenServerTransportFactory();
     transportFactoryForSource.transport.addServiceAccount(
@@ -307,7 +295,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void fromStream_Impersonation_providesToken_WithoutQuotaProject() throws IOException {
+  void fromStream_Impersonation_providesToken_WithoutQuotaProject() throws IOException {
     MockTokenServerTransportFactory transportFactoryForSource =
         new MockTokenServerTransportFactory();
     transportFactoryForSource.transport.addServiceAccount(
@@ -338,7 +326,7 @@ public class GoogleCredentialsTest {
   }
 
   @Test
-  public void createScoped_overloadCallsImplementation() {
+  void createScoped_overloadCallsImplementation() {
     final AtomicReference<Collection<String>> called = new AtomicReference<>();
     final GoogleCredentials expectedScopedCredentials = new GoogleCredentials();
 
@@ -358,13 +346,12 @@ public class GoogleCredentialsTest {
   }
 
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
-    try {
-      GoogleCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);
-      fail(
-          String.format(
-              "Should throw exception with message containing '%s'", expectedMessageContent));
-    } catch (IOException expected) {
-      assertTrue(expected.getMessage().contains(expectedMessageContent));
-    }
+    IOException exception =
+        assertThrows(
+            IOException.class,
+            () -> GoogleCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY),
+            String.format(
+                "Should throw exception with message containing '%s'", expectedMessageContent));
+    assertTrue(exception.getMessage().contains(expectedMessageContent));
   }
 }


### PR DESCRIPTION
It belongs to #756 . Second iteration for oauth2_http module.