### PR TITLE
fix: change revoke request from get to post

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -315,10 +315,14 @@ public class UserAuthorizer {
         OAuth2Utils.validateOptionalString(tokenJson, "refresh_token", TOKEN_STORE_ERROR);
     // If both tokens are present, either can be used
     String revokeToken = (refreshToken != null) ? refreshToken : accessTokenValue;
+
     GenericUrl revokeUrl = new GenericUrl(OAuth2Utils.TOKEN_REVOKE_URI);
-    revokeUrl.put("token", revokeToken);
+    GenericData genericData = new GenericData();
+    genericData.put("token", revokeToken);
+    UrlEncodedContent content = new UrlEncodedContent(genericData);
+
     HttpRequestFactory requestFactory = transportFactory.create().createRequestFactory();
-    HttpRequest tokenRequest = requestFactory.buildGetRequest(revokeUrl);
+    HttpRequest tokenRequest = requestFactory.buildPostRequest(revokeUrl, content);
     tokenRequest.execute();
 
     if (deleteTokenException != null) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -257,7 +257,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
       return new MockLowLevelHttpRequest(url) {
         @Override
         public LowLevelHttpResponse execute() throws IOException {
-          Map<String, String> parameters = TestUtils.parseQuery(query);
+          Map<String, String> parameters = TestUtils.parseQuery(this.getContentAsString());
           String token = parameters.get("token");
           if (token == null) {
             throw new IOException("Token to revoke not found.");


### PR DESCRIPTION
https://oauth2.googleapis.com/revoke does not have a GET endpoint. It has only a POST. So updating the code accordingly.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<782> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
