### PR TITLE
fix: Enforce Locale.US for AwsRequestSignerTest

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsRequestSignerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsRequestSignerTest.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,6 +65,8 @@ public class AwsRequestSignerTest {
 
   @Before
   public void setUp() throws IOException {
+    // Required for date parsing when run in different Locales
+    Locale.setDefault(Locale.US);
     awsSecurityCredentials = retrieveAwsSecurityCredentials();
   }
 


### PR DESCRIPTION
Enforce Locale.US for AwsRequestSignerTest. Date parsing can fail in other locales.

Specifically, in `en-CA` (Canada), the tests's defined date `Mon, 09 Sep 2011 23:36:00 GMT` won't parse correctly, as the weekday short name for the locale is `Mon.` (extra period).

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #1110  ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
