### PR TITLE
chore: update Kokoro job to GraalVM 22.3.2

### DIFF
--- a/.kokoro/presubmit/graalvm-native-17.cfg
+++ b/.kokoro/presubmit/graalvm-native-17.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm17:22.3.2"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native.cfg
+++ b/.kokoro/presubmit/graalvm-native.cfg
@@ -3,7 +3,7 @@
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
   key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm"
+  value: "gcr.io/cloud-devrel-kokoro-resources/graalvm:22.3.2"
 }
 
 env_vars: {


### PR DESCRIPTION
This PR upgrades the Kokoro to run on the latest GraalVM version. The presubmit jobs are currently running in 22.2.0:

Stacktrace from [example PR:](https://github.com/googleapis/google-auth-library-java/pull/1189)

```
[1/7] Initializing...                                                                                    (7.9s @ 0.14GB)
 Version info: 'GraalVM 22.2.0 Java 11 CE'
 Java version info: '11.0.16+8-jvmci-22.2-b06'
 C compiler: gcc (redhat, x86_64, 4.8.5)
 Garbage collector: Serial GC
 2 user-specific feature(s)
 - com.oracle.svm.thirdparty.gson.GsonFeature
 - org.graalvm.junit.platform.JUnitPlatformFeature
[junit-platform-native] Running in 'test listener' mode using files matching pattern [junit-platform-unique-ids*] found in folder [/tmpfs/src/github/google-auth-library-java/oauth2_http/target/test-ids] and its subfolders.
```