### PR TITLE
build(deps): Bump autovalue version to 1.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <project.findbugs.version>3.0.2</project.findbugs.version>
     <deploy.autorelease>false</deploy.autorelease>
     <project.autovalue.version>1.8.2</project.autovalue.version>
-    <auto-value-annotation.version>1.10.1</auto-value-annotation.version>
+    <auto-value-annotation.version>1.10.2</auto-value-annotation.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

As part of the release cycle, `shared-configs`'s autovalue-annoatation's version has been bumped to 1.10.2. We are seeing this issue with the enforcer plugin which *should* be resolved by bumping this to 1.10.2
