### PR TITLE
chore: Update library definitions in README to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you are using Maven, add this to your pom.xml file (notice that you can repla
 <dependency>
   <groupId>com.google.auth</groupId>
   <artifactId>google-auth-library-oauth2-http</artifactId>
-  <version>1.3.0</version>
+  <version>1.19.0</version>
 </dependency>
 ```
 [//]: # ({x-version-update-end})
@@ -67,7 +67,7 @@ If you are using Gradle, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Groovy
-implementation 'com.google.auth:google-auth-library-oauth2-http:1.3.0'
+implementation 'com.google.auth:google-auth-library-oauth2-http:1.19.0'
 ```
 [//]: # ({x-version-update-end})
 
@@ -75,7 +75,7 @@ If you are using SBT, add this to your dependencies
 
 [//]: # ({x-version-update-start:google-auth-library-oauth2-http:released})
 ```Scala
-libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "1.3.0"
+libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "1.19.0"
 ```
 [//]: # ({x-version-update-end})
 


### PR DESCRIPTION
I recently switched to this library for a project, and since I just copied the info from the readme I used an ancient version at first. That was especially annoying since many APIs that would've been helpful for me during migration didn't exist back in version 1.3.0 (like creating ServiceAccountCredentials from a PKCS8 string without having to pass JSON).

I'd love to prevent other users from making the same mistake as myself in the future through this README update.