### PR TITLE
chore: setup 1.17.x lts branch

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -22,3 +22,7 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 1.6.x
+  - bumpMinorPreMajor: true
+    handleGHRelease: true
+    releaseType: java-backport
+    branch: 1.17.x

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -81,6 +81,19 @@ branchProtectionRules:
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: true
+  - pattern: 1.17.x
+    isAdminEnforced: true
+    requiredStatusCheckContexts:
+      - dependencies (8)
+      - dependencies (11)
+      - lint
+      - clirr
+      - units (8)
+      - units (11)
+      - cla/google
+    requiredApprovingReviewCount: 1
+    requiresCodeOwnerReviews: true
+    requiresStrictStatusChecks: true
 permissionRules:
   - team: Googlers
     permission: pull


### PR DESCRIPTION
enable releases

```
release-brancher create-pull-request \
  --branch-name="1.17.x" \
  --target-tag="v1.17.1" \
  --repo="googleapis/google-auth-library-java" \
  --pull-request-title="chore: setup 1.17.x lts branch" \
  --release-type=java-backport
```