### PR TITLE
Fixes GCE residency check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ target/
 .classpath
 .project
 .settings
-.factorypath
 
 # Intellij
 *.iml
@@ -14,6 +13,3 @@ target/
 
 # VS Code
 .vscode/
-
-# MacOS
-.DS_Store

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineUtils.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
+import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.SocketTimeoutException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Locale;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class ComputeEngineUtils {
+  private static final Logger LOGGER = Logger.getLogger(ComputeEngineUtils.class.getName());
+  private static final String WINDOWS_COMMAND = "powershell.exe";
+  private static final String METADATA_FLAVOR = "Metadata-Flavor";
+  private static final String GOOGLE = "Google";
+
+  // Note: the explicit `timeout` and `tries` below is a workaround. The underlying
+  // issue is that resolving an unknown host on some networks will take
+  // 20-30 seconds; making this timeout short fixes the issue, but
+  // could lead to false negatives in the event that we are on GCE, but
+  // the metadata resolution was particularly slow. The latter case is
+  // "unlikely" since the expected 4-nines time is about 0.5 seconds.
+  // This allows us to limit the total ping maximum timeout to 1.5 seconds
+  // for developer desktop scenarios.
+  static final int MAX_COMPUTE_PING_TRIES = 3;
+  static final int COMPUTE_PING_CONNECTION_TIMEOUT_MS = 500;
+  static final String DEFAULT_METADATA_SERVER_URL = "http://metadata.google.internal";
+
+  private ComputeEngineUtils() {}
+
+  /** Returns {@code true} if currently running on Google Compute Environment (GCE). */
+  public static synchronized boolean isOnGce(HttpTransportFactory transportFactory, DefaultCredentialsProvider provider) {
+    boolean result = isRunningOnGce();
+
+    if (!result) {
+      result = pingComputeEngineMetadata(transportFactory, provider);
+    }
+    return result;
+  }
+
+  @VisibleForTesting
+  static boolean checkProductNameOnLinux(BufferedReader reader) throws IOException {
+    String name = reader.readLine().trim();
+    return name.equals("Google") || name.equals("Google Compute Engine");
+  }
+
+  @VisibleForTesting
+  static boolean checkBiosDataOnWindows(BufferedReader reader) throws IOException {
+    String line;
+    while ((line = reader.readLine()) != null) {
+      if (line.startsWith("Manufacturer")) {
+        String name = line.substring(line.indexOf(':') + 1).trim();
+        return name.equals("Google");
+      }
+    }
+    return false;
+  }
+
+  private static boolean isRunningOnGce() {
+    String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+    try {
+      if (osName.startsWith("linux")) {
+        // Checks GCE residency on Linux platform.
+        return checkProductNameOnLinux(
+            Files.newBufferedReader(Paths.get("/sys/class/dmi/id/product_name"), UTF_8));
+      } else if (osName.startsWith("windows")) {
+        // Checks GCE residency on Windows platform.
+        Process p =
+            new ProcessBuilder()
+                .command(WINDOWS_COMMAND, "Get-WmiObject", "-Class", "Win32_BIOS")
+                .start();
+        return checkBiosDataOnWindows(
+            new BufferedReader(new InputStreamReader(p.getInputStream(), UTF_8)));
+      }
+    } catch (IOException e) {
+      return false;
+    }
+    // Platforms other than Linux and Windows are not supported.
+    return false;
+  }
+
+  private static boolean pingComputeEngineMetadata(
+      HttpTransportFactory transportFactory, DefaultCredentialsProvider provider) {
+
+    GenericUrl tokenUrl = new GenericUrl(getMetadataServerUrl(provider));
+    for (int i = 1; i <= MAX_COMPUTE_PING_TRIES; ++i) {
+      try {
+        HttpRequest request =
+            transportFactory.create().createRequestFactory().buildGetRequest(tokenUrl);
+        request.setConnectTimeout(COMPUTE_PING_CONNECTION_TIMEOUT_MS);
+        request.getHeaders().set(METADATA_FLAVOR, GOOGLE);
+
+        HttpResponse response = request.execute();
+        try {
+          // Internet providers can return a generic response to all requests, so it is necessary
+          // to check that metadata header is present also.
+          HttpHeaders headers = response.getHeaders();
+          return OAuth2Utils.headersContainValue(headers, METADATA_FLAVOR, GOOGLE);
+        } finally {
+          response.disconnect();
+        }
+      } catch (SocketTimeoutException expected) {
+        // Ignore logging timeouts which is the expected failure mode in non GCE environments.
+      } catch (IOException e) {
+        LOGGER.log(
+            Level.FINE,
+            "Encountered an unexpected exception when determining"
+                + " if we are running on Google Compute Engine.",
+            e);
+      }
+    }
+    LOGGER.log(Level.FINE, "Failed to detect whether we are running on Google Compute Engine.");
+    return false;
+  }
+
+  public static String getMetadataServerUrl(DefaultCredentialsProvider provider) {
+    String metadataServerAddress =
+        provider.getEnv(DefaultCredentialsProvider.GCE_METADATA_HOST_ENV_VAR);
+    if (metadataServerAddress != null) {
+      return "http://" + metadataServerAddress;
+    }
+    return DEFAULT_METADATA_SERVER_URL;
+  }
+
+  public static String getMetadataServerUrl() {
+    return getMetadataServerUrl(DefaultCredentialsProvider.DEFAULT);
+  }
+
+  public static String getTokenServerEncodedUrl(DefaultCredentialsProvider provider) {
+    return getMetadataServerUrl(provider)
+        + "/computeMetadata/v1/instance/service-accounts/default/token";
+  }
+
+  public static String getTokenServerEncodedUrl() {
+    return getTokenServerEncodedUrl(DefaultCredentialsProvider.DEFAULT);
+  }
+
+  public static String getServiceAccountsUrl() {
+    return getMetadataServerUrl(DefaultCredentialsProvider.DEFAULT)
+        + "/computeMetadata/v1/instance/service-accounts/?recursive=true";
+  }
+
+  public static String getIdentityDocumentUrl() {
+    return getMetadataServerUrl(DefaultCredentialsProvider.DEFAULT)
+        + "/computeMetadata/v1/instance/service-accounts/default/identity";
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -831,7 +831,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
         && Objects.equals(this.defaultRetriesEnabled, other.defaultRetriesEnabled);
   }
 
-  String createAssertion(JsonFactory jsonFactory, long currentTime) throws IOException {
+  String createAssertion(JsonFactory jsonFactory, long currentTime)
+      throws IOException {
     JsonWebSignature.Header header = new JsonWebSignature.Header();
     header.setAlgorithm("RS256");
     header.setType("JWT");

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -159,14 +159,14 @@ class DefaultCredentialsProviderTest {
         "No credential expected.");
     assertEquals(
         transportFactory.transport.getRequestCount(),
-        ComputeEngineCredentials.MAX_COMPUTE_PING_TRIES);
+        ComputeEngineUtils.MAX_COMPUTE_PING_TRIES);
     assertThrows(
         IOException.class,
         () -> testProvider.getDefaultCredentials(transportFactory),
         "No credential expected.");
     assertEquals(
         transportFactory.transport.getRequestCount(),
-        ComputeEngineCredentials.MAX_COMPUTE_PING_TRIES);
+        ComputeEngineUtils.MAX_COMPUTE_PING_TRIES);
   }
 
   @Test
