### PR TITLE
fix: AwsCredentials should not call metadata server if security creds and region are retrievable through environment vars

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -63,6 +63,13 @@ import javax.annotation.Nullable;
  */
 public class AwsCredentials extends ExternalAccountCredentials {
 
+  // Supported environment variables.
+  static final String AWS_REGION = "AWS_REGION";
+  static final String AWS_DEFAULT_REGION = "AWS_DEFAULT_REGION";
+  static final String AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
+  static final String AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
+  static final String AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN";
+
   static final String AWS_IMDSV2_SESSION_TOKEN_HEADER = "x-aws-ec2-metadata-token";
   static final String AWS_IMDSV2_SESSION_TOKEN_TTL_HEADER = "x-aws-ec2-metadata-token-ttl-seconds";
   static final String AWS_IMDSV2_SESSION_TOKEN_TTL = "300";
@@ -273,10 +280,10 @@ public class AwsCredentials extends ExternalAccountCredentials {
   private boolean canRetrieveRegionFromEnvironment() {
     // The AWS region can be provided through AWS_REGION or AWS_DEFAULT_REGION. Only one is
     // required.
-    List<String> keys = ImmutableList.of("AWS_REGION", "AWS_DEFAULT_REGION");
+    List<String> keys = ImmutableList.of(AWS_REGION, AWS_DEFAULT_REGION);
     for (String env : keys) {
       String value = getEnvironmentProvider().getEnv(env);
-      if (value != null && !value.isEmpty()) {
+      if (value != null && value.trim().length() > 0) {
         // Region available.
         return true;
       }
@@ -286,10 +293,10 @@ public class AwsCredentials extends ExternalAccountCredentials {
 
   private boolean canRetrieveSecurityCredentialsFromEnvironment() {
     // Check if both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are available.
-    List<String> keys = ImmutableList.of("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY");
+    List<String> keys = ImmutableList.of(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY);
     for (String env : keys) {
       String value = getEnvironmentProvider().getEnv(env);
-      if (value == null || value.isEmpty()) {
+      if (value == null || value.trim().length() == 0) {
         // Return false if one of them are missing.
         return false;
       }
@@ -342,11 +349,11 @@ public class AwsCredentials extends ExternalAccountCredentials {
     String region;
     if (canRetrieveRegionFromEnvironment()) {
       // For AWS Lambda, the region is retrieved through the AWS_REGION environment variable.
-      region = getEnvironmentProvider().getEnv("AWS_REGION");
-      if (region != null) {
+      region = getEnvironmentProvider().getEnv(AWS_REGION);
+      if (region != null && region.trim().length() > 0) {
         return region;
       }
-      return getEnvironmentProvider().getEnv("AWS_DEFAULT_REGION");
+      return getEnvironmentProvider().getEnv(AWS_DEFAULT_REGION);
     }
 
     if (awsCredentialSource.regionUrl == null || awsCredentialSource.regionUrl.isEmpty()) {
@@ -366,9 +373,9 @@ public class AwsCredentials extends ExternalAccountCredentials {
       throws IOException {
     // Check environment variables for credentials first.
     if (canRetrieveSecurityCredentialsFromEnvironment()) {
-      String accessKeyId = getEnvironmentProvider().getEnv("AWS_ACCESS_KEY_ID");
-      String secretAccessKey = getEnvironmentProvider().getEnv("AWS_SECRET_ACCESS_KEY");
-      String token = getEnvironmentProvider().getEnv("AWS_SESSION_TOKEN");
+      String accessKeyId = getEnvironmentProvider().getEnv(AWS_ACCESS_KEY_ID);
+      String secretAccessKey = getEnvironmentProvider().getEnv(AWS_SECRET_ACCESS_KEY);
+      String token = getEnvironmentProvider().getEnv(AWS_SESSION_TOKEN);
       return new AwsSecurityCredentials(accessKeyId, secretAccessKey, token);
     }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -955,6 +955,41 @@ public class AwsCredentialsTest {
   }
 
   @Test
+  public void shouldUseMetadataServer_missingAwsSecurityCreds() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    // Add required environment variables.
+    List<String> regionKeys = ImmutableList.of("AWS_REGION", "AWS_DEFAULT_REGION");
+    for (String regionKey : regionKeys) {
+      TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+      // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are always required.
+      // Not set here.
+      AwsCredentials awsCredential =
+          (AwsCredentials)
+              AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                  .setHttpTransportFactory(transportFactory)
+                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+                  .setEnvironmentProvider(environmentProvider)
+                  .build();
+      assertTrue(awsCredential.shouldUseMetadataServer());
+    }
+  }
+
+  @Test
+  public void shouldUseMetadataServer_noEnvironmentVars() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+    AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+                .build();
+    assertTrue(awsCredential.shouldUseMetadataServer());
+  }
+
+  @Test
   public void builder() {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -31,6 +31,7 @@
 
 package com.google.auth.oauth2;
 
+import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -44,6 +45,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.auth.TestUtils;
 import com.google.auth.oauth2.AwsCredentials.AwsCredentialSource;
 import com.google.auth.oauth2.ExternalAccountCredentialsTest.MockExternalAccountCredentialsTransportFactory;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -251,19 +253,11 @@ public class AwsCredentialsTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
 
-    Map<String, Object> credentialSourceMap = new HashMap<>();
-    credentialSourceMap.put("environment_id", "aws1");
-    credentialSourceMap.put("region_url", transportFactory.transport.getAwsRegionUrl());
-    credentialSourceMap.put("url", transportFactory.transport.getAwsCredentialsUrl());
-    credentialSourceMap.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
-    credentialSourceMap.put(
-        "imdsv2_session_token_url", transportFactory.transport.getAwsImdsv2SessionTokenUrl());
-
     AwsCredentials awsCredential =
         (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(new AwsCredentialSource(credentialSourceMap))
+                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
                 .build();
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
@@ -315,6 +309,100 @@ public class AwsCredentialsTest {
 
     // Validate security credentials request.
     ValidateRequest(requests.get(3), AWS_CREDENTIALS_URL_WITH_ROLE, sessionTokenHeader);
+  }
+
+  @Test
+  public void retrieveSubjectToken_imdsv1EnvVariablesSet_metadataServerNotCalled()
+      throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    // Provide AWS credentials through environment vars.
+    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+    environmentProvider
+        .setEnv("AWS_REGION", "awsRegion")
+        .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
+        .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey")
+        .setEnv("AWS_SESSION_TOKEN", "awsToken");
+
+    AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsCredentialSource(transportFactory))
+                .setEnvironmentProvider(environmentProvider)
+                .build();
+
+    String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
+
+    JsonParser parser = OAuth2Utils.JSON_FACTORY.createJsonParser(subjectToken);
+    GenericJson json = parser.parseAndClose(GenericJson.class);
+
+    List<Map<String, String>> headersList = (List<Map<String, String>>) json.get("headers");
+    Map<String, String> headers = new HashMap<>();
+    for (Map<String, String> header : headersList) {
+      headers.put(header.get("key"), header.get("value"));
+    }
+
+    assertEquals("POST", json.get("method"));
+    assertEquals(GET_CALLER_IDENTITY_URL, json.get("url"));
+    assertEquals(URI.create(GET_CALLER_IDENTITY_URL).getHost(), headers.get("host"));
+    assertEquals("awsToken", headers.get("x-amz-security-token"));
+    assertEquals(awsCredential.getAudience(), headers.get("x-goog-cloud-target-resource"));
+    assertTrue(headers.containsKey("x-amz-date"));
+    assertNotNull(headers.get("Authorization"));
+
+    // No requests should have been made since AWS credentials and region is passed through
+    // environment variables.
+    List<MockLowLevelHttpRequest> requests = transportFactory.transport.getRequests();
+    assertEquals(0, requests.size());
+  }
+
+  @Test
+  public void retrieveSubjectToken_imdsv2EnvVariablesSet_metadataServerNotCalled()
+      throws IOException {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    // Provide AWS credentials through environment vars.
+    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+    environmentProvider
+        .setEnv("AWS_REGION", "awsRegion")
+        .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
+        .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey")
+        .setEnv("AWS_SESSION_TOKEN", "awsToken");
+
+    AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+                .setEnvironmentProvider(environmentProvider)
+                .build();
+
+    String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
+
+    JsonParser parser = OAuth2Utils.JSON_FACTORY.createJsonParser(subjectToken);
+    GenericJson json = parser.parseAndClose(GenericJson.class);
+
+    List<Map<String, String>> headersList = (List<Map<String, String>>) json.get("headers");
+    Map<String, String> headers = new HashMap<>();
+    for (Map<String, String> header : headersList) {
+      headers.put(header.get("key"), header.get("value"));
+    }
+
+    assertEquals("POST", json.get("method"));
+    assertEquals(GET_CALLER_IDENTITY_URL, json.get("url"));
+    assertEquals(URI.create(GET_CALLER_IDENTITY_URL).getHost(), headers.get("host"));
+    assertEquals("awsToken", headers.get("x-amz-security-token"));
+    assertEquals(awsCredential.getAudience(), headers.get("x-goog-cloud-target-resource"));
+    assertTrue(headers.containsKey("x-amz-date"));
+    assertNotNull(headers.get("Authorization"));
+
+    // No requests should have been made since AWS credentials and region is passed through
+    // environment variables.
+    List<MockLowLevelHttpRequest> requests = transportFactory.transport.getRequests();
+    assertEquals(0, requests.size());
   }
 
   @Test
@@ -775,6 +863,98 @@ public class AwsCredentialsTest {
   }
 
   @Test
+  public void shouldUseMetadataServer_withRequiredEnvironmentVariables() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    // Add required environment variables.
+    List<String> regionKeys = ImmutableList.of("AWS_REGION", "AWS_DEFAULT_REGION");
+    for (String regionKey : regionKeys) {
+      TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+      // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are always required.
+      environmentProvider
+          .setEnv(regionKey, "awsRegion")
+          .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
+          .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
+      AwsCredentials awsCredential =
+          (AwsCredentials)
+              AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                  .setHttpTransportFactory(transportFactory)
+                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+                  .setEnvironmentProvider(environmentProvider)
+                  .build();
+      assertFalse(awsCredential.shouldUseMetadataServer());
+    }
+  }
+
+  @Test
+  public void shouldUseMetadataServer_missingRegion() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+    environmentProvider
+        .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
+        .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
+    AwsCredentials awsCredential =
+        (AwsCredentials)
+            AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                .setHttpTransportFactory(transportFactory)
+                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+                .setEnvironmentProvider(environmentProvider)
+                .build();
+    assertTrue(awsCredential.shouldUseMetadataServer());
+  }
+
+  @Test
+  public void shouldUseMetadataServer_missingAwsAccessKeyId() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    // Add required environment variables.
+    List<String> regionKeys = ImmutableList.of("AWS_REGION", "AWS_DEFAULT_REGION");
+    for (String regionKey : regionKeys) {
+      TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+      // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are always required.
+      environmentProvider
+          .setEnv(regionKey, "awsRegion")
+          .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
+      AwsCredentials awsCredential =
+          (AwsCredentials)
+              AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                  .setHttpTransportFactory(transportFactory)
+                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+                  .setEnvironmentProvider(environmentProvider)
+                  .build();
+      assertTrue(awsCredential.shouldUseMetadataServer());
+    }
+  }
+
+  @Test
+  public void shouldUseMetadataServer_missingAwsSecretAccessKey() {
+    MockExternalAccountCredentialsTransportFactory transportFactory =
+        new MockExternalAccountCredentialsTransportFactory();
+
+    // Add required environment variables.
+    List<String> regionKeys = ImmutableList.of("AWS_REGION", "AWS_DEFAULT_REGION");
+    for (String regionKey : regionKeys) {
+      TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+      // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are always required.
+      environmentProvider
+          .setEnv(regionKey, "awsRegion")
+          .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId");
+      AwsCredentials awsCredential =
+          (AwsCredentials)
+              AwsCredentials.newBuilder(AWS_CREDENTIAL)
+                  .setHttpTransportFactory(transportFactory)
+                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+                  .setEnvironmentProvider(environmentProvider)
+                  .build();
+      assertTrue(awsCredential.shouldUseMetadataServer());
+    }
+  }
+
+  @Test
   public void builder() {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
@@ -822,14 +1002,26 @@ public class AwsCredentialsTest {
     }
   }
 
-  private static AwsCredentialSource buildAwsCredentialSource(
+  private static Map<String, Object> buildAwsCredentialSourceMap(
       MockExternalAccountCredentialsTransportFactory transportFactory) {
     Map<String, Object> credentialSourceMap = new HashMap<>();
     credentialSourceMap.put("environment_id", "aws1");
     credentialSourceMap.put("region_url", transportFactory.transport.getAwsRegionUrl());
     credentialSourceMap.put("url", transportFactory.transport.getAwsCredentialsUrl());
     credentialSourceMap.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
+    return credentialSourceMap;
+  }
 
+  private static AwsCredentialSource buildAwsCredentialSource(
+      MockExternalAccountCredentialsTransportFactory transportFactory) {
+    return new AwsCredentialSource(buildAwsCredentialSourceMap(transportFactory));
+  }
+
+  private static AwsCredentialSource buildAwsImdsv2CredentialSource(
+      MockExternalAccountCredentialsTransportFactory transportFactory) {
+    Map<String, Object> credentialSourceMap = buildAwsCredentialSourceMap(transportFactory);
+    credentialSourceMap.put(
+        "imdsv2_session_token_url", transportFactory.transport.getAwsImdsv2SessionTokenUrl());
     return new AwsCredentialSource(credentialSourceMap);
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -965,6 +965,7 @@ public class AwsCredentialsTest {
       TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
       // AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are always required.
       // Not set here.
+      environmentProvider.setEnv(regionKey, "awsRegion");
       AwsCredentials awsCredential =
           (AwsCredentials)
               AwsCredentials.newBuilder(AWS_CREDENTIAL)


### PR DESCRIPTION
Fixes an issue introduced by the AWS IMDSv2 changes where the metadata server is being called even if everything is retrievable through the defined environment variables. 
