### PR TITLE
chore: exclude requirements.txt file from renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     ":maintainLockFilesDisabled",
     ":autodetectPinVersions"
   ],
+  "ignorePaths": [".kokoro/requirements.txt"],
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
The synthtool PR (https://github.com/googleapis/google-auth-library-java/pull/1004) didn't include these changes for some reason so this PR manually brings them in. 