### PR TITLE
Override AwsSecurityCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -376,6 +376,12 @@ public class AwsCredentials extends ExternalAccountCredentials {
     return new AwsCredentials.Builder(awsCredentials);
   }
 
+  public static class SecurityCredentials extends AwsSecurityCredentials {
+    public SecurityCredentials(String accessKeyId, String secretAccessKey, @Nullable String token) {
+      super(accessKeyId, secretAccessKey, token);
+    }
+  }
+
   public static class Builder extends ExternalAccountCredentials.Builder {
 
     protected AwsSecurityCredentials awsSecurityCredentials;
@@ -392,7 +398,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
       return new AwsCredentials(this);
     }
 
-    public Builder setAwsSecurityCredentials(AwsSecurityCredentials awsSecurityCredentials) {
+    public Builder setAwsSecurityCredentials(SecurityCredentials awsSecurityCredentials) {
       this.awsSecurityCredentials = awsSecurityCredentials;
       return this;
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -34,6 +34,7 @@ package com.google.auth.oauth2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -373,6 +374,23 @@ class AwsCredentialsTest {
     // No requests because the credential source does not contain region URL.
     List<MockLowLevelHttpRequest> requests = transportFactory.transport.getRequests();
     assertTrue(requests.isEmpty());
+  }
+
+  @Test
+  void getAwsSecurityCredentials_fromBuilderVariable() throws IOException {
+    AwsSecurityCredentials testAwsSecurityCredentials = new AwsSecurityCredentials(
+        "awsAccessKeyId", "awsSecretAccessKey", null);
+
+    AwsCredentials testAwsCredentials =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setAwsSecurityCredentials(testAwsSecurityCredentials)
+                .build();
+
+    AwsSecurityCredentials credentials =
+        testAwsCredentials.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);
+
+    assertSame(testAwsSecurityCredentials, credentials);
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -43,6 +43,7 @@ import com.google.api.client.json.JsonParser;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.auth.TestUtils;
 import com.google.auth.oauth2.AwsCredentials.AwsCredentialSource;
+import com.google.auth.oauth2.AwsCredentials.SecurityCredentials;
 import com.google.auth.oauth2.ExternalAccountCredentialsTest.MockExternalAccountCredentialsTransportFactory;
 import java.io.IOException;
 import java.io.InputStream;
@@ -378,14 +379,13 @@ class AwsCredentialsTest {
 
   @Test
   void getAwsSecurityCredentials_fromBuilderVariable() throws IOException {
-    AwsSecurityCredentials testAwsSecurityCredentials = new AwsSecurityCredentials(
+    SecurityCredentials testAwsSecurityCredentials = new SecurityCredentials(
         "awsAccessKeyId", "awsSecretAccessKey", null);
 
     AwsCredentials testAwsCredentials =
-        (AwsCredentials)
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setAwsSecurityCredentials(testAwsSecurityCredentials)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setAwsSecurityCredentials(testAwsSecurityCredentials)
+            .build();
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);


### PR DESCRIPTION
See https://issuetracker.google.com/issues/238911014

When using a Web Identity token file (`AWS_WEB_IDENTITY_TOKEN_FILE`) to authenticate with AWS, environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` are not set.

While the existing implementation then makes a request to Amazon's EC2 metadata service endpoint; when the Java instance is running in a pod in EKS, the metadata endpoint does not return metadata for the pod, but for the underlying EKS node.

To work around this, we can optionally set these variables in the credential builder instead of looking up the env variables or polling the metadata endpoint.