@@ -337,7 +337,7 @@ class DefaultCredentialsProviderTest {
     String testUrl = "192.0.2.0";
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.GCE_METADATA_HOST_ENV_VAR, testUrl);
-    assertEquals(ComputeEngineCredentials.getMetadataServerUrl(testProvider), "http://" + testUrl);
+    assertEquals(ComputeEngineUtils.getMetadataServerUrl(testProvider), "http://" + testUrl);
   }
 
   @Test
@@ -346,7 +346,7 @@ class DefaultCredentialsProviderTest {
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setEnv(DefaultCredentialsProvider.GCE_METADATA_HOST_ENV_VAR, testUrl);
     assertEquals(
-        ComputeEngineCredentials.getTokenServerEncodedUrl(testProvider),
+        ComputeEngineUtils.getTokenServerEncodedUrl(testProvider),
         "http://" + testUrl + "/computeMetadata/v1/instance/service-accounts/default/token");
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -82,7 +82,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
 
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
-    if (url.equals(ComputeEngineCredentials.getTokenServerEncodedUrl())) {
+    if (url.equals(ComputeEngineUtils.getTokenServerEncodedUrl())) {
 
       return new MockLowLevelHttpRequest(url) {
         @Override
@@ -112,7 +112,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
               .setContent(refreshText);
         }
       };
-    } else if (url.equals(ComputeEngineCredentials.getMetadataServerUrl())) {
+    } else if (url.equals(ComputeEngineUtils.getMetadataServerUrl())) {
       return new MockLowLevelHttpRequest(url) {
         @Override
         public LowLevelHttpResponse execute() {
@@ -214,7 +214,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
   }
 
   protected boolean isGetServiceAccountsUrl(String url) {
-    return url.equals(ComputeEngineCredentials.getServiceAccountsUrl());
+    return url.equals(ComputeEngineUtils.getServiceAccountsUrl());
   }
 
   protected boolean isSignRequestUrl(String url) {
@@ -224,6 +224,6 @@ public class MockMetadataServerTransport extends MockHttpTransport {
   }
 
   protected boolean isIdentityDocumentUrl(String url) {
-    return url.startsWith(String.format(ComputeEngineCredentials.getIdentityDocumentUrl()));
+    return url.startsWith(String.format(ComputeEngineUtils.getIdentityDocumentUrl()));
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -244,7 +244,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis);
+    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis, null);
 
     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
     JsonWebToken.Payload payload = signature.getPayload();
@@ -274,7 +274,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis);
+    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis, null);
 
     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
     JsonWebToken.Payload payload = signature.getPayload();
@@ -292,7 +292,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
-    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis);
+    String assertion = credentials.createAssertion(jsonFactory, currentTimeMillis, null);
 
     JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
     JsonWebToken.Payload payload = signature.getPayload();
