### PR TITLE
fix: Removed url pattern validation for google urls in external account credential configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,13 @@ ExternalAccountCredentials credentials =
     ExternalAccountCredentials.fromStream(new FileInputStream("/path/to/credentials.json"));
 ```
 
+##### Security Considerations
+Note that this library does not perform any validation on the token_url, token_info_url,
+or service_account_impersonation_url fields of the credential configuration.
+It is not recommended to use a credential configuration that you did not
+generate with the gcloud CLI unless you verify that the URL fields point to a
+googleapis.com domain.
+
 ### Downscoping with Credential Access Boundaries
 
 [Downscoping with Credential Access Boundaries](https://cloud.google.com/iam/docs/downscoping-short-lived-credentials)

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Executor;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
@@ -601,10 +600,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     }
   }
 
-  /**
-   * Returns true if the provided URL's scheme is valid and is HTTPS.
-   */
-  private static boolean isValidUrl( String url) {
+  /** Returns true if the provided URL's scheme is valid and is HTTPS. */
+  private static boolean isValidUrl(String url) {
     URI uri;
 
     try {

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -589,37 +589,22 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
   }
 
   static void validateTokenUrl(String tokenUrl) {
-    List<Pattern> patterns = new ArrayList<>();
-    patterns.add(Pattern.compile("^[^\\.\\s\\/\\\\]+\\.sts\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^sts\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^sts\\.[^\\.\\s\\/\\\\]+\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^[^\\.\\s\\/\\\\]+\\-sts\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^sts\\-[^\\.\\s\\/\\\\]+\\.p\\.googleapis\\.com$"));
-
-    if (!isValidUrl(patterns, tokenUrl)) {
+    if (!isValidUrl(tokenUrl)) {
       throw new IllegalArgumentException("The provided token URL is invalid.");
     }
   }
 
   static void validateServiceAccountImpersonationInfoUrl(String serviceAccountImpersonationUrl) {
-    List<Pattern> patterns = new ArrayList<>();
-    patterns.add(Pattern.compile("^[^\\.\\s\\/\\\\]+\\.iamcredentials\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^iamcredentials\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^iamcredentials\\.[^\\.\\s\\/\\\\]+\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^[^\\.\\s\\/\\\\]+\\-iamcredentials\\.googleapis\\.com$"));
-    patterns.add(Pattern.compile("^iamcredentials-[^\\.\\s\\/\\\\]+\\.p\\.googleapis\\.com$"));
-
-    if (!isValidUrl(patterns, serviceAccountImpersonationUrl)) {
+    if (!isValidUrl(serviceAccountImpersonationUrl)) {
       throw new IllegalArgumentException(
           "The provided service account impersonation URL is invalid.");
     }
   }
 
   /**
-   * Returns true if the provided URL's scheme is HTTPS and the host comforms to at least one of the
-   * provided patterns.
+   * Returns true if the provided URL's scheme is valid and is HTTPS.
    */
-  private static boolean isValidUrl(List<Pattern> patterns, String url) {
+  private static boolean isValidUrl( String url) {
     URI uri;
 
     try {
@@ -635,13 +620,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
       return false;
     }
 
-    for (Pattern pattern : patterns) {
-      Matcher match = pattern.matcher(uri.getHost().toLowerCase(Locale.US));
-      if (match.matches()) {
-        return true;
-      }
-    }
-    return false;
+    return true;
   }
 
   /**

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -980,34 +980,14 @@ public class ExternalAccountCredentialsTest {
   public void validateTokenUrl_invalidUrls() {
     List<String> invalidUrls =
         Arrays.asList(
-            "https://iamcredentials.googleapis.com",
             "sts.googleapis.com",
             "https://",
             "http://sts.googleapis.com",
-            "https://st.s.googleapis.com",
             "https://us-eas\\t-1.sts.googleapis.com",
             "https:/us-east-1.sts.googleapis.com",
-            "https://US-WE/ST-1-sts.googleapis.com",
-            "https://sts-us-east-1.googleapis.com",
-            "https://sts-US-WEST-1.googleapis.com",
             "testhttps://us-east-1.sts.googleapis.com",
-            "https://us-east-1.sts.googleapis.comevil.com",
-            "https://us-east-1.us-east-1.sts.googleapis.com",
-            "https://us-ea.s.t.sts.googleapis.com",
-            "https://sts.googleapis.comevil.com",
             "hhttps://us-east-1.sts.googleapis.com",
-            "https://us- -1.sts.googleapis.com",
-            "https://-sts.googleapis.com",
-            "https://us-east-1.sts.googleapis.com.evil.com",
-            "https://sts.pgoogleapis.com",
-            "https://p.googleapis.com",
-            "https://sts.p.com",
-            "http://sts.p.googleapis.com",
-            "https://xyz-sts.p.googleapis.com",
-            "https://sts-xyz.123.p.googleapis.com",
-            "https://sts-xyz.p1.googleapis.com",
-            "https://sts-xyz.p.foo.com",
-            "https://sts-xyz.p.foo.googleapis.com");
+            "https://us- -1.sts.googleapis.com");
 
     for (String url : invalidUrls) {
       try {
@@ -1046,34 +1026,14 @@ public class ExternalAccountCredentialsTest {
   public void validateServiceAccountImpersonationUrls_invalidUrls() {
     List<String> invalidUrls =
         Arrays.asList(
-            "https://sts.googleapis.com",
             "iamcredentials.googleapis.com",
             "https://",
             "http://iamcredentials.googleapis.com",
-            "https://iamcre.dentials.googleapis.com",
+            "https:/iamcredentials.googleapis.com",
             "https://us-eas\t-1.iamcredentials.googleapis.com",
-            "https:/us-east-1.iamcredentials.googleapis.com",
-            "https://US-WE/ST-1-iamcredentials.googleapis.com",
-            "https://iamcredentials-us-east-1.googleapis.com",
-            "https://iamcredentials-US-WEST-1.googleapis.com",
             "testhttps://us-east-1.iamcredentials.googleapis.com",
-            "https://us-east-1.iamcredentials.googleapis.comevil.com",
-            "https://us-east-1.us-east-1.iamcredentials.googleapis.com",
-            "https://us-ea.s.t.iamcredentials.googleapis.com",
-            "https://iamcredentials.googleapis.comevil.com",
             "hhttps://us-east-1.iamcredentials.googleapis.com",
-            "https://us- -1.iamcredentials.googleapis.com",
-            "https://-iamcredentials.googleapis.com",
-            "https://us-east-1.iamcredentials.googleapis.com.evil.com",
-            "https://iamcredentials.pgoogleapis.com",
-            "https://p.googleapis.com",
-            "https://iamcredentials.p.com",
-            "http://iamcredentials.p.googleapis.com",
-            "https://xyz-iamcredentials.p.googleapis.com",
-            "https://iamcredentials-xyz.123.p.googleapis.com",
-            "https://iamcredentials-xyz.p1.googleapis.com",
-            "https://iamcredentials-xyz.p.foo.com",
-            "https://iamcredentials-xyz.p.foo.googleapis.com");
+            "https://us- -1.iamcredentials.googleapis.com");
 
     for (String url : invalidUrls) {
       try {


### PR DESCRIPTION
Removed pattern checking for external accounts to support TPC urls. Also added readme change to explain risk to users.