### PR TITLE
feat: setting the audience to always point to google token endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/
 .classpath
 .project
 .settings
+.factorypath
 
 # Intellij
 *.iml
@@ -12,3 +13,6 @@ target/
 
 # VS Code
 .vscode/
+
+# MacOS
+.DS_Store

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -882,8 +882,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
         && Objects.equals(this.useJwtAccessWithScope, other.useJwtAccessWithScope);
   }
 
-  String createAssertion(JsonFactory jsonFactory, long currentTime)
-      throws IOException {
+  String createAssertion(JsonFactory jsonFactory, long currentTime) throws IOException {
     JsonWebSignature.Header header = new JsonWebSignature.Header();
     header.setAlgorithm("RS256");
     header.setType("JWT");

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -567,7 +567,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
   public AccessToken refreshAccessToken() throws IOException {
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTime = clock.currentTimeMillis();
-    String assertion = createAssertion(jsonFactory, currentTime, tokenServerUri.toString());
+    String assertion = createAssertion(jsonFactory, currentTime);
 
     GenericData tokenRequest = new GenericData();
     tokenRequest.set("grant_type", GRANT_TYPE);
@@ -882,7 +882,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
         && Objects.equals(this.useJwtAccessWithScope, other.useJwtAccessWithScope);
   }
 
-  String createAssertion(JsonFactory jsonFactory, long currentTime, String audience)
+  String createAssertion(JsonFactory jsonFactory, long currentTime)
       throws IOException {
     JsonWebSignature.Header header = new JsonWebSignature.Header();
     header.setAlgorithm("RS256");
@@ -900,13 +900,9 @@ public class ServiceAccountCredentials extends GoogleCredentials
       payload.put("scope", Joiner.on(' ').join(scopes));
     }
 
-    if (audience == null) {
-      payload.setAudience(OAuth2Utils.TOKEN_SERVER_URI.toString());
-    } else {
-      payload.setAudience(audience);
-    }
-
+    payload.setAudience(OAuth2Utils.TOKEN_SERVER_URI.toString());
     String assertion;
+
     try {
       assertion = JsonWebSignature.signUsingRsaSha256(privateKey, jsonFactory, header, payload);
     } catch (GeneralSecurityException e) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -242,7 +242,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis, null);
+    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis);
 
     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
     JsonWebToken.Payload payload = signature.getPayload();
@@ -272,7 +272,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis, null);
+    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis);
 
     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
     JsonWebToken.Payload payload = signature.getPayload();
@@ -290,7 +290,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis, null);
+    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis);
 
     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
     JsonWebToken.Payload payload = signature.getPayload();
@@ -370,36 +370,6 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
     assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
     assertEquals(USER, payload.getSubject());
-  }
-
-  @Test
-  void createAssertion_withTokenUri_correct() throws IOException {
-    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(PRIVATE_KEY_PKCS8);
-    List<String> scopes = Arrays.asList("scope1", "scope2");
-    ServiceAccountCredentials credentials =
-        ServiceAccountCredentials.newBuilder()
-            .setClientId(CLIENT_ID)
-            .setClientEmail(CLIENT_EMAIL)
-            .setPrivateKey(privateKey)
-            .setPrivateKeyId(PRIVATE_KEY_ID)
-            .setScopes(scopes)
-            .setServiceAccountUser(USER)
-            .setProjectId(PROJECT_ID)
-            .build();
-
-    JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
-    long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-    String assertion =
-        credentials.createAssertion(jsonFactory, currentTimeMillis, "https://foo.com/bar");
-
-    JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
-    JsonWebToken.Payload payload = signature.getPayload();
-    assertEquals(CLIENT_EMAIL, payload.getIssuer());
-    assertEquals("https://foo.com/bar", payload.getAudience());
-    assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
-    assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
-    assertEquals(USER, payload.getSubject());
-    assertEquals(String.join(" ", scopes), payload.get("scope"));
   }
 
   @Test


### PR DESCRIPTION
After this change, service account can send requests to the private endpoint (if configured) and still use the oauth2.googleapis.com/token in the assertion.

Fixes #809 ☕️