@@ -372,6 +372,36 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
     assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
     assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
     assertEquals(USER, payload.getSubject());
+  }
+
+  @Test
+  void createAssertion_withTokenUri_correct() throws IOException {
+    PrivateKey privateKey = ServiceAccountCredentials.privateKeyFromPkcs8(PRIVATE_KEY_PKCS8);
+    List<String> scopes = Arrays.asList("scope1", "scope2");
+    ServiceAccountCredentials credentials =
+        ServiceAccountCredentials.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setClientEmail(CLIENT_EMAIL)
+            .setPrivateKey(privateKey)
+            .setPrivateKeyId(PRIVATE_KEY_ID)
+            .setScopes(scopes)
+            .setServiceAccountUser(USER)
+            .setProjectId(PROJECT_ID)
+            .build();
+
+    JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
+    long currentTimeMillis = Clock.SYSTEM.currentTimeMillis();
+    String assertion =
+        credentials.createAssertion(jsonFactory, currentTimeMillis, "https://foo.com/bar");
+
+    JsonWebSignature signature = JsonWebSignature.parse(jsonFactory, assertion);
+    JsonWebToken.Payload payload = signature.getPayload();
+    assertEquals(CLIENT_EMAIL, payload.getIssuer());
+    assertEquals("https://foo.com/bar", payload.getAudience());
+    assertEquals(currentTimeMillis / 1000, (long) payload.getIssuedAtTimeSeconds());
+    assertEquals(currentTimeMillis / 1000 + 3600, (long) payload.getExpirationTimeSeconds());
+    assertEquals(USER, payload.getSubject());
+    assertEquals(String.join(" ", scopes), payload.get("scope"));
   }
 
   @Test


### PR DESCRIPTION
Current GCE residency check depends on network stack initialization and therefore error-prone. 
With this fix, library will check unique environment variables to detect GCE residency. 

For more details: go/auth-library-noping
