### PR TITLE
feat: option to clear cached application default credentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -32,6 +32,8 @@
 package com.google.auth.oauth2;
 
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -137,8 +139,9 @@ class DefaultCredentialsProvider {
     }
   }
 
-  private final GoogleCredentials getDefaultCredentialsUnsynchronized(
-      HttpTransportFactory transportFactory) throws IOException {
+  @VisibleForTesting
+  final GoogleCredentials getDefaultCredentialsUnsynchronized(
+          HttpTransportFactory transportFactory) throws IOException {
 
     // First try the environment variable
     GoogleCredentials credentials = null;
@@ -362,6 +365,7 @@ class DefaultCredentialsProvider {
     return System.getProperty(property, def);
   }
 
+  @VisibleForTesting
   boolean isFile(File file) {
     return file.isFile();
   }

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -87,7 +87,7 @@ class DefaultCredentialsProvider {
   // These variables should only be accessed inside a synchronized block
   private GoogleCredentials cachedCredentials = null;
   private boolean checkedAppEngine = false;
-  private boolean checkedComputeEngine = false;
+  boolean checkedComputeEngine = false;
 
   DefaultCredentialsProvider() {}
 

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -131,6 +131,12 @@ class DefaultCredentialsProvider {
             CREDENTIAL_ENV_VAR, HELP_PERMALINK));
   }
 
+  final void clearCachedCredentials() {
+    synchronized (this) {
+      cachedCredentials = null;
+    }
+  }
+
   private final GoogleCredentials getDefaultCredentialsUnsynchronized(
       HttpTransportFactory transportFactory) throws IOException {
 

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -33,7 +33,6 @@ package com.google.auth.oauth2;
 
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -140,8 +139,8 @@ class DefaultCredentialsProvider {
   }
 
   @VisibleForTesting
-  final GoogleCredentials getDefaultCredentialsUnsynchronized(
-          HttpTransportFactory transportFactory) throws IOException {
+  final GoogleCredentials getDefaultCredentialsUnsynchronized(HttpTransportFactory transportFactory)
+      throws IOException {
 
     // First try the environment variable
     GoogleCredentials credentials = null;
@@ -365,7 +364,6 @@ class DefaultCredentialsProvider {
     return System.getProperty(property, def);
   }
 
-  @VisibleForTesting
   boolean isFile(File file) {
     return file.isFile();
   }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -130,6 +130,17 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   }
 
   /**
+   * Clears the default credentials provider's cached credentials
+   *
+   * <p>This will remove the cached credentials returned by {@code getApplicationDefault()}, meaning
+   * that a new call to {@code getApplicationDefault()} will trigger the search for Application
+   * Default Credentials
+   */
+  public static void clearApplicationDefaultCachedCredentials() {
+    defaultCredentialsProvider.clearCachedCredentials();
+  }
+
+  /**
    * Returns credentials defined by a JSON file stream.
    *
    * <p>The stream can contain a Service Account key file in JSON format from the Google Developers

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -36,7 +36,6 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.Preconditions;
 import com.google.auth.http.HttpTransportFactory;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,7 +60,6 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
 
   protected final String quotaProjectId;
 
-  @VisibleForTesting
   private static final DefaultCredentialsProvider defaultCredentialsProvider =
       new DefaultCredentialsProvider();
 

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -36,6 +36,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.JsonObjectParser;
 import com.google.api.client.util.Preconditions;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,6 +61,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
 
   protected final String quotaProjectId;
 
+  @VisibleForTesting
   private static final DefaultCredentialsProvider defaultCredentialsProvider =
       new DefaultCredentialsProvider();
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -72,6 +72,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+
 /** Test case for {@link DefaultCredentialsProvider}. */
 @RunWith(JUnit4.class)
 public class DefaultCredentialsProviderTest {
@@ -263,6 +264,23 @@ public class DefaultCredentialsProviderTest {
 
     assertNotNull(firstCall);
     assertSame(firstCall, secondCall);
+  }
+
+  @Test
+  public void getDefaultCredentials_clearCache() throws IOException {
+    MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+    TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
+
+    GoogleCredentials firstCall = testProvider.getDefaultCredentials(transportFactory);
+    GoogleCredentials secondCall = testProvider.getDefaultCredentials(transportFactory);
+    testProvider.clearCachedCredentials();
+    testProvider.setCheckedComputeEngine(false);
+    GoogleCredentials thirdCall = testProvider.getDefaultCredentials(transportFactory);
+
+    assertNotNull(firstCall);
+    assertNotNull(thirdCall);
+    assertSame(firstCall, secondCall);
+    assertNotSame(secondCall, thirdCall);
   }
 
   @Test
@@ -645,6 +663,8 @@ public class DefaultCredentialsProviderTest {
     assertNull(message);
   }
 
+
+
   private LogRecord getCredentialsAndReturnLogMessage(boolean suppressWarning) throws IOException {
     Logger logger = Logger.getLogger(DefaultCredentialsProvider.class.getName());
     LogHandler handler = new LogHandler();
@@ -842,6 +862,10 @@ public class DefaultCredentialsProviderTest {
 
     void setFileSandbox(boolean fileSandbox) {
       this.fileSandbox = fileSandbox;
+    }
+
+    void setCheckedComputeEngine(boolean value) {
+      this.checkedComputeEngine = value;
     }
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -34,6 +34,7 @@ package com.google.auth.oauth2;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -72,7 +72,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-
 /** Test case for {@link DefaultCredentialsProvider}. */
 @RunWith(JUnit4.class)
 public class DefaultCredentialsProviderTest {
@@ -662,8 +661,6 @@ public class DefaultCredentialsProviderTest {
     LogRecord message = getCredentialsAndReturnLogMessage(true);
     assertNull(message);
   }
-
-
 
   private LogRecord getCredentialsAndReturnLogMessage(boolean suppressWarning) throws IOException {
     Logger logger = Logger.getLogger(DefaultCredentialsProvider.class.getName());

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -52,9 +52,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
 
 /** Test case for {@link GoogleCredentials}. */
 @RunWith(JUnit4.class)
@@ -597,10 +599,15 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void clearCache() throws IOException {
+    DefaultCredentialsProvider mockProvider = Mockito.spy(DefaultCredentialsProvider.DEFAULT);
+    Mockito.when(mockProvider.getDefaultCredentialsUnsynchronized(OAuth2Utils.HTTP_TRANSPORT_FACTORY))
+            .thenAnswer(GoogleCredentials -> new GoogleCredentials.Builder().build());
     GoogleCredentials credentialsFirst = GoogleCredentials.getApplicationDefault();
-    GoogleCredentials.clearApplicationDefaultCachedCredentials();
     GoogleCredentials credentialsSecond = GoogleCredentials.getApplicationDefault();
-    assertNotSame(credentialsFirst, credentialsSecond);
+    GoogleCredentials.clearApplicationDefaultCachedCredentials();
+    GoogleCredentials credentialsThird = GoogleCredentials.getApplicationDefault();
+    assertSame(credentialsFirst, credentialsSecond);
+    assertNotSame(credentialsSecond, credentialsThird);
   }
 
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -55,7 +55,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mockito;
 
 /** Test case for {@link GoogleCredentials}. */
 @RunWith(JUnit4.class)
@@ -594,20 +593,6 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
     assertEquals(testCredentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(testCredentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
-  }
-
-  @Test
-  public void clearCache() throws IOException {
-    DefaultCredentialsProvider mockProvider = Mockito.spy(DefaultCredentialsProvider.DEFAULT);
-    Mockito.when(
-            mockProvider.getDefaultCredentialsUnsynchronized(OAuth2Utils.HTTP_TRANSPORT_FACTORY))
-        .thenAnswer(GoogleCredentials -> new GoogleCredentials.Builder().build());
-    GoogleCredentials credentialsFirst = GoogleCredentials.getApplicationDefault();
-    GoogleCredentials credentialsSecond = GoogleCredentials.getApplicationDefault();
-    GoogleCredentials.clearApplicationDefaultCachedCredentials();
-    GoogleCredentials credentialsThird = GoogleCredentials.getApplicationDefault();
-    assertSame(credentialsFirst, credentialsSecond);
-    assertNotSame(credentialsSecond, credentialsThird);
   }
 
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -52,7 +52,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -600,8 +599,9 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
   @Test
   public void clearCache() throws IOException {
     DefaultCredentialsProvider mockProvider = Mockito.spy(DefaultCredentialsProvider.DEFAULT);
-    Mockito.when(mockProvider.getDefaultCredentialsUnsynchronized(OAuth2Utils.HTTP_TRANSPORT_FACTORY))
-            .thenAnswer(GoogleCredentials -> new GoogleCredentials.Builder().build());
+    Mockito.when(
+            mockProvider.getDefaultCredentialsUnsynchronized(OAuth2Utils.HTTP_TRANSPORT_FACTORY))
+        .thenAnswer(GoogleCredentials -> new GoogleCredentials.Builder().build());
     GoogleCredentials credentialsFirst = GoogleCredentials.getApplicationDefault();
     GoogleCredentials credentialsSecond = GoogleCredentials.getApplicationDefault();
     GoogleCredentials.clearApplicationDefaultCachedCredentials();

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -595,6 +595,14 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
   }
 
+  @Test
+  public void clearCache() throws IOException {
+    GoogleCredentials credentialsFirst = GoogleCredentials.getApplicationDefault();
+    GoogleCredentials.clearApplicationDefaultCachedCredentials();
+    GoogleCredentials credentialsSecond = GoogleCredentials.getApplicationDefault();
+    assertNotSame(credentialsFirst, credentialsSecond);
+  }
+
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {
     try {
       GoogleCredentials.fromStream(stream, DUMMY_TRANSPORT_FACTORY);


### PR DESCRIPTION
fixes #1181 
Adds a public method in `GoogleCredentials` to clear the cached credentials of `DefaultCredentialsProvider`
