### PR TITLE
oauth2_http: Use Futures.getDone() instead of Future.get() in listener

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -272,12 +272,10 @@ public class OAuth2Credentials extends Credentials {
   private void finishRefreshAsync(ListenableFuture<OAuthValue> finishedTask) {
     synchronized (lock) {
       try {
-        this.value = finishedTask.get();
+        this.value = Futures.getDone(finishedTask);
         for (CredentialsChangedListener listener : changeListeners) {
           listener.onChanged(this);
         }
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
       } catch (Exception e) {
         // noop
       } finally {


### PR DESCRIPTION
Listeners for Futures should generally use Futures.addCallback() or Futures.getDone() when called. This makes it clear they won't block and allows tooling to know it will never block.

cl/492555987
