### PR TITLE
feat: Introduce a way to pass additional parameters to auhtorization url

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 /** Handles an interactive 3-Legged-OAuth2 (3LO) user consent authorization. */
 public class UserAuthorizer {
@@ -168,6 +169,20 @@ public class UserAuthorizer {
    * @return The URL that can be navigated or redirected to.
    */
   public URL getAuthorizationUrl(String userId, String state, URI baseUri) {
+    return this.getAuthorizationUrl(userId, state, baseUri, null);
+  }
+
+  /**
+   * Return an URL that performs the authorization consent prompt web UI.
+   *
+   * @param userId Application's identifier for the end user.
+   * @param state State that is passed on to the OAuth2 callback URI after the consent.
+   * @param baseUri The URI to resolve the OAuth2 callback URI relative to.
+   * @param additionalParameters Additional query parameters to be added to the authorization url
+   * @return The URL that can be navigated or redirected to.
+   */
+  public URL getAuthorizationUrl(
+      String userId, String state, URI baseUri, Map<String, String> additionalParameters) {
     URI resolvedCallbackUri = getCallbackUri(baseUri);
     String scopesString = Joiner.on(' ').join(scopes);
 
@@ -185,6 +200,13 @@ public class UserAuthorizer {
       url.put("login_hint", userId);
     }
     url.put("include_granted_scopes", true);
+
+    if (additionalParameters != null) {
+      for (Map.Entry<String, String> entry : additionalParameters.entrySet()) {
+        url.put(entry.getKey(), entry.getValue());
+      }
+    }
+
     if (pkce != null) {
       url.put("code_challenge", pkce.getCodeChallenge());
       url.put("code_challenge_method", pkce.getCodeChallengeMethod());

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -265,8 +265,6 @@ public class UserAuthorizer {
    *
    * @param code Code returned from OAuth2 consent prompt.
    * @param baseUri The URI to resolve the OAuth2 callback URI relative to.
-   * @param additionalParameters Additional parameters to be added to the post body of token
-   *     endpoint request.
    * @return the UserCredentials instance created from the authorization code.
    * @throws IOException An error from the server API call to get the tokens.
    */

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -265,10 +265,27 @@ public class UserAuthorizer {
    *
    * @param code Code returned from OAuth2 consent prompt.
    * @param baseUri The URI to resolve the OAuth2 callback URI relative to.
+   * @param additionalParameters Additional parameters to be added to the post body of token
+   *     endpoint request.
    * @return the UserCredentials instance created from the authorization code.
    * @throws IOException An error from the server API call to get the tokens.
    */
   public UserCredentials getCredentialsFromCode(String code, URI baseUri) throws IOException {
+    return getCredentialsFromCode(code, baseUri, null);
+  }
+
+  /**
+   * Returns a UserCredentials instance by exchanging an OAuth2 authorization code for tokens.
+   *
+   * @param code Code returned from OAuth2 consent prompt.
+   * @param baseUri The URI to resolve the OAuth2 callback URI relative to.
+   * @param additionalParameters Additional parameters to be added to the post body of token
+   *     endpoint request.
+   * @return the UserCredentials instance created from the authorization code.
+   * @throws IOException An error from the server API call to get the tokens.
+   */
+  public UserCredentials getCredentialsFromCode(
+      String code, URI baseUri, Map<String, String> additionalParameters) throws IOException {
     Preconditions.checkNotNull(code);
     URI resolvedCallbackUri = getCallbackUri(baseUri);
 
@@ -278,6 +295,12 @@ public class UserAuthorizer {
     tokenData.put("client_secret", clientId.getClientSecret());
     tokenData.put("redirect_uri", resolvedCallbackUri);
     tokenData.put("grant_type", "authorization_code");
+
+    if (additionalParameters != null) {
+      for (Map.Entry<String, String> entry : additionalParameters.entrySet()) {
+        tokenData.put(entry.getKey(), entry.getValue());
+      }
+    }
 
     if (pkce != null) {
       tokenData.put("code_verifier", pkce.getCodeVerifier());

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -178,7 +178,7 @@ public class UserAuthorizer {
    * @param userId Application's identifier for the end user.
    * @param state State that is passed on to the OAuth2 callback URI after the consent.
    * @param baseUri The URI to resolve the OAuth2 callback URI relative to.
-   * @param additionalParameters Additional query parameters to be added to the authorization url
+   * @param additionalParameters Additional query parameters to be added to the authorization URL.
    * @return The URL that can be navigated or redirected to.
    */
   public URL getAuthorizationUrl(

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -65,7 +65,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
   final Map<String, String> serviceAccounts = new HashMap<String, String>();
   final Map<String, String> gdchServiceAccounts = new HashMap<String, String>();
   final Map<String, String> codes = new HashMap<String, String>();
-  final Map<String, Map<String, String>> customParameters =
+  final Map<String, Map<String, String>> additionalParameters =
       new HashMap<String, Map<String, String>>();
   URI tokenServerUri = OAuth2Utils.TOKEN_SERVER_URI;
   private IOException error;
@@ -87,13 +87,13 @@ public class MockTokenServerTransport extends MockHttpTransport {
       String refreshToken,
       String accessToken,
       String grantedScopes,
-      Map<String, String> customParameters) {
+      Map<String, String> additionalParameters) {
     codes.put(code, refreshToken);
     refreshTokens.put(refreshToken, accessToken);
     this.grantedScopes.put(refreshToken, grantedScopes);
 
-    if (customParameters != null) {
-      this.customParameters.put(refreshToken, customParameters);
+    if (additionalParameters != null) {
+      this.additionalParameters.put(refreshToken, additionalParameters);
     }
   }
 
@@ -231,16 +231,24 @@ public class MockTokenServerTransport extends MockHttpTransport {
               grantedScopesString = grantedScopes.get(refreshToken);
             }
 
-            if (customParameters.containsKey(refreshToken)) {
-              Map<String, String> customParametersMap = customParameters.get(refreshToken);
-              for (Map.Entry<String, String> entry : customParametersMap.entrySet()) {
+            if (additionalParameters.containsKey(refreshToken)) {
+              Map<String, String> additionalParametersMap = additionalParameters.get(refreshToken);
+              for (Map.Entry<String, String> entry : additionalParametersMap.entrySet()) {
                 String key = entry.getKey();
-                String value = entry.getValue();
+                String expectedValue = entry.getValue();
                 if (!query.containsKey(key)) {
-                  throw new IllegalArgumentException("Missing custom parameter: " + key);
-                } else if (!query.get(key).equals(value)) {
-                  throw new IllegalArgumentException(
-                      "Custom parameter " + key + " does not match: " + value);
+                  throw new IllegalArgumentException("Missing additional parameter: " + key);
+                } else {
+                  String actualValue = query.get(key);
+                  if (!expectedValue.equals(actualValue)) {
+                    throw new IllegalArgumentException(
+                        "For additional parameter "
+                            + key
+                            + ", Actual value: "
+                            + actualValue
+                            + ", Expected value: "
+                            + expectedValue);
+                  }
                 }
               }
             }

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -379,7 +379,7 @@ public class UserAuthorizerTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
     transportFactory.transport.addAuthorizationCode(
-        CODE, REFRESH_TOKEN, ACCESS_TOKEN_VALUE, GRANTED_SCOPES_STRING);
+        CODE, REFRESH_TOKEN, ACCESS_TOKEN_VALUE, GRANTED_SCOPES_STRING, null);
     TokenStore tokenStore = new MemoryTokensStorage();
     UserAuthorizer authorizer =
         UserAuthorizer.newBuilder()
@@ -390,6 +390,34 @@ public class UserAuthorizerTest {
             .build();
 
     UserCredentials credentials = authorizer.getCredentialsFromCode(CODE, BASE_URI);
+
+    assertEquals(REFRESH_TOKEN, credentials.getRefreshToken());
+    assertEquals(ACCESS_TOKEN_VALUE, credentials.getAccessToken().getTokenValue());
+    assertEquals(GRANTED_SCOPES, credentials.getAccessToken().getScopes());
+  }
+
+  @Test
+  public void getCredentialsFromCode_additionalParameters() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
+
+    Map<String, String> additionalParameters = new HashMap<String, String>();
+    additionalParameters.put("param1", "value1");
+    additionalParameters.put("param2", "value2");
+
+    transportFactory.transport.addAuthorizationCode(
+        CODE, REFRESH_TOKEN, ACCESS_TOKEN_VALUE, GRANTED_SCOPES_STRING, additionalParameters);
+    TokenStore tokenStore = new MemoryTokensStorage();
+    UserAuthorizer authorizer =
+        UserAuthorizer.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setScopes(DUMMY_SCOPES)
+            .setTokenStore(tokenStore)
+            .setHttpTransportFactory(transportFactory)
+            .build();
+
+    UserCredentials credentials =
+        authorizer.getCredentialsFromCode(CODE, BASE_URI, additionalParameters);
 
     assertEquals(REFRESH_TOKEN, credentials.getRefreshToken());
     assertEquals(ACCESS_TOKEN_VALUE, credentials.getAccessToken().getTokenValue());
@@ -415,7 +443,7 @@ public class UserAuthorizerTest {
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
     transportFactory.transport.addAuthorizationCode(
-        CODE, REFRESH_TOKEN, accessTokenValue1, GRANTED_SCOPES_STRING);
+        CODE, REFRESH_TOKEN, accessTokenValue1, GRANTED_SCOPES_STRING, null);
     TokenStore tokenStore = new MemoryTokensStorage();
     UserAuthorizer authorizer =
         UserAuthorizer.newBuilder()


### PR DESCRIPTION
Sometimes customers might want to pass custom query parameters to the auth endpoint. Adding a property bag like solution so that customers can pass any key, value pair to the auth service.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
