### PR TITLE
fix: Validate url domain for aws metadata urls

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -137,14 +137,14 @@ public class AwsCredentials extends ExternalAccountCredentials {
       validateMetadataServerUrlIfAny(this.imdsv2SessionTokenUrl, "imdsv2_session_token_url");
     }
 
-    private static void validateMetadataServerUrlIfAny(String urlString, String nameOfData) {
+    private static void validateMetadataServerUrlIfAny(String urlString, String nameInConfig) {
       if (urlString != null) {
         try {
           URL url = new URL(urlString);
           String host = url.getHost();
           if (!host.equals("169.254.169.254") && !host.equals("[fd00:ec2::254]")) {
             throw new IllegalArgumentException(
-                String.format("Invalid host %s for %s.", host, nameOfData));
+                String.format("Invalid host %s for %s.", host, nameInConfig));
           }
         } catch (MalformedURLException malformedURLException) {
           throw new IllegalArgumentException(malformedURLException);

--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -132,19 +132,19 @@ public class AwsCredentials extends ExternalAccountCredentials {
     }
 
     private void validateMetadataServerUrls() {
-      this.validateMetadataServerUrlIfAny(this.regionUrl, "region_url");
-      this.validateMetadataServerUrlIfAny(this.url, "url");
-      this.validateMetadataServerUrlIfAny(this.imdsv2SessionTokenUrl, "imdsv2_session_token_url");
+      validateMetadataServerUrlIfAny(this.regionUrl, "region_url");
+      validateMetadataServerUrlIfAny(this.url, "url");
+      validateMetadataServerUrlIfAny(this.imdsv2SessionTokenUrl, "imdsv2_session_token_url");
     }
 
-    private void validateMetadataServerUrlIfAny(String urlString, String nameOfData) {
+    private static void validateMetadataServerUrlIfAny(String urlString, String nameOfData) {
       if (urlString != null) {
         try {
           URL url = new URL(urlString);
           String host = url.getHost();
           if (!host.equals("169.254.169.254") && !host.equals("[fd00:ec2::254]")) {
             throw new IllegalArgumentException(
-                String.format("Invalid host %s for %s", host, nameOfData));
+                String.format("Invalid host %s for %s.", host, nameOfData));
           }
         } catch (MalformedURLException malformedURLException) {
           throw new IllegalArgumentException(malformedURLException);

--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -43,6 +43,8 @@ import com.google.api.client.json.JsonParser;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -124,6 +126,29 @@ public class AwsCredentials extends ExternalAccountCredentials {
             (String) credentialSourceMap.get(IMDSV2_SESSION_TOKEN_URL_FIELD_NAME);
       } else {
         this.imdsv2SessionTokenUrl = null;
+      }
+
+      this.validateMetadataServerUrls();
+    }
+
+    private void validateMetadataServerUrls() {
+      this.validateMetadataServerUrlIfAny(this.regionUrl, "region_url");
+      this.validateMetadataServerUrlIfAny(this.url, "url");
+      this.validateMetadataServerUrlIfAny(this.imdsv2SessionTokenUrl, "imdsv2_session_token_url");
+    }
+
+    private void validateMetadataServerUrlIfAny(String urlString, String nameOfData) {
+      if (urlString != null) {
+        try {
+          URL url = new URL(urlString);
+          String host = url.getHost();
+          if (!host.equals("169.254.169.254") && !host.equals("[fd00:ec2::254]")) {
+            throw new IllegalArgumentException(
+                String.format("Invalid host %s for %s", host, nameOfData));
+          }
+        } catch (MalformedURLException malformedURLException) {
+          throw new IllegalArgumentException(malformedURLException);
+        }
       }
     }
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -103,23 +103,16 @@ public class AwsCredentialsTest {
               .build();
 
   @Test
-  public void test_awsCredentialSource() {
-    String regionUrl = "http://[fd00:ec2::254]/region";
-    String url = "http://[fd00:ec2::254]";
-    String imdsv2SessionTokenUrl = "http://[fd00:ec2::254]/imdsv2";
-    Map<String, Object> credentialSourceMap = new HashMap<>();
-    credentialSourceMap.put("environment_id", "aws1");
-    credentialSourceMap.put("region_url", regionUrl);
-    credentialSourceMap.put("url", url);
-    credentialSourceMap.put("imdsv2_session_token_url", imdsv2SessionTokenUrl);
-    credentialSourceMap.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
+  public void test_awsCredentialSource_ipv6() {
+    // If no exception is thrown, it means the urls were valid.
+    new AwsCredentialSource(buildAwsIpv6CredentialSourceMap());
+  }
 
-    // If no exception is thrown, it means the urls were valid
-    new AwsCredentialSource(credentialSourceMap);
-
+  @Test
+  public void test_awsCredentialSource_invalid_urls() {
     String keys[] = {"region_url", "url", "imdsv2_session_token_url"};
     for (String key : keys) {
-      Map<String, Object> credentialSourceWithInvalidUrl = new HashMap<>(credentialSourceMap);
+      Map<String, Object> credentialSourceWithInvalidUrl = buildAwsIpv6CredentialSourceMap();
       credentialSourceWithInvalidUrl.put(key, "https://badhost.com/fake");
       IllegalArgumentException e =
           assertThrows(
@@ -131,7 +124,7 @@ public class AwsCredentialsTest {
                 }
               });
 
-      assertEquals(String.format("Invalid host %s for %s", "badhost.com", key), e.getMessage());
+      assertEquals(String.format("Invalid host badhost.com for %s.", key), e.getMessage());
     }
   }
 
@@ -766,6 +759,20 @@ public class AwsCredentialsTest {
     credentialSourceMap.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
 
     return new AwsCredentialSource(credentialSourceMap);
+  }
+
+  private static Map<String, Object> buildAwsIpv6CredentialSourceMap() {
+    String regionUrl = "http://[fd00:ec2::254]/region";
+    String url = "http://[fd00:ec2::254]";
+    String imdsv2SessionTokenUrl = "http://[fd00:ec2::254]/imdsv2";
+    Map<String, Object> credentialSourceMap = new HashMap<>();
+    credentialSourceMap.put("environment_id", "aws1");
+    credentialSourceMap.put("region_url", regionUrl);
+    credentialSourceMap.put("url", url);
+    credentialSourceMap.put("imdsv2_session_token_url", imdsv2SessionTokenUrl);
+    credentialSourceMap.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
+
+    return credentialSourceMap;
   }
 
   static InputStream writeAwsCredentialsStream(String stsUrl, String regionUrl, String metadataUrl)

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -1117,8 +1117,8 @@ public class ExternalAccountCredentialsTest {
 
     Map<String, String> map = new HashMap<>();
     map.put("environment_id", "aws1");
-    map.put("region_url", "regionUrl");
-    map.put("url", "url");
+    map.put("region_url", "https://169.254.169.254/region");
+    map.put("url", "https://169.254.169.254/");
     map.put("regional_cred_verification_url", "regionalCredVerificationUrl");
     json.put("credential_source", map);
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
@@ -65,9 +65,9 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
   private static final String CLOUD_PLATFORM_SCOPE =
       "https://www.googleapis.com/auth/cloud-platform";
   private static final String ISSUED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
-  private static final String AWS_CREDENTIALS_URL = "https://www.aws-credentials.com";
-  private static final String AWS_REGION_URL = "https://www.aws-region.com";
-  private static final String AWS_IMDSV2_SESSION_TOKEN_URL = "https://www.aws-session-token.com";
+  private static final String AWS_CREDENTIALS_URL = "https://169.254.169.254";
+  private static final String AWS_REGION_URL = "https://169.254.169.254/region";
+  private static final String AWS_IMDSV2_SESSION_TOKEN_URL = "https://169.254.169.254/imdsv2";
   private static final String METADATA_SERVER_URL = "https://www.metadata.google.com";
   private static final String STS_URL = "https://sts.googleapis.com";
 


### PR DESCRIPTION
Updating AWS credential source validation as per new updates in [AIP](https://github.com/aip-dev/google.aip.dev/pull/959). Make sure the host of url, region_url and imdsv2 session token url belong to AWS metadata server.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
