### PR TITLE
fix: update branding in ExternalAccountCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -58,7 +58,8 @@ import javax.annotation.Nullable;
 /**
  * Base external account credentials class.
  *
- * <p>Handles initializing external credentials, calls to STS, and service account impersonation.
+ * <p>Handles initializing external credentials, calls to the Security Token Service, and service
+ * account impersonation.
  */
 public abstract class ExternalAccountCredentials extends GoogleCredentials
     implements QuotaProjectIdProvider {
@@ -89,8 +90,9 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
   @Nullable private final String clientId;
   @Nullable private final String clientSecret;
 
-  // This is used for Workforce Pools. It is passed to STS during token exchange in the
-  // `options` param and will be embedded in the token by STS.
+  // This is used for Workforce Pools. It is passed to the Security Token Service during token
+  // exchange in the `options` param and will be embedded in the token by the Security Token
+  // Service.
   @Nullable private final String workforcePoolUserProject;
 
   protected transient HttpTransportFactory transportFactory;
@@ -104,18 +106,17 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
    * workforce credentials.
    *
    * @param transportFactory HTTP transport factory, creates the transport used to get access tokens
-   * @param audience the STS audience which is usually the fully specified resource name of the
-   *     workload/workforce pool provider
-   * @param subjectTokenType the STS subject token type based on the OAuth 2.0 token exchange spec.
-   *     Indicates the type of the security token in the credential file
-   * @param tokenUrl the STS token exchange endpoint
+   * @param audience the Security Token Service audience, which is usually the fully specified
+   *     resource name of the workload/workforce pool provider
+   * @param subjectTokenType the Security Token Service subject token type based on the OAuth 2.0
+   *     token exchange spec. Indicates the type of the security token in the credential file
+   * @param tokenUrl the Security Token Service token exchange endpoint
    * @param tokenInfoUrl the endpoint used to retrieve account related information. Required for
    *     gCloud session account identification.
    * @param credentialSource the external credential source
    * @param serviceAccountImpersonationUrl the URL for the service account impersonation request.
-   *     This is only required for workload identity pools when APIs to be accessed have not
-   *     integrated with UberMint. If this is not available, the STS returned GCP access token is
-   *     directly used. May be null.
+   *     This URL is required for some APIs. If this URL is not available, the access token from the
+   *     Security Token Service is used directly. May be null.
    * @param quotaProjectId the project used for quota and billing purposes. May be null.
    * @param clientId client ID of the service account from the console. May be null.
    * @param clientSecret client secret of the service account from the console. May be null.
@@ -395,11 +396,11 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
   }
 
   /**
-   * Exchanges the external credential for a GCP access token.
+   * Exchanges the external credential for a Google Cloud access token.
    *
-   * @param stsTokenExchangeRequest the STS token exchange request
-   * @return the access token returned by STS
-   * @throws OAuthException if the call to STS fails
+   * @param stsTokenExchangeRequest the Security Token Service token exchange request
+   * @return the access token returned by the Security Token Service
+   * @throws OAuthException if the call to the Security Token Service fails
    */
   protected AccessToken exchangeExternalCredentialForAccessToken(
       StsTokenExchangeRequest stsTokenExchangeRequest) throws IOException {
@@ -413,7 +414,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
             tokenUrl, stsTokenExchangeRequest, transportFactory.create().createRequestFactory());
 
     // If this credential was initialized with a Workforce configuration then the
-    // workforcePoolUserProject must passed to STS via the the internal options param.
+    // workforcePoolUserProject must be passed to the Security Token Service via the internal
+    // options param.
     if (isWorkforcePoolConfiguration()) {
       GenericJson options = new GenericJson();
       options.setFactory(OAuth2Utils.JSON_FACTORY);
@@ -431,7 +433,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
   }
 
   /**
-   * Retrieves the external subject token to be exchanged for a GCP access token.
+   * Retrieves the external subject token to be exchanged for a Google Cloud access token.
    *
    * <p>Must be implemented by subclasses as the retrieval method is dependent on the credential
    * source.
@@ -603,8 +605,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     }
 
     /**
-     * Sets the STS audience which is usually the fully specified resource name of the
-     * workload/workforce pool provider.
+     * Sets the Security Token Service audience, which is usually the fully specified resource name
+     * of the workload/workforce pool provider.
      */
     public Builder setAudience(String audience) {
       this.audience = audience;
@@ -612,15 +614,15 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     }
 
     /**
-     * Sets the STS subject token type based on the OAuth 2.0 token exchange spec. Indicates the
-     * type of the security token in the credential file.
+     * Sets the Security Token Service subject token type based on the OAuth 2.0 token exchange
+     * spec. Indicates the type of the security token in the credential file.
      */
     public Builder setSubjectTokenType(String subjectTokenType) {
       this.subjectTokenType = subjectTokenType;
       return this;
     }
 
-    /** Sets the STS token exchange endpoint. */
+    /** Sets the Security Token Service token exchange endpoint. */
     public Builder setTokenUrl(String tokenUrl) {
       this.tokenUrl = tokenUrl;
       return this;
@@ -633,9 +635,9 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     }
 
     /**
-     * Sets the optional URL used for service account impersonation. This is only required when APIs
-     * to be accessed have not integrated with UberMint. If this is not available, the STS returned
-     * GCP access token is directly used.
+     * Sets the optional URL used for service account impersonation, which is required for some
+     * APIs. If this URL is not available, the access token from the Security Token Service is used
+     * directly.
      */
     public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
       this.serviceAccountImpersonationUrl = serviceAccountImpersonationUrl;


### PR DESCRIPTION
These changes align the Javadoc comments with the branding that Google uses externally:

+ STS -> Security Token Service
+ GCP -> Google Cloud
+ Remove references to a Google-internal token type

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass: Tests are failing, but I don't think that was caused by the changes in this PR
- [ ] Code coverage does not decrease (if any source code was changed): n/a
- [ ] Appropriate docs were updated (if necessary): n/a
