### PR TITLE
fix: create and reuse self signed jwt creds for better performance

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -145,12 +145,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
     this.lifetime = builder.lifetime;
     this.useJwtAccessWithScope = builder.useJwtAccessWithScope;
     this.defaultRetriesEnabled = builder.defaultRetriesEnabled;
-
-    // Create a jwt credential for self signed jwt with scopes, and reuse it to improve the
-    // performance. For example see https://github.com/googleapis/google-cloud-java/issues/3149.
-    if (!createScopedRequired() && this.useJwtAccessWithScope) {
-      this.selfSignedJwtCredentialsWithScope = createSelfSignedJwtCredentials(null);
-    }
   }
 
   /**
@@ -948,7 +942,10 @@ public class ServiceAccountCredentials extends GoogleCredentials
     // Otherwise, use self signed JWT with uri as the audience.
     JwtCredentials jwtCredentials;
     if (!createScopedRequired() && useJwtAccessWithScope) {
-      // Reuse selfSignedJwtCredentialsWithScope to improve the performance.
+      // Create selfSignedJwtCredentialsWithScope when needed and reuse it for better performance.
+      if (selfSignedJwtCredentialsWithScope == null) {
+        selfSignedJwtCredentialsWithScope = createSelfSignedJwtCredentials(null);
+      }
       jwtCredentials = selfSignedJwtCredentialsWithScope;
     } else {
       // Create JWT credentials with the uri as audience.

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -1465,6 +1465,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    assertNotNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
     verifyJwtAccess(metadata, "dummy.scope");
   }
 
@@ -1518,6 +1519,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    assertNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
     verifyJwtAccess(metadata, null);
   }
 


### PR DESCRIPTION
GAPIC clients all use self signed jwt (with scopes) now. Currently we are creating a new jwt credential each time, and this causes perf issue, similar to https://github.com/googleapis/google-cloud-java/issues/3149.

In this PR we create one jwt cred and reuse it each time.
Internal bug:  b/268603529