### PR TITLE
feat: adds configurable token lifetime support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ credentials as well as utility methods to create them and to get Application Def
       * [Accessing resources from Azure](#access-resources-from-microsoft-azure)
       * [Accessing resources from an OIDC identity provider](#accessing-resources-from-an-oidc-identity-provider)
       * [Accessing resources using Executable-sourced credentials](#using-executable-sourced-credentials-with-oidc-and-saml)
+      * [Configurable Token Lifetime](#configurable-token-lifetime)
   * [Workforce Identity Federation](#workforce-identity-federation)
       * [Accessing resources using an OIDC or SAML 2.0 identity provider](#accessing-resources-using-an-oidc-or-saml-20-identity-provider)
       * [Accessing resources using Executable-sourced credentials](#using-executable-sourced-workforce-credentials-with-oidc-and-saml)
@@ -466,6 +467,34 @@ credentials unless they do not meet your specific requirements.
 
 You can now [use the Auth library](#using-external-identities) to call Google Cloud
 resources from an OIDC or SAML provider.
+
+#### Configurable Token Lifetime
+When creating a credential configuration with workload identity federation using service account impersonation, you can provide an optional argument to configure the access token lifetime.
+
+To generate the configuration with configurable token lifetime, run the following command (This example uses an AWS configuration, but the token lifetime can be configured for all workload identity federation providers):
+  ```bash
+  # Generate an AWS configuration file with configurable token lifetime.
+  gcloud iam workload-identity-pools create-cred-config \
+      projects/$PROJECT_NUMBER/locations/global/workloadIdentityPools/$POOL_ID/providers/$AWS_PROVIDER_ID \
+      --service-account $SERVICE_ACCOUNT_EMAIL \
+      --aws \
+      --output-file /path/to/generated/config.json \
+      --service-account-token-lifetime-seconds $TOKEN_LIFETIME
+  ```
+
+Where the following variables need to be substituted:
+- `$PROJECT_NUMBER`: The Google Cloud project number.
+- `$POOL_ID`: The workload identity pool ID.
+- `$AWS_PROVIDER_ID`: The AWS provider ID.
+- `$SERVICE_ACCOUNT_EMAIL`: The email of the service account to impersonate.
+- `$TOKEN_LIFETIME`: The desired lifetime duration of the service account access token in seconds.
+
+The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour.
+The minimum allowed value is 600 (10 minutes) and the maximum allowed value is 43200 (12 hours).
+If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
+Note that configuring a short lifetime (e.g. 10 minutes) will result in the library initiating the entire token exchange flow every 10 minutes, which will call the 3rd party token provider even if the 3rd party token is not expired.
+
+
 
 ###  Workforce Identity Federation
 

--- a/README.md
+++ b/README.md
@@ -469,9 +469,9 @@ You can now [use the Auth library](#using-external-identities) to call Google Cl
 resources from an OIDC or SAML provider.
 
 #### Configurable Token Lifetime
-When creating a credential configuration with workload identity federation using service account impersonation, you can provide an optional argument to configure the access token lifetime.
+When creating a credential configuration with workload identity federation using service account impersonation, you can provide an optional argument to configure the service account access token lifetime.
 
-To generate the configuration with configurable token lifetime, run the following command (This example uses an AWS configuration, but the token lifetime can be configured for all workload identity federation providers):
+To generate the configuration with configurable token lifetime, run the following command (this example uses an AWS configuration, but the token lifetime can be configured for all workload identity federation providers):
   ```bash
   # Generate an AWS configuration file with configurable token lifetime.
   gcloud iam workload-identity-pools create-cred-config \
@@ -492,9 +492,8 @@ Where the following variables need to be substituted:
 The `service-account-token-lifetime-seconds` flag is optional. If not provided, this defaults to one hour.
 The minimum allowed value is 600 (10 minutes) and the maximum allowed value is 43200 (12 hours).
 If a lifetime greater than one hour is required, the service account must be added as an allowed value in an Organization Policy that enforces the `constraints/iam.allowServiceAccountCredentialLifetimeExtension` constraint.
+
 Note that configuring a short lifetime (e.g. 10 minutes) will result in the library initiating the entire token exchange flow every 10 minutes, which will call the 3rd party token provider even if the 3rd party token is not expired.
-
-
 
 ###  Workforce Identity Federation
 

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -649,6 +649,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
    */
   static final class ServiceAccountImpersonationOptions {
     private static final int DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
+    private static final int MAXIMUM_TOKEN_LIFETIME_SECONDS = 43200;
+    private static final int MINIMUM_TOKEN_LIFETIME_SECONDS = 600;
     private static final String TOKEN_LIFETIME_SECONDS_KEY = "token_lifetime_seconds";
 
     private final int lifetime;
@@ -671,6 +673,13 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
       } catch (NumberFormatException | ArithmeticException e) {
         throw new IllegalArgumentException(
             "Value of \"token_lifetime_seconds\" field could not be parsed into an integer.", e);
+      }
+
+      if (lifetime < MINIMUM_TOKEN_LIFETIME_SECONDS || lifetime > MAXIMUM_TOKEN_LIFETIME_SECONDS) {
+        throw new IllegalArgumentException(
+            String.format(
+                "The \"token_lifetime_seconds\" field must be between %s and %s seconds.",
+                MINIMUM_TOKEN_LIFETIME_SECONDS, MAXIMUM_TOKEN_LIFETIME_SECONDS));
       }
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -79,8 +79,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
    * Encapsulates the service account impersonation options portion of the configuration for
    * ExternalAccountCredentials.
    *
-   * <p>If token_lifetime_seconds is not specified, the library will
-   * default to a 1-hour lifetime.
+   * <p>If token_lifetime_seconds is not specified, the library will default to a 1-hour lifetime.
    *
    * <pre>
    * Sample credential source for Pluggable Auth credentials:
@@ -100,13 +99,13 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
         Object timeout = serviceAccountImpersonationOptionsMap.get(TOKEN_LIFETIME_SECONDS_KEY);
         if (timeout instanceof BigDecimal) {
           lifetime = ((BigDecimal) timeout).intValue();
-        } else if (serviceAccountImpersonationOptionsMap.get(TOKEN_LIFETIME_SECONDS_KEY) instanceof Integer) {
+        } else if (serviceAccountImpersonationOptionsMap.get(TOKEN_LIFETIME_SECONDS_KEY)
+            instanceof Integer) {
           lifetime = (int) timeout;
         } else {
           lifetime = Integer.parseInt((String) timeout);
         }
-      }
-      else{
+      } else {
         lifetime = DEFAULT_TOKEN_LIFETIME_SECONDS;
       }
     }
@@ -181,7 +180,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
       @Nullable String quotaProjectId,
       @Nullable String clientId,
       @Nullable String clientSecret,
-      @Nullable Collection<String> scopes){
+      @Nullable Collection<String> scopes) {
     this(
         transportFactory,
         audience,
@@ -236,10 +235,11 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
 
   /**
    * See {@link ExternalAccountCredentials#ExternalAccountCredentials(HttpTransportFactory, String,
-   * String, String, CredentialSource, String, String, String, String, String, Collection, EnvironmentProvider)}
+   * String, String, CredentialSource, String, String, String, String, String, Collection,
+   * EnvironmentProvider)}
    *
    * @param serviceAccountImpersonationOptions additional options for service account impersonation,
-   *    may be null.
+   *     may be null.
    */
   protected ExternalAccountCredentials(
       HttpTransportFactory transportFactory,
@@ -316,8 +316,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
             : builder.environmentProvider;
     this.serviceAccountImpersonationOptions =
         builder.serviceAccountImpersonationOptions == null
-        ? new ServiceAccountImpersonationOptions(new HashMap<String, Object>())
-        : builder.serviceAccountImpersonationOptions;
+            ? new ServiceAccountImpersonationOptions(new HashMap<String, Object>())
+            : builder.serviceAccountImpersonationOptions;
 
     this.workforcePoolUserProject = builder.workforcePoolUserProject;
     if (workforcePoolUserProject != null && !isWorkforcePoolConfiguration()) {
@@ -463,11 +463,13 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     String clientSecret = (String) json.get("client_secret");
     String quotaProjectId = (String) json.get("quota_project_id");
     String userProject = (String) json.get("workforce_pool_user_project");
-    Map<String, Object> impersonationOptionsMap = (Map<String, Object>) json.get("service_account_impersonation");
+    Map<String, Object> impersonationOptionsMap =
+        (Map<String, Object>) json.get("service_account_impersonation");
 
     ServiceAccountImpersonationOptions serviceAccountImpersonationOptions = null;
-    if (impersonationOptionsMap != null){
-      serviceAccountImpersonationOptions = new ServiceAccountImpersonationOptions(impersonationOptionsMap);
+    if (impersonationOptionsMap != null) {
+      serviceAccountImpersonationOptions =
+          new ServiceAccountImpersonationOptions(impersonationOptionsMap);
     }
 
     if (isAwsCredential(credentialSourceMap)) {
@@ -842,7 +844,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
       return this;
     }
 
-    Builder setServiceAccountImpersonationOptions(ServiceAccountImpersonationOptions serviceAccountImpersonationOptions) {
+    Builder setServiceAccountImpersonationOptions(
+        ServiceAccountImpersonationOptions serviceAccountImpersonationOptions) {
       this.serviceAccountImpersonationOptions = serviceAccountImpersonationOptions;
       return this;
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -91,7 +91,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
    * }
    * </pre>
    */
-  static final class ServiceAccountImpersonationOptions {
+  public static final class ServiceAccountImpersonationOptions {
     private static final int DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
     private static final String TOKEN_LIFETIME_SECONDS_KEY = "token_lifetime_seconds";
 

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -91,11 +91,11 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
    * }
    * </pre>
    */
-  static class ServiceAccountImpersonationOptions {
+  static final class ServiceAccountImpersonationOptions {
     private static final int DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;
     private static final String TOKEN_LIFETIME_SECONDS_KEY = "token_lifetime_seconds";
 
-    public final int lifetime;
+    private final int lifetime;
 
     ServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
       if (!optionsMap.containsKey(TOKEN_LIFETIME_SECONDS_KEY)) {
@@ -111,6 +111,10 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
       } else {
         lifetime = Integer.parseInt((String) timeout);
       }
+    }
+
+    int getLifetime() {
+      return lifetime;
     }
   }
 
@@ -799,15 +803,15 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
       return this;
     }
 
-    Builder setEnvironmentProvider(EnvironmentProvider environmentProvider) {
-      this.environmentProvider = environmentProvider;
+    /** Sets the optional service account impersonation options. */
+    public Builder setServiceAccountImpersonationOptions(
+        ServiceAccountImpersonationOptions serviceAccountImpersonationOptions) {
+      this.serviceAccountImpersonationOptions = serviceAccountImpersonationOptions;
       return this;
     }
 
-    /** Sets the optional service account impersonation options. */
-    Builder setServiceAccountImpersonationOptions(
-        ServiceAccountImpersonationOptions serviceAccountImpersonationOptions) {
-      this.serviceAccountImpersonationOptions = serviceAccountImpersonationOptions;
+    Builder setEnvironmentProvider(EnvironmentProvider environmentProvider) {
+      this.environmentProvider = environmentProvider;
       return this;
     }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -42,7 +42,6 @@ import com.google.api.client.json.JsonParser;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.auth.TestUtils;
 import com.google.auth.oauth2.AwsCredentials.AwsCredentialSource;
-import com.google.auth.oauth2.ExternalAccountCredentials.ServiceAccountImpersonationOptions;
 import com.google.auth.oauth2.ExternalAccountCredentialsTest.MockExternalAccountCredentialsTransportFactory;
 import java.io.IOException;
 import java.io.InputStream;
@@ -159,9 +158,7 @@ public class AwsCredentialsTest {
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
                 .setServiceAccountImpersonationOptions(
-                    new ServiceAccountImpersonationOptions(
-                        ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(
-                            2800)))
+                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
                 .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -220,7 +220,7 @@ public class ExternalAccountCredentialsTest {
     assertEquals(STS_URL, credential.getTokenUrl());
     assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
     assertNotNull(credential.getCredentialSource());
-    assertEquals(2800, credential.getServiceAccountImpersonationOptions().lifetime);
+    assertEquals(2800, credential.getServiceAccountImpersonationOptions().getLifetime());
   }
 
   @Test
@@ -252,7 +252,7 @@ public class ExternalAccountCredentialsTest {
     assertEquals(STS_URL, credential.getTokenUrl());
     assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
     assertNotNull(credential.getCredentialSource());
-    assertEquals(2800, credential.getServiceAccountImpersonationOptions().lifetime);
+    assertEquals(2800, credential.getServiceAccountImpersonationOptions().getLifetime());
   }
 
   @Test
@@ -342,7 +342,7 @@ public class ExternalAccountCredentialsTest {
     assertEquals(STS_URL, credential.getTokenUrl());
     assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
     assertNotNull(credential.getCredentialSource());
-    assertEquals(2800, credential.getServiceAccountImpersonationOptions().lifetime);
+    assertEquals(2800, credential.getServiceAccountImpersonationOptions().getLifetime());
 
     PluggableAuthCredentialSource source =
         (PluggableAuthCredentialSource) credential.getCredentialSource();

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -957,7 +957,7 @@ public class ExternalAccountCredentialsTest {
     return json;
   }
 
-  private Map<String, Object> buildServiceAccountImpersonationOptions(Integer lifetime) {
+  static Map<String, Object> buildServiceAccountImpersonationOptions(Integer lifetime) {
     Map<String, Object> map = new HashMap<String, Object>();
     map.put("token_lifetime_seconds", lifetime);
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -328,7 +328,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void fromJson_pluggableAuthCredentialsWithServiceAccountImpersonation() {
+  public void fromJson_pluggableAuthCredentialsWithServiceAccountImpersonationOptions() {
     GenericJson pluggableAuthCredentialJson = buildJsonPluggableAuthCredential();
     pluggableAuthCredentialJson.set(
         "service_account_impersonation", buildServiceAccountImpersonationOptions(2800));
@@ -541,7 +541,7 @@ public class ExternalAccountCredentialsTest {
   }
 
   @Test
-  public void constructor_builder_invalidTokenLifetime() {
+  public void constructor_builder_invalidTokenLifetime_throws() {
     Map<String, Object> invalidOptionsMap = new HashMap<String, Object>();
     invalidOptionsMap.put("token_lifetime_seconds", "thisIsAString");
 
@@ -647,6 +647,66 @@ public class ExternalAccountCredentialsTest {
             .build();
 
     assertEquals(2800, credentials.getServiceAccountImpersonationOptions().getLifetime());
+  }
+
+  @Test
+  public void constructor_builder_lowTokenLifetime_throws() {
+    Map<String, Object> optionsMap = new HashMap<String, Object>();
+    optionsMap.put("token_lifetime_seconds", 599);
+
+    try {
+      ExternalAccountCredentials credentials =
+          IdentityPoolCredentials.newBuilder()
+              .setHttpTransportFactory(transportFactory)
+              .setAudience(
+                  "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+              .setSubjectTokenType("subjectTokenType")
+              .setTokenUrl(STS_URL)
+              .setTokenInfoUrl("https://tokeninfo.com")
+              .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+              .setCredentialSource(new TestCredentialSource(FILE_CREDENTIAL_SOURCE_MAP))
+              .setScopes(Arrays.asList("scope1", "scope2"))
+              .setQuotaProjectId("projectId")
+              .setClientId("clientId")
+              .setClientSecret("clientSecret")
+              .setWorkforcePoolUserProject("workforcePoolUserProject")
+              .setServiceAccountImpersonationOptions(optionsMap)
+              .build();
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "The \"token_lifetime_seconds\" field must be between 600 and 43200 seconds.",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void constructor_builder_highTokenLifetime_throws() {
+    Map<String, Object> optionsMap = new HashMap<String, Object>();
+    optionsMap.put("token_lifetime_seconds", 43201);
+
+    try {
+      ExternalAccountCredentials credentials =
+          IdentityPoolCredentials.newBuilder()
+              .setHttpTransportFactory(transportFactory)
+              .setAudience(
+                  "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+              .setSubjectTokenType("subjectTokenType")
+              .setTokenUrl(STS_URL)
+              .setTokenInfoUrl("https://tokeninfo.com")
+              .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+              .setCredentialSource(new TestCredentialSource(FILE_CREDENTIAL_SOURCE_MAP))
+              .setScopes(Arrays.asList("scope1", "scope2"))
+              .setQuotaProjectId("projectId")
+              .setClientId("clientId")
+              .setClientSecret("clientSecret")
+              .setWorkforcePoolUserProject("workforcePoolUserProject")
+              .setServiceAccountImpersonationOptions(optionsMap)
+              .build();
+    } catch (IllegalArgumentException e) {
+      assertEquals(
+          "The \"token_lifetime_seconds\" field must be between 600 and 43200 seconds.",
+          e.getMessage());
+    }
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -46,6 +46,7 @@ import com.google.auth.oauth2.ExternalAccountCredentialsTest.TestExternalAccount
 import com.google.auth.oauth2.PluggableAuthCredentials.PluggableAuthCredentialSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -537,6 +538,115 @@ public class ExternalAccountCredentialsTest {
         .setTokenUrl(STS_URL)
         .setCredentialSource(new TestCredentialSource(credentialSource))
         .build();
+  }
+
+  @Test
+  public void constructor_builder_invalidTokenLifetime() {
+    Map<String, Object> invalidOptionsMap = new HashMap<String, Object>();
+    invalidOptionsMap.put("token_lifetime_seconds", "thisIsAString");
+
+    try {
+      IdentityPoolCredentials.newBuilder()
+          .setHttpTransportFactory(transportFactory)
+          .setAudience(
+              "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+          .setSubjectTokenType("subjectTokenType")
+          .setTokenUrl(STS_URL)
+          .setTokenInfoUrl("https://tokeninfo.com")
+          .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+          .setCredentialSource(new TestCredentialSource(FILE_CREDENTIAL_SOURCE_MAP))
+          .setScopes(Arrays.asList("scope1", "scope2"))
+          .setQuotaProjectId("projectId")
+          .setClientId("clientId")
+          .setClientSecret("clientSecret")
+          .setWorkforcePoolUserProject("workforcePoolUserProject")
+          .setServiceAccountImpersonationOptions(invalidOptionsMap)
+          .build();
+      fail("Should not be able to continue without exception.");
+    } catch (IllegalArgumentException exception) {
+      assertEquals(
+          "Value of \"token_lifetime_seconds\" field could not be parsed into an integer.",
+          exception.getMessage());
+      assertEquals(NumberFormatException.class, exception.getCause().getClass());
+    }
+  }
+
+  @Test
+  public void constructor_builder_stringTokenLifetime() {
+    Map<String, Object> optionsMap = new HashMap<String, Object>();
+    optionsMap.put("token_lifetime_seconds", "2800");
+
+    ExternalAccountCredentials credentials =
+        IdentityPoolCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("https://tokeninfo.com")
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setCredentialSource(new TestCredentialSource(FILE_CREDENTIAL_SOURCE_MAP))
+            .setScopes(Arrays.asList("scope1", "scope2"))
+            .setQuotaProjectId("projectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setWorkforcePoolUserProject("workforcePoolUserProject")
+            .setServiceAccountImpersonationOptions(optionsMap)
+            .build();
+
+    assertEquals(2800, credentials.getServiceAccountImpersonationOptions().getLifetime());
+  }
+
+  @Test
+  public void constructor_builder_bigDecimalTokenLifetime() {
+    Map<String, Object> optionsMap = new HashMap<String, Object>();
+    optionsMap.put("token_lifetime_seconds", new BigDecimal("2800"));
+
+    ExternalAccountCredentials credentials =
+        IdentityPoolCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("https://tokeninfo.com")
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setCredentialSource(new TestCredentialSource(FILE_CREDENTIAL_SOURCE_MAP))
+            .setScopes(Arrays.asList("scope1", "scope2"))
+            .setQuotaProjectId("projectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setWorkforcePoolUserProject("workforcePoolUserProject")
+            .setServiceAccountImpersonationOptions(optionsMap)
+            .build();
+
+    assertEquals(2800, credentials.getServiceAccountImpersonationOptions().getLifetime());
+  }
+
+  @Test
+  public void constructor_builder_integerTokenLifetime() {
+    Map<String, Object> optionsMap = new HashMap<String, Object>();
+    optionsMap.put("token_lifetime_seconds", Integer.valueOf(2800));
+
+    ExternalAccountCredentials credentials =
+        IdentityPoolCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("https://tokeninfo.com")
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setCredentialSource(new TestCredentialSource(FILE_CREDENTIAL_SOURCE_MAP))
+            .setScopes(Arrays.asList("scope1", "scope2"))
+            .setQuotaProjectId("projectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setWorkforcePoolUserProject("workforcePoolUserProject")
+            .setServiceAccountImpersonationOptions(optionsMap)
+            .build();
+
+    assertEquals(2800, credentials.getServiceAccountImpersonationOptions().getLifetime());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -205,10 +205,12 @@ public class ExternalAccountCredentialsTest {
   @Test
   public void fromJson_identityPoolCredentialsWithServiceAccountImpersonationOptions() {
     GenericJson identityPoolCredentialJson = buildJsonIdentityPoolCredential();
-    identityPoolCredentialJson.set("service_account_impersonation", buildServiceAccountImpersonationOptions(2800));
+    identityPoolCredentialJson.set(
+        "service_account_impersonation", buildServiceAccountImpersonationOptions(2800));
 
     ExternalAccountCredentials credential =
-        ExternalAccountCredentials.fromJson(identityPoolCredentialJson, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+        ExternalAccountCredentials.fromJson(
+            identityPoolCredentialJson, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
 
     assertTrue(credential instanceof IdentityPoolCredentials);
     assertEquals(
@@ -218,9 +220,7 @@ public class ExternalAccountCredentialsTest {
     assertEquals(STS_URL, credential.getTokenUrl());
     assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
     assertNotNull(credential.getCredentialSource());
-    assertEquals(
-        2800,
-        credential.getServiceAccountImpersonationOptions().lifetime);
+    assertEquals(2800, credential.getServiceAccountImpersonationOptions().lifetime);
   }
 
   @Test
@@ -240,7 +240,8 @@ public class ExternalAccountCredentialsTest {
   @Test
   public void fromJson_awsCredentialsWithServiceAccountImpersonationOptions() throws IOException {
     GenericJson awsCredentialJson = buildJsonAwsCredential();
-    awsCredentialJson.set("service_account_impersonation", buildServiceAccountImpersonationOptions(2800));
+    awsCredentialJson.set(
+        "service_account_impersonation", buildServiceAccountImpersonationOptions(2800));
 
     ExternalAccountCredentials credential =
         ExternalAccountCredentials.fromJson(awsCredentialJson, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
@@ -251,9 +252,7 @@ public class ExternalAccountCredentialsTest {
     assertEquals(STS_URL, credential.getTokenUrl());
     assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
     assertNotNull(credential.getCredentialSource());
-    assertEquals(
-        2800,
-        credential.getServiceAccountImpersonationOptions().lifetime);
+    assertEquals(2800, credential.getServiceAccountImpersonationOptions().lifetime);
   }
 
   @Test
@@ -330,10 +329,12 @@ public class ExternalAccountCredentialsTest {
   @Test
   public void fromJson_pluggableAuthCredentialsWithServiceAccountImpersonation() {
     GenericJson pluggableAuthCredentialJson = buildJsonPluggableAuthCredential();
-    pluggableAuthCredentialJson.set("service_account_impersonation", buildServiceAccountImpersonationOptions(2800));
+    pluggableAuthCredentialJson.set(
+        "service_account_impersonation", buildServiceAccountImpersonationOptions(2800));
 
     ExternalAccountCredentials credential =
-        ExternalAccountCredentials.fromJson(pluggableAuthCredentialJson, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+        ExternalAccountCredentials.fromJson(
+            pluggableAuthCredentialJson, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
 
     assertTrue(credential instanceof PluggableAuthCredentials);
     assertEquals("audience", credential.getAudience());
@@ -341,9 +342,7 @@ public class ExternalAccountCredentialsTest {
     assertEquals(STS_URL, credential.getTokenUrl());
     assertEquals("tokenInfoUrl", credential.getTokenInfoUrl());
     assertNotNull(credential.getCredentialSource());
-    assertEquals(
-        2800,
-        credential.getServiceAccountImpersonationOptions().lifetime);
+    assertEquals(2800, credential.getServiceAccountImpersonationOptions().lifetime);
 
     PluggableAuthCredentialSource source =
         (PluggableAuthCredentialSource) credential.getCredentialSource();

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -241,7 +241,8 @@ public class GoogleCredentialsTest {
         IdentityPoolCredentialsTest.writeIdentityPoolCredentialsStream(
             transportFactory.transport.getStsUrl(),
             transportFactory.transport.getMetadataUrl(),
-            /* serviceAccountImpersonationUrl= */ null);
+            /* serviceAccountImpersonationUrl= */ null,
+            /* serviceAccountImpersonationOptionsMap= */ null);
 
     GoogleCredentials credentials =
         GoogleCredentials.fromStream(identityPoolCredentialStream, transportFactory);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
@@ -175,7 +175,7 @@ public final class ITWorkloadIdentityFederationTest {
    * for token_lifetime_seconds and validates that the lifetime is used for the access token.
    */
   @Test
-  public void IdentityPoolCredentialsWithServiceAccountImpersonationOptions() throws IOException {
+  public void identityPoolCredentials_withServiceAccountImpersonationOptions() throws IOException {
     GenericJson identityPoolCredentialConfig = buildIdentityPoolCredentialConfig();
     Map<String, Object> map = new HashMap<String, Object>();
     map.put("token_lifetime_seconds", 2800);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
@@ -52,6 +52,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -166,6 +168,29 @@ public final class ITWorkloadIdentityFederationTest {
                 buildPluggableCredentialConfig(), OAuth2Utils.HTTP_TRANSPORT_FACTORY);
 
     callGcs(pluggableAuthCredentials);
+  }
+
+  /**
+   * Sets the service account impersonation object in configuration JSON with a non-default value
+   * for token_lifetime_seconds and validates that the lifetime is used for the access token.
+   */
+  @Test
+  public void IdentityPoolCredentialsWithServiceAccountImpersonationOptions() throws IOException {
+    GenericJson identityPoolCredentialConfig = buildIdentityPoolCredentialConfig();
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put("token_lifetime_seconds", 2800);
+    identityPoolCredentialConfig.put("service_account_impersonation", map);
+
+    IdentityPoolCredentials identityPoolCredentials =
+        (IdentityPoolCredentials)
+            ExternalAccountCredentials.fromJson(
+                identityPoolCredentialConfig, OAuth2Utils.HTTP_TRANSPORT_FACTORY);
+    long maxExpirationTime = Instant.now().plusSeconds(2800 + 5).toEpochMilli();
+    long minExpirationtime = Instant.now().plusSeconds(2800 - 5).toEpochMilli();
+
+    callGcs(identityPoolCredentials);
+    long tokenExpiry = identityPoolCredentials.getAccessToken().getExpirationTimeMillis();
+    assertTrue(minExpirationtime <= tokenExpiry && tokenExpiry <= maxExpirationTime);
   }
 
   private GenericJson buildIdentityPoolCredentialConfig() throws IOException {

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -663,7 +663,10 @@ public class IdentityPoolCredentialsTest {
   }
 
   static InputStream writeIdentityPoolCredentialsStream(
-      String tokenUrl, String url, @Nullable String serviceAccountImpersonationUrl)
+      String tokenUrl,
+      String url,
+      @Nullable String serviceAccountImpersonationUrl,
+      @Nullable Map<String, Object> serviceAccountImpersonationOptionsMap)
       throws IOException {
     GenericJson json = new GenericJson();
     json.put("audience", "audience");
@@ -674,6 +677,10 @@ public class IdentityPoolCredentialsTest {
 
     if (serviceAccountImpersonationUrl != null) {
       json.put("service_account_impersonation_url", serviceAccountImpersonationUrl);
+    }
+
+    if (serviceAccountImpersonationOptionsMap != null) {
+      json.put("service_account_impersonation", serviceAccountImpersonationOptionsMap);
     }
 
     GenericJson credentialSource = new GenericJson();

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -42,7 +42,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.GenericJson;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
-import com.google.auth.oauth2.ExternalAccountCredentials.ServiceAccountImpersonationOptions;
 import com.google.auth.oauth2.IdentityPoolCredentials.IdentityPoolCredentialSource;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -403,9 +402,7 @@ public class IdentityPoolCredentialsTest {
                 .setCredentialSource(
                     buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
                 .setServiceAccountImpersonationOptions(
-                    new ServiceAccountImpersonationOptions(
-                        ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(
-                            2800)))
+                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
                 .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
@@ -478,9 +475,7 @@ public class IdentityPoolCredentialsTest {
                     buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
                 .setWorkforcePoolUserProject("userProject")
                 .setServiceAccountImpersonationOptions(
-                    new ServiceAccountImpersonationOptions(
-                        ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(
-                            2800)))
+                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
                 .build();
 
     AccessToken accessToken = credential.refreshAccessToken();

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -42,6 +42,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.GenericJson;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.ExternalAccountCredentials.ServiceAccountImpersonationOptions;
 import com.google.auth.oauth2.IdentityPoolCredentials.IdentityPoolCredentialSource;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -387,6 +388,41 @@ public class IdentityPoolCredentialsTest {
   }
 
   @Test
+  public void refreshAccessToken_withServiceAccountImpersonationOptions() throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
+    IdentityPoolCredentials credential =
+        (IdentityPoolCredentials)
+            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+                .setTokenUrl(transportFactory.transport.getStsUrl())
+                .setServiceAccountImpersonationUrl(
+                    transportFactory.transport.getServiceAccountImpersonationUrl())
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(
+                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+                .setServiceAccountImpersonationOptions(
+                    new ServiceAccountImpersonationOptions(
+                        ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(
+                            2800)))
+                .build();
+
+    AccessToken accessToken = credential.refreshAccessToken();
+
+    assertEquals(
+        transportFactory.transport.getServiceAccountAccessToken(), accessToken.getTokenValue());
+
+    // Validate that default lifetime was set correctly on the request.
+    GenericJson query =
+        OAuth2Utils.JSON_FACTORY
+            .createJsonParser(transportFactory.transport.getLastRequest().getContentAsString())
+            .parseAndClose(GenericJson.class);
+
+    assertEquals("2800s", query.get("lifetime"));
+  }
+
+  @Test
   public void refreshAccessToken_workforceWithServiceAccountImpersonation() throws IOException {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
@@ -420,6 +456,45 @@ public class IdentityPoolCredentialsTest {
 
     assertNotNull(query.get("options"));
     assertEquals(expectedInternalOptions.toString(), query.get("options"));
+  }
+
+  @Test
+  public void refreshAccessToken_workforceWithServiceAccountImpersonationOptions()
+      throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
+    IdentityPoolCredentials credential =
+        (IdentityPoolCredentials)
+            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+                .setAudience(
+                    "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+                .setTokenUrl(transportFactory.transport.getStsUrl())
+                .setServiceAccountImpersonationUrl(
+                    transportFactory.transport.getServiceAccountImpersonationUrl())
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(
+                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+                .setWorkforcePoolUserProject("userProject")
+                .setServiceAccountImpersonationOptions(
+                    new ServiceAccountImpersonationOptions(
+                        ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(
+                            2800)))
+                .build();
+
+    AccessToken accessToken = credential.refreshAccessToken();
+
+    // Validate that default lifetime was set correctly on the request.
+    assertEquals(
+        transportFactory.transport.getServiceAccountAccessToken(), accessToken.getTokenValue());
+
+    GenericJson query =
+        OAuth2Utils.JSON_FACTORY
+            .createJsonParser(transportFactory.transport.getLastRequest().getContentAsString())
+            .parseAndClose(GenericJson.class);
+
+    assertEquals("2800s", query.get("lifetime"));
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
@@ -42,7 +42,6 @@ import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.ExecutableHandler.ExecutableOptions;
 import com.google.auth.oauth2.ExternalAccountCredentials.CredentialSource;
-import com.google.auth.oauth2.ExternalAccountCredentials.ServiceAccountImpersonationOptions;
 import com.google.auth.oauth2.PluggableAuthCredentials.PluggableAuthCredentialSource;
 import java.io.IOException;
 import java.io.InputStream;
@@ -248,9 +247,7 @@ public class PluggableAuthCredentialsTest {
                     transportFactory.transport.getServiceAccountImpersonationUrl())
                 .setHttpTransportFactory(transportFactory)
                 .setServiceAccountImpersonationOptions(
-                    new ServiceAccountImpersonationOptions(
-                        ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(
-                            2800)))
+                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
                 .build();
 
     AccessToken accessToken = credential.refreshAccessToken();


### PR DESCRIPTION
Adds support for configurable token lifespan via the service_account_impersonation object in the ADC. Also adds unit + integration tests.
See go/byoid-sdk-service-account-impersonation-ctl
