### PR TITLE
fix: environment variable is "AWS_SESSION_TOKEN" and not "Token"

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -273,7 +273,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
     // Check environment variables for credentials first.
     String accessKeyId = getEnvironmentProvider().getEnv("AWS_ACCESS_KEY_ID");
     String secretAccessKey = getEnvironmentProvider().getEnv("AWS_SECRET_ACCESS_KEY");
-    String token = getEnvironmentProvider().getEnv("Token");
+    String token = getEnvironmentProvider().getEnv("AWS_SESSION_TOKEN");
     if (accessKeyId != null && secretAccessKey != null) {
       return new AwsSecurityCredentials(accessKeyId, secretAccessKey, token);
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -276,7 +276,7 @@ class AwsCredentialsTest {
     environmentProvider
         .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
         .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey")
-        .setEnv("Token", "token");
+        .setEnv("AWS_SESSION_TOKEN", "awsSessionToken");
 
     AwsCredentials testAwsCredentials =
         (AwsCredentials)
@@ -288,7 +288,7 @@ class AwsCredentialsTest {
 
     assertEquals("awsAccessKeyId", credentials.getAccessKeyId());
     assertEquals("awsSecretAccessKey", credentials.getSecretAccessKey());
-    assertEquals("token", credentials.getToken());
+    assertEquals("awsSessionToken", credentials.getToken());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsRequestSignerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsRequestSignerTest.java
@@ -535,9 +535,9 @@ class AwsRequestSignerTest {
 
     GenericJson json = parser.parseAndClose(stream, StandardCharsets.UTF_8, GenericJson.class);
 
-    String awsToken = (String) json.get("Token");
-    String secretAccessKey = (String) json.get("SecretAccessKey");
     String accessKeyId = (String) json.get("AccessKeyId");
+    String secretAccessKey = (String) json.get("SecretAccessKey");
+    String awsToken = (String) json.get("Token");
 
     return new AwsSecurityCredentials(accessKeyId, secretAccessKey, awsToken);
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
@@ -138,7 +138,7 @@ class ITWorkloadIdentityFederationTest {
     testEnvironmentProvider
         .setEnv("AWS_ACCESS_KEY_ID", awsAccessKeyId)
         .setEnv("AWS_SECRET_ACCESS_KEY", awsSecretAccessKey)
-        .setEnv("Token", awsSessionToken)
+        .setEnv("AWS_SESSION_TOKEN", awsSessionToken)
         .setEnv("AWS_REGION", "us-east-2");
 
     AwsCredentials awsCredential =


### PR DESCRIPTION
For AWS, the environment variable to retrieve the session token is "AWS_SESSION_TOKEN". 

See b/203688830.

