### PR TITLE
feat: Add custom parameters to token body during user cred refresh

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -71,6 +71,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
   private final String refreshToken;
   private final URI tokenServerUri;
   private final String transportFactoryClassName;
+  private final Map<String, String> additionalParameters;
 
   private transient HttpTransportFactory transportFactory;
 
@@ -91,6 +92,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     this.tokenServerUri =
         (builder.tokenServerUri == null) ? OAuth2Utils.TOKEN_SERVER_URI : builder.tokenServerUri;
     this.transportFactoryClassName = this.transportFactory.getClass().getName();
+    this.additionalParameters = builder.additionalParameters;
     Preconditions.checkState(
         builder.getAccessToken() != null || builder.refreshToken != null,
         "Either accessToken or refreshToken must not be null");
@@ -259,6 +261,13 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     tokenRequest.set("client_secret", clientSecret);
     tokenRequest.set("refresh_token", refreshToken);
     tokenRequest.set("grant_type", GRANT_TYPE);
+
+    if (additionalParameters != null) {
+      for (Map.Entry<String, String> entry : additionalParameters.entrySet()) {
+        tokenRequest.set(entry.getKey(), entry.getValue());
+      }
+    }
+
     UrlEncodedContent content = new UrlEncodedContent(tokenRequest);
 
     HttpRequestFactory requestFactory = transportFactory.create().createRequestFactory();
@@ -376,6 +385,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     private String refreshToken;
     private URI tokenServerUri;
     private HttpTransportFactory transportFactory;
+    private Map<String, String> additionalParameters;
 
     protected Builder() {}
 
@@ -386,6 +396,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
       this.refreshToken = credentials.refreshToken;
       this.transportFactory = credentials.transportFactory;
       this.tokenServerUri = credentials.tokenServerUri;
+      this.additionalParameters = credentials.additionalParameters;
     }
 
     public Builder setClientId(String clientId) {
@@ -410,6 +421,11 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
     public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
       this.transportFactory = transportFactory;
+      return this;
+    }
+
+    public Builder setAdditionalParameters(Map<String, String> additionalParameters) {
+      this.additionalParameters = additionalParameters;
       return this;
     }
 
@@ -451,6 +467,10 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
 
     public HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
+    }
+
+    public Map<String, String> getAdditionalParameters() {
+      return additionalParameters;
     }
 
     public UserCredentials build() {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -111,6 +111,12 @@ public class MockTokenServerTransport extends MockHttpTransport {
     this.grantedScopes.put(refreshToken, grantedScopes);
   }
 
+  public void addRefreshToken(
+      String refreshToken, String accessTokenToReturn, Map<String, String> additionalParameters) {
+    refreshTokens.put(refreshToken, accessTokenToReturn);
+    this.additionalParameters.put(refreshToken, additionalParameters);
+  }
+
   public void addServiceAccount(String email, String accessToken) {
     serviceAccounts.put(email, accessToken);
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -60,6 +60,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -804,6 +805,51 @@ public class UserCredentialsTest extends BaseSerializationTest {
         assertEquals(0, ex.getRetryCount());
       }
     }
+  }
+
+  @Test
+  public void refreshAccessToken() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+
+    transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
+    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN);
+
+    UserCredentials credentials =
+        UserCredentials.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setClientSecret(CLIENT_SECRET)
+            .setRefreshToken(REFRESH_TOKEN)
+            .setAccessToken(new AccessToken(ACCESS_TOKEN, new Date()))
+            .setHttpTransportFactory(transportFactory)
+            .build();
+    credentials.refresh();
+
+    assertEquals(ACCESS_TOKEN, credentials.getAccessToken().getTokenValue());
+  }
+
+  @Test
+  public void refreshAccessToken_AdditionalParameters() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+
+    Map<String, String> additionalParameters = new HashMap<String, String>();
+    additionalParameters.put("param1", "value1");
+    additionalParameters.put("param2", "value2");
+
+    transportFactory.transport.addClient(CLIENT_ID, CLIENT_SECRET);
+    transportFactory.transport.addRefreshToken(REFRESH_TOKEN, ACCESS_TOKEN, additionalParameters);
+
+    UserCredentials credentials =
+        UserCredentials.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setClientSecret(CLIENT_SECRET)
+            .setRefreshToken(REFRESH_TOKEN)
+            .setAccessToken(new AccessToken(ACCESS_TOKEN, new Date()))
+            .setHttpTransportFactory(transportFactory)
+            .setAdditionalParameters(additionalParameters)
+            .build();
+    credentials.refresh();
+
+    assertEquals(ACCESS_TOKEN, credentials.getAccessToken().getTokenValue());
   }
 
   @Test


### PR DESCRIPTION
Providing a way for passing additional parameters in token body of a token refresh request for user credentials.
