### PR TITLE
fix: ensure both refreshMargin and expirationMargin are set when using OAuth2CredentialsWithRefresh

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -152,12 +152,14 @@ public class OAuth2Credentials extends Credentials {
   }
 
   /** Returns the credentials' refresh margin. */
-  public Duration getRefreshMargin() {
+  @VisibleForTesting
+  Duration getRefreshMargin() {
     return this.refreshMargin;
   }
 
   /** Returns the credentials' expiration margin. */
-  public Duration getExpirationMargin() {
+  @VisibleForTesting
+  Duration getExpirationMargin() {
     return this.expirationMargin;
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -151,6 +151,16 @@ public class OAuth2Credentials extends Credentials {
     return null;
   }
 
+  /** Returns the credentials' refresh margin. */
+  public Duration getRefreshMargin() {
+    return this.refreshMargin;
+  }
+
+  /** Returns the credentials' expiration margin. */
+  public Duration getExpirationMargin() {
+    return this.expirationMargin;
+  }
+
   @Override
   public void getRequestMetadata(
       final URI uri, Executor executor, final RequestMetadataCallback callback) {

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
@@ -49,6 +49,16 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
 
   private final OAuth2RefreshHandler refreshHandler;
 
+  protected OAuth2CredentialsWithRefresh(Builder builder) {
+    super(builder.getAccessToken(), builder.getRefreshMargin(), builder.getExpirationMargin());
+    // An expiration time must be provided.
+    if (builder.getAccessToken() != null && builder.getAccessToken().getExpirationTime() == null) {
+      throw new IllegalArgumentException(
+          "The provided access token must contain the expiration time.");
+    }
+    this.refreshHandler = checkNotNull(builder.refreshHandler);
+  }
+
   protected OAuth2CredentialsWithRefresh(
       AccessToken accessToken, OAuth2RefreshHandler refreshHandler) {
     super(accessToken);
@@ -101,7 +111,7 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
     }
 
     public OAuth2CredentialsWithRefresh build() {
-      return new OAuth2CredentialsWithRefresh(getAccessToken(), refreshHandler);
+      return new OAuth2CredentialsWithRefresh(this);
     }
   }
 }


### PR DESCRIPTION
Fixes b/263058140
