### PR TITLE
chore: try fully-qualified Serializable to avoid compile error

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -43,7 +43,6 @@ import com.google.auth.oauth2.PluggableAuthCredentials.PluggableAuthCredentialSo
 import com.google.common.base.MoreObjects;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -69,7 +68,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
   private static final long serialVersionUID = 8049126194174465023L;
 
   /** Base credential source class. Dictates the retrieval method of the external credential. */
-  abstract static class CredentialSource implements Serializable {
+  abstract static class CredentialSource implements java.io.Serializable {
 
     private static final long serialVersionUID = 8204657811562399944L;
 
@@ -263,7 +262,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     this.workforcePoolUserProject = builder.workforcePoolUserProject;
     if (workforcePoolUserProject != null && !isWorkforcePoolConfiguration()) {
       throw new IllegalArgumentException(
-          "The workforce_pool_user_project parameter should only be provided for a Workforce Pool configuration.");
+          "The workforce_pool_user_project parameter should only be provided for a Workforce Pool"
+              + " configuration.");
     }
 
     validateTokenUrl(tokenUrl);

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -641,7 +641,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
    * }
    * </pre>
    */
-  static final class ServiceAccountImpersonationOptions implements Serializable {
+  static final class ServiceAccountImpersonationOptions implements java.io.Serializable {
 
     private static final long serialVersionUID = 4250771921886280953L;
     private static final int DEFAULT_TOKEN_LIFETIME_SECONDS = 3600;


### PR DESCRIPTION
No need to review yet. Trying the behavior of OwlBot postprocessor and the compilation error in Kokoro.