### PR TITLE
feat: Introduce Environment Variable for Quota Project Id

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -224,7 +224,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     this.credentialSource = checkNotNull(builder.credentialSource);
     this.tokenInfoUrl = builder.tokenInfoUrl;
     this.serviceAccountImpersonationUrl = builder.serviceAccountImpersonationUrl;
-    this.quotaProjectId = builder.quotaProjectId;
+    this.quotaProjectId = builder.getEffectiveQuotaProjectId(builder.quotaProjectId);
     this.clientId = builder.clientId;
     this.clientSecret = builder.clientSecret;
     this.scopes =
@@ -691,7 +691,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
   }
 
   /** Base builder for external account credentials. */
-  public abstract static class Builder extends GoogleCredentials.Builder {
+  public abstract static class Builder extends GoogleCredentials.Builder
+      implements QuotaProjectIdBuilder {
 
     protected String audience;
     protected String subjectTokenType;
@@ -784,8 +785,14 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     }
 
     /** Sets the optional project used for quota and billing purposes. */
+    @Override
     public Builder setQuotaProjectId(String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
+      return this;
+    }
+
+    @Override
+    public Builder getBuilder() {
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -224,7 +224,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials
     this.credentialSource = checkNotNull(builder.credentialSource);
     this.tokenInfoUrl = builder.tokenInfoUrl;
     this.serviceAccountImpersonationUrl = builder.serviceAccountImpersonationUrl;
-    this.quotaProjectId = builder.getEffectiveQuotaProjectId(builder.quotaProjectId);
+    this.quotaProjectId = builder.quotaProjectId;
     this.clientId = builder.clientId;
     this.clientSecret = builder.clientSecret;
     this.scopes =

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -470,7 +470,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
         firstNonNull(
             builder.getHttpTransportFactory(),
             getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
-    this.quotaProjectId = builder.getEffectiveQuotaProjectId(builder.quotaProjectId);
+    this.quotaProjectId = builder.quotaProjectId;
     this.iamEndpointOverride = builder.iamEndpointOverride;
     this.transportFactoryClassName = this.transportFactory.getClass().getName();
     this.calendar = builder.getCalendar();

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -470,7 +470,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
         firstNonNull(
             builder.getHttpTransportFactory(),
             getFromServiceLoader(HttpTransportFactory.class, OAuth2Utils.HTTP_TRANSPORT_FACTORY));
-    this.quotaProjectId = builder.quotaProjectId;
+    this.quotaProjectId = builder.getEffectiveQuotaProjectId(builder.quotaProjectId);
     this.iamEndpointOverride = builder.iamEndpointOverride;
     this.transportFactoryClassName = this.transportFactory.getClass().getName();
     this.calendar = builder.getCalendar();
@@ -620,7 +620,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
     return new Builder();
   }
 
-  public static class Builder extends GoogleCredentials.Builder {
+  public static class Builder extends GoogleCredentials.Builder implements QuotaProjectIdBuilder {
 
     private GoogleCredentials sourceCredentials;
     private String targetPrincipal;
@@ -693,8 +693,14 @@ public class ImpersonatedCredentials extends GoogleCredentials
       return transportFactory;
     }
 
+    @Override
     public Builder setQuotaProjectId(String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
+      return this;
+    }
+
+    @Override
+    public Builder getBuilder() {
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -58,6 +58,9 @@ import java.util.Set;
 
 /** Internal utilities for the com.google.auth.oauth2 namespace. */
 class OAuth2Utils {
+  // Environment variable defining the project to be used for quota and billing.
+  static final String GOOGLE_CLOUD_QUOTA_PROJECT = "GOOGLE_CLOUD_QUOTA_PROJECT";
+
   static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
 
   static final String TOKEN_TYPE_ACCESS_TOKEN = "urn:ietf:params:oauth:token-type:access_token";
@@ -200,6 +203,10 @@ class OAuth2Utils {
       throw new IOException(String.format(VALUE_WRONG_TYPE_MESSAGE, errorPrefix, "Map", key));
     }
     return (Map) value;
+  }
+
+  static String getQuotaProjectIdFromEnvironment() {
+    return System.getenv(GOOGLE_CLOUD_QUOTA_PROJECT);
   }
 
   private OAuth2Utils() {}

--- a/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdBuilder.java
+++ b/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdBuilder.java
@@ -38,14 +38,6 @@ public interface QuotaProjectIdBuilder {
   /** Sets the quota project ID used for quota and billing purposes */
   GoogleCredentials.Builder setQuotaProjectId(String quotaProjectId);
 
-  default String getEffectiveQuotaProjectId(String quotaProjectId) {
-    if (quotaProjectId == null || quotaProjectId.isEmpty()) {
-      quotaProjectId = getQuotaProjectIdFromEnvironment();
-    }
-
-    return quotaProjectId;
-  }
-
   /**
    * Reads from environment variable and sets the quota project ID used for quota and billing
    * purposes

--- a/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdBuilder.java
+++ b/oauth2_http/java/com/google/auth/oauth2/QuotaProjectIdBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019, Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+/** Interface for {@link GoogleCredentials.Builder} that sets a quota project ID. */
+public interface QuotaProjectIdBuilder {
+  GoogleCredentials.Builder getBuilder();
+
+  /** Sets the quota project ID used for quota and billing purposes */
+  GoogleCredentials.Builder setQuotaProjectId(String quotaProjectId);
+
+  default String getEffectiveQuotaProjectId(String quotaProjectId) {
+    if (quotaProjectId == null || quotaProjectId.isEmpty()) {
+      quotaProjectId = getQuotaProjectIdFromEnvironment();
+    }
+
+    return quotaProjectId;
+  }
+
+  /**
+   * Reads from environment variable and sets the quota project ID used for quota and billing
+   * purposes
+   */
+  default GoogleCredentials.Builder setQuotaProjectIdFromEnvironment() {
+    String quotaFromEnvironment = getQuotaProjectIdFromEnvironment();
+
+    if (quotaFromEnvironment == null || quotaFromEnvironment.isEmpty()) {
+      return this.getBuilder();
+    }
+
+    return this.setQuotaProjectId(quotaFromEnvironment);
+  }
+
+  default String getQuotaProjectIdFromEnvironment() {
+    return OAuth2Utils.getQuotaProjectIdFromEnvironment();
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -145,7 +145,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
         (builder.tokenServerUri == null) ? OAuth2Utils.TOKEN_SERVER_URI : builder.tokenServerUri;
     this.serviceAccountUser = builder.serviceAccountUser;
     this.projectId = builder.projectId;
-    this.quotaProjectId = builder.quotaProjectId;
+    this.quotaProjectId = builder.getEffectiveQuotaProjectId(builder.quotaProjectId);
     if (builder.lifetime > TWELVE_HOURS_IN_SECONDS) {
       throw new IllegalStateException("lifetime must be less than or equal to 43200");
     }
@@ -1002,7 +1002,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return quotaProjectId;
   }
 
-  public static class Builder extends GoogleCredentials.Builder {
+  public static class Builder extends GoogleCredentials.Builder implements QuotaProjectIdBuilder {
 
     private String clientId;
     private String clientEmail;
@@ -1095,8 +1095,14 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return this;
     }
 
+    @Override
     public Builder setQuotaProjectId(String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
+      return this;
+    }
+
+    @Override
+    public Builder getBuilder() {
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -145,7 +145,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
         (builder.tokenServerUri == null) ? OAuth2Utils.TOKEN_SERVER_URI : builder.tokenServerUri;
     this.serviceAccountUser = builder.serviceAccountUser;
     this.projectId = builder.projectId;
-    this.quotaProjectId = builder.getEffectiveQuotaProjectId(builder.quotaProjectId);
+    this.quotaProjectId = builder.quotaProjectId;
     if (builder.lifetime > TWELVE_HOURS_IN_SECONDS) {
       throw new IllegalStateException("lifetime must be less than or equal to 43200");
     }

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -390,7 +390,7 @@ public class UserCredentials extends GoogleCredentials
     return quotaProjectId;
   }
 
-  public static class Builder extends GoogleCredentials.Builder {
+  public static class Builder extends GoogleCredentials.Builder implements QuotaProjectIdBuilder {
 
     private String clientId;
     private String clientSecret;
@@ -440,8 +440,14 @@ public class UserCredentials extends GoogleCredentials
       return this;
     }
 
+    @Override
     public Builder setQuotaProjectId(String quotaProjectId) {
       this.quotaProjectId = quotaProjectId;
+      return this;
+    }
+
+    @Override
+    public Builder getBuilder() {
       return this;
     }
 
@@ -477,7 +483,7 @@ public class UserCredentials extends GoogleCredentials
           getAccessToken(),
           transportFactory,
           tokenServerUri,
-          quotaProjectId);
+          getEffectiveQuotaProjectId(quotaProjectId));
     }
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -483,7 +483,7 @@ public class UserCredentials extends GoogleCredentials
           getAccessToken(),
           transportFactory,
           tokenServerUri,
-          getEffectiveQuotaProjectId(quotaProjectId));
+          quotaProjectId);
     }
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/QuotaProjectIdTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/QuotaProjectIdTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.auth.oauth2.GoogleCredentials.Builder;
+import org.junit.Test;
+
+public class QuotaProjectIdTest {
+  private final String EXPLICIT_QUOTA_PROJECT = "explicit_quota_project";
+  private final String ENVIRONMENT_QUOTA_PROJECT = "environment_quota_project";
+
+  @Test
+  public void getEffectiveQuotaProjectId_fromEnvironment() {
+    TestQuotaProjectIdBuilder testQuotaProjectIdBuilder =
+        new TestQuotaProjectIdBuilder(ENVIRONMENT_QUOTA_PROJECT);
+    assertEquals(
+        ENVIRONMENT_QUOTA_PROJECT, testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(null));
+    assertEquals(
+        ENVIRONMENT_QUOTA_PROJECT, testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(""));
+  }
+
+  @Test
+  public void getEffectiveQuotaProjectId_explicit() {
+    TestQuotaProjectIdBuilder testQuotaProjectIdBuilder =
+        new TestQuotaProjectIdBuilder(ENVIRONMENT_QUOTA_PROJECT);
+    assertEquals(
+        EXPLICIT_QUOTA_PROJECT,
+        testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(EXPLICIT_QUOTA_PROJECT));
+  }
+
+  @Test
+  public void getEffectiveQuotaProjectId_noQuotaProjectId() {
+    TestQuotaProjectIdBuilder testQuotaProjectIdBuilder = new TestQuotaProjectIdBuilder(null);
+    assertEquals(null, testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(null));
+  }
+}
+
+class TestQuotaProjectIdBuilder implements QuotaProjectIdBuilder {
+
+  private String quotaProjectIdFromEnvironment;
+
+  TestQuotaProjectIdBuilder(String quotaProjectIdFromEnvironment) {
+    this.quotaProjectIdFromEnvironment = quotaProjectIdFromEnvironment;
+  }
+
+  @Override
+  public Builder getBuilder() {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public Builder setQuotaProjectId(String quotaProjectId) {
+    // TODO Auto-generated method stub
+    return null;
+  }
+
+  @Override
+  public String getQuotaProjectIdFromEnvironment() {
+    return this.quotaProjectIdFromEnvironment;
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/QuotaProjectIdTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/QuotaProjectIdTest.java
@@ -41,34 +41,31 @@ public class QuotaProjectIdTest {
   private final String ENVIRONMENT_QUOTA_PROJECT = "environment_quota_project";
 
   @Test
-  public void getEffectiveQuotaProjectId_fromEnvironment() {
-    TestQuotaProjectIdBuilder testQuotaProjectIdBuilder =
+  public void setQuotaProjectIdFromEnvironment_fromEnvironment() {
+    TestQuotaProjectIdBuilder testBuilder =
         new TestQuotaProjectIdBuilder(ENVIRONMENT_QUOTA_PROJECT);
-    assertEquals(
-        ENVIRONMENT_QUOTA_PROJECT, testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(null));
-    assertEquals(
-        ENVIRONMENT_QUOTA_PROJECT, testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(""));
+    testBuilder.setQuotaProjectId(EXPLICIT_QUOTA_PROJECT);
+    assertEquals(EXPLICIT_QUOTA_PROJECT, testBuilder.getQuotaProjectId());
+
+    testBuilder.setQuotaProjectIdFromEnvironment();
+    assertEquals(ENVIRONMENT_QUOTA_PROJECT, testBuilder.getQuotaProjectId());
   }
 
   @Test
-  public void getEffectiveQuotaProjectId_explicit() {
-    TestQuotaProjectIdBuilder testQuotaProjectIdBuilder =
-        new TestQuotaProjectIdBuilder(ENVIRONMENT_QUOTA_PROJECT);
-    assertEquals(
-        EXPLICIT_QUOTA_PROJECT,
-        testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(EXPLICIT_QUOTA_PROJECT));
-  }
+  public void setQuotaProjectIdFromEnvironment_notFromEnvironment() {
+    TestQuotaProjectIdBuilder testBuilder = new TestQuotaProjectIdBuilder(null);
+    testBuilder.setQuotaProjectId(EXPLICIT_QUOTA_PROJECT);
+    assertEquals(EXPLICIT_QUOTA_PROJECT, testBuilder.getQuotaProjectId());
 
-  @Test
-  public void getEffectiveQuotaProjectId_noQuotaProjectId() {
-    TestQuotaProjectIdBuilder testQuotaProjectIdBuilder = new TestQuotaProjectIdBuilder(null);
-    assertEquals(null, testQuotaProjectIdBuilder.getEffectiveQuotaProjectId(null));
+    testBuilder.setQuotaProjectIdFromEnvironment();
+    assertEquals(EXPLICIT_QUOTA_PROJECT, testBuilder.getQuotaProjectId());
   }
 }
 
-class TestQuotaProjectIdBuilder implements QuotaProjectIdBuilder {
+class TestQuotaProjectIdBuilder extends GoogleCredentials.Builder implements QuotaProjectIdBuilder {
 
   private String quotaProjectIdFromEnvironment;
+  private String quotaProjectId;
 
   TestQuotaProjectIdBuilder(String quotaProjectIdFromEnvironment) {
     this.quotaProjectIdFromEnvironment = quotaProjectIdFromEnvironment;
@@ -76,14 +73,17 @@ class TestQuotaProjectIdBuilder implements QuotaProjectIdBuilder {
 
   @Override
   public Builder getBuilder() {
-    // TODO Auto-generated method stub
-    return null;
+    return this;
+  }
+
+  public String getQuotaProjectId() {
+    return this.quotaProjectId;
   }
 
   @Override
   public Builder setQuotaProjectId(String quotaProjectId) {
-    // TODO Auto-generated method stub
-    return null;
+    this.quotaProjectId = quotaProjectId;
+    return this;
   }
 
   @Override


### PR DESCRIPTION
Introduce a new environment variable "GOOGLE_CLOUD_QUOTA_PROJECT" that can be used to specify a quota project id. This quota project will be used to override the quota project from the credential detected during ADC generation if another quota project was not provided explicitly.
This change also introduces a helper method to set the quota project from environment variable on the credential explicitly.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
