### PR TITLE
fix: empty string check for aws url validation

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -137,18 +137,21 @@ public class AwsCredentials extends ExternalAccountCredentials {
       validateMetadataServerUrlIfAny(this.imdsv2SessionTokenUrl, "imdsv2_session_token_url");
     }
 
-    private static void validateMetadataServerUrlIfAny(String urlString, String nameInConfig) {
-      if (urlString != null && !urlString.isEmpty()) {
-        try {
-          URL url = new URL(urlString);
-          String host = url.getHost();
-          if (!host.equals("169.254.169.254") && !host.equals("[fd00:ec2::254]")) {
-            throw new IllegalArgumentException(
-                String.format("Invalid host %s for %s.", host, nameInConfig));
-          }
-        } catch (MalformedURLException malformedURLException) {
-          throw new IllegalArgumentException(malformedURLException);
+    @VisibleForTesting
+    static void validateMetadataServerUrlIfAny(String urlString, String nameInConfig) {
+      if (urlString == null || urlString.trim().length() == 0) {
+        return;
+      }
+
+      try {
+        URL url = new URL(urlString);
+        String host = url.getHost();
+        if (!host.equals("169.254.169.254") && !host.equals("[fd00:ec2::254]")) {
+          throw new IllegalArgumentException(
+              String.format("Invalid host %s for %s.", host, nameInConfig));
         }
+      } catch (MalformedURLException malformedURLException) {
+        throw new IllegalArgumentException(malformedURLException);
       }
     }
   }

--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -138,7 +138,7 @@ public class AwsCredentials extends ExternalAccountCredentials {
     }
 
     private static void validateMetadataServerUrlIfAny(String urlString, String nameInConfig) {
-      if (urlString != null) {
+      if (urlString != null && !urlString.isEmpty()) {
         try {
           URL url = new URL(urlString);
           String host = url.getHost();

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -525,7 +525,7 @@ public class AwsCredentialsTest {
   }
 
   @Test
-  public void validateMetadataServerUrlIfAny_validUrls() {
+  public void validateMetadataServerUrlIfAny_validOrEmptyUrls() {
     String[] urls = {
       "http://[fd00:ec2::254]/region",
       "http://169.254.169.254",

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -475,6 +475,40 @@ public class AwsCredentialsTest {
         .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey")
         .setEnv("AWS_SESSION_TOKEN", "awsSessionToken");
 
+    AwsCredentialSource credSource = new AwsCredentialSource(
+      new HashMap<String, Object>() {
+        {
+          put("environment_id", "aws1");
+          put("region_url", "");
+          put("url", "");
+          put("regional_cred_verification_url", "regionalCredVerificationUrl");
+        }
+      }
+    );
+
+    AwsCredentials testAwsCredentials =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setEnvironmentProvider(environmentProvider)
+                .setCredentialSource(credSource)
+                .build();
+
+    AwsSecurityCredentials credentials =
+        testAwsCredentials.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);
+
+    assertEquals("awsAccessKeyId", credentials.getAccessKeyId());
+    assertEquals("awsSecretAccessKey", credentials.getSecretAccessKey());
+    assertEquals("awsSessionToken", credentials.getToken());
+  }
+
+  @Test
+  public void getAwsSecurityCredentials_fromEnvironmentVariables_noMetadataServerCall() throws IOException {
+    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+    environmentProvider
+        .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
+        .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey")
+        .setEnv("AWS_SESSION_TOKEN", "awsSessionToken");
+
     AwsCredentials testAwsCredentials =
         (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -475,16 +475,16 @@ public class AwsCredentialsTest {
         .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey")
         .setEnv("AWS_SESSION_TOKEN", "awsSessionToken");
 
-    AwsCredentialSource credSource = new AwsCredentialSource(
-      new HashMap<String, Object>() {
-        {
-          put("environment_id", "aws1");
-          put("region_url", "");
-          put("url", "");
-          put("regional_cred_verification_url", "regionalCredVerificationUrl");
-        }
-      }
-    );
+    AwsCredentialSource credSource =
+        new AwsCredentialSource(
+            new HashMap<String, Object>() {
+              {
+                put("environment_id", "aws1");
+                put("region_url", "");
+                put("url", "");
+                put("regional_cred_verification_url", "regionalCredVerificationUrl");
+              }
+            });
 
     AwsCredentials testAwsCredentials =
         (AwsCredentials)
@@ -502,7 +502,8 @@ public class AwsCredentialsTest {
   }
 
   @Test
-  public void getAwsSecurityCredentials_fromEnvironmentVariables_noMetadataServerCall() throws IOException {
+  public void getAwsSecurityCredentials_fromEnvironmentVariables_noMetadataServerCall()
+      throws IOException {
     TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
     environmentProvider
         .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")


### PR DESCRIPTION
Validate aws metadata urls only if they are not null or empty. It is possible to fetch tokens successfully even if metadata urls are not provided but required environment variables are set. If both metadata urls and env vars are not provided, we will throw an exception.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
