### PR TITLE
fix: create and reuse self signed jwt creds for better performance 

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -119,6 +119,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
   private transient HttpTransportFactory transportFactory;
 
+  private transient JwtCredentials selfSignedJwtCredentialsWithScope = null;
+
   /**
    * Internal constructor
    *
@@ -731,6 +733,11 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return useJwtAccessWithScope;
   }
 
+  @VisibleForTesting
+  JwtCredentials getSelfSignedJwtCredentialsWithScope() {
+    return selfSignedJwtCredentialsWithScope;
+  }
+
   @Override
   public String getAccount() {
     return getClientEmail();
@@ -971,8 +978,11 @@ public class ServiceAccountCredentials extends GoogleCredentials
     // Otherwise, use self signed JWT with uri as the audience.
     JwtCredentials jwtCredentials;
     if (!createScopedRequired() && useJwtAccessWithScope) {
-      // Create JWT credentials with the scopes.
-      jwtCredentials = createSelfSignedJwtCredentials(null);
+      // Create selfSignedJwtCredentialsWithScope when needed and reuse it for better performance.
+      if (selfSignedJwtCredentialsWithScope == null) {
+        selfSignedJwtCredentialsWithScope = createSelfSignedJwtCredentials(null);
+      }
+      jwtCredentials = selfSignedJwtCredentialsWithScope;
     } else {
       // Create JWT credentials with the uri as audience.
       jwtCredentials = createSelfSignedJwtCredentials(uri);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -1421,6 +1421,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    assertNotNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
     verifyJwtAccess(metadata, "dummy.scope");
   }
 
@@ -1472,6 +1473,7 @@ class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .build();
 
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
+    assertNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
     verifyJwtAccess(metadata, null);
   }
 


### PR DESCRIPTION
* fix: create and reuse self signed jwt creds for better performance
* only create jwt cred when needed
