### PR TITLE
fix: Populate HttpHeaders fields with List<String> instead of String.

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -51,7 +51,9 @@ import java.nio.file.LinkOption;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -230,7 +232,10 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
 
     if (identityPoolCredentialSource.hasHeaders()) {
       HttpHeaders headers = new HttpHeaders();
-      headers.putAll(identityPoolCredentialSource.headers);
+      for (Map.Entry<String, String> entry : identityPoolCredentialSource.headers.entrySet()) {
+        // HttpHeaders expects List<String> instead of String.
+        headers.put(entry.getKey(), Collections.singletonList(entry.getValue()));
+      }
       request.setHeaders(headers);
     }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -679,6 +679,7 @@ public class IdentityPoolCredentialsTest {
     GenericJson credentialSource = new GenericJson();
     GenericJson headers = new GenericJson();
     headers.put("Metadata-Flavor", "Google");
+    headers.put("Authorization", "Bearer token");
     credentialSource.put("url", url);
     credentialSource.put("headers", headers);
 
@@ -695,6 +696,7 @@ public class IdentityPoolCredentialsTest {
     Map<String, Object> credentialSourceMap = new HashMap<>();
     Map<String, String> headers = new HashMap<>();
     headers.put("Metadata-Flavor", "Google");
+    headers.put("Authorization", "Bearer token");
     credentialSourceMap.put("url", url);
     credentialSourceMap.put("headers", headers);
     credentialSourceMap.put("format", formatMap);


### PR DESCRIPTION
IdentityPoolCredentials#getSubjectTokenFromMetadataServer calls
HttpHeaders.putAll to set request headers. The latter sets its fields through
reflective access: well-known headers such as Content-Type or Authentication
have dedicated fields of type List<String>, while remaining headers go into a
Map<String, Object> grab bag. However, we attempt to set every header to a
String, which causes a crash for well-known headers.