### PR TITLE
Fix class-cast-exception

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -365,12 +365,19 @@ public class ImpersonatedCredentials extends GoogleCredentials
   @Override
   public GoogleCredentials createScoped(Collection<String> scopes) {
     return toBuilder()
-        .setScopes((List<String>) scopes)
+        .setScopes(toList(scopes))
         .setLifetime(this.lifetime)
         .setDelegates(this.delegates)
         .setHttpTransportFactory(this.transportFactory)
         .setQuotaProjectId(this.quotaProjectId)
         .build();
+  }
+
+  private static <T> List<T> toList(Collection<T> collection) {
+    if (collection instanceof List) {
+      return (List<T>) collection;
+    }
+    return new ArrayList<>(collection);
   }
 
   @Override

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -64,6 +64,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -842,6 +843,14 @@ class ImpersonatedCredentialsTest extends BaseSerializationTest {
     assertEquals(targetCredentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(targetCredentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
+  }
+
+  @Test
+  void testCreateScoped() {
+    final ImpersonatedCredentials credentials =
+        ImpersonatedCredentials.newBuilder().setScopes(new ArrayList<>()).build();
+    // Verify that this does not throw an exception
+    credentials.createScoped(new HashSet<>());
   }
 
   public static String getDefaultExpireTime() {


### PR DESCRIPTION
Observed problem:

    Caused by: java.lang.ClassCastException: class com.google.common.collect.SingletonImmutableSet cannot be cast to class java.util.List (com.google.common.collect.SingletonImmutableSet is in unnamed module of loader 'app'; java.util.List is in module java.base of loader 'bootstrap')
	at com.google.auth.oauth2.ImpersonatedCredentials.createScoped(ImpersonatedCredentials.java:367)
	at com.google.cloud.ServiceOptions.getScopedCredentials(ServiceOptions.java:596)
	at com.google.cloud.http.HttpTransportOptions.getHttpRequestInitializer(HttpTransportOptions.java:145)
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.<init>(HttpStorageRpc.java:111)
	at com.google.cloud.storage.StorageOptions$DefaultStorageRpcFactory.create(StorageOptions.java:55)
	at com.google.cloud.storage.StorageOptions$DefaultStorageRpcFactory.create(StorageOptions.java:49)
	at com.google.cloud.ServiceOptions.getRpc(ServiceOptions.java:560)
	at com.google.cloud.storage.StorageOptions.getStorageRpcV1(StorageOptions.java:121)
	at com.google.cloud.storage.StorageImpl.<init>(StorageImpl.java:111)
	at com.google.cloud.storage.StorageOptions$DefaultStorageFactory.create(StorageOptions.java:45)
	at com.google.cloud.storage.StorageOptions$DefaultStorageFactory.create(StorageOptions.java:39)
	at com.google.cloud.ServiceOptions.getService(ServiceOptions.java:540)

Fixes #887