### PR TITLE
chore: update README to migrate deprecated usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you are using Gradle, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Groovy
-compile 'com.google.auth:google-auth-library-oauth2-http:1.3.0'
+implementation 'com.google.auth:google-auth-library-oauth2-http:1.3.0'
 ```
 [//]: # ({x-version-update-end})
 

--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@
       </activation>
       <properties>
         <!-- default config values -->
-        <docletName>java-docfx-doclet-1.3.0</docletName>
+        <docletName>java-docfx-doclet-1.4.0</docletName>
         <outputpath>${project.build.directory}/docfx-yml</outputpath>
         <projectname>${project.artifactId}</projectname>
         <excludeclasses></excludeclasses>


### PR DESCRIPTION
The `compile` configuration doesn't work in recent Gradle versions.