### PR TITLE
chore: add java-shared-config as parent for consolidated version management

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,12 +72,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-2 test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-2 test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,12 +72,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-2 test -pl 'oauth2_http'
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative-2 test -pl 'oauth2_http'
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,12 +72,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,12 +72,12 @@ integration)
     ;;
 graalvm)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test
     RETURN_CODE=$?
     ;;
 graalvm17)
     # Run Unit and Integration Tests with Native Image
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative test
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test
     RETURN_CODE=$?
     ;;
 samples)

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -23,7 +23,21 @@
 
   <profiles>
     <profile>
-      <id>native-test</id>
+      <id>native-2</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.junit.vintage</groupId>
+          <artifactId>junit-vintage-engine</artifactId>
+          <version>5.9.3</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.graalvm.buildtools</groupId>
+          <artifactId>junit-platform-native</artifactId>
+          <version>0.9.28</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
        <plugins>
          <plugin>
@@ -38,6 +52,27 @@
           </includes>
           </configuration>
           </plugin>
+         <plugin>
+           <groupId>org.graalvm.buildtools</groupId>
+           <artifactId>native-maven-plugin</artifactId>
+           <version>0.9.28</version>
+           <extensions>true</extensions>
+           <executions>
+             <execution>
+               <id>test-native</id>
+               <goals>
+                 <goal>test</goal>
+               </goals>
+               <phase>test</phase>
+             </execution>
+           </executions>
+           <configuration>
+             <buildArgs>
+               <buildArg>--no-fallback</buildArg>
+               <buildArg>--no-server</buildArg>
+             </buildArgs>
+           </configuration>
+         </plugin>
       </plugins>
       </build>
     </profile>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -23,60 +23,22 @@
 
   <profiles>
     <profile>
-      <!-- This profile is used to enable GraalVM native image testing -->
-      <id>native</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-          <version>5.10.0</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.graalvm.buildtools</groupId>
-          <artifactId>junit-platform-native</artifactId>
-          <version>0.9.28</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <id>native-test</id>
       <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <!-- Must use older version of surefire plugin for native-image testing. -->
-            <version>2.22.2</version>
-            <configuration>
-              <!-- Include all tests during native image testing. -->
-              <excludes combine.self="override"/>
-              <includes>
-                <include>**/IT*.java</include>
-                <include>**/functional/*.java</include>
-              </includes>
-            </configuration>
+       <plugins>
+         <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-surefire-plugin</artifactId>
+         <configuration>
+         <!-- Include all tests during native image testing. -->
+          <excludes combine.self="override"/>
+          <includes>
+            <include>**/IT*.java</include>
+            <include>**/functional/*.java</include>
+          </includes>
+          </configuration>
           </plugin>
-          <plugin>
-            <groupId>org.graalvm.buildtools</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-            <version>0.9.28</version>
-            <extensions>true</extensions>
-            <executions>
-              <execution>
-                <id>test-native</id>
-                <goals>
-                  <goal>test</goal>
-                </goals>
-                <phase>test</phase>
-              </execution>
-            </executions>
-            <configuration>
-              <buildArgs>
-                <buildArg>--no-fallback</buildArg>
-                <buildArg>--no-server</buildArg>
-              </buildArgs>
-            </configuration>
-          </plugin>
-        </plugins>
+      </plugins>
       </build>
     </profile>
   </profiles>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -23,6 +23,36 @@
 
   <profiles>
     <profile>
+      <id>junit47</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${surefire.version}</version>
+            <configuration>
+              <!-- Excludes integration tests when unit tests are run. -->
+              <excludes>
+                <exclude>**/IT*.java</exclude>
+                <exclude>**/functional/*.java</exclude>
+              </excludes>
+              <reportNameSuffix>sponge_log</reportNameSuffix>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>surefire-junit47</artifactId>
+                <version>${surefire.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>native-test</id>
       <build>
         <plugins>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -33,7 +33,7 @@
             <configuration>
               <excludes combine.self="override"></excludes>
               <includes>
-<!--                <include>**/IT*.java</include>-->
+                <include>**/IT*.java</include>
                 <include>**/functional/*.java</include>
             </includes>
             </configuration>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -29,7 +29,7 @@
           <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>${surefire.version}</version>
             <configuration>
               <excludes combine.self="override"></excludes>
               <includes>
@@ -135,7 +135,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
+        <version>${surefire.version}</version>
         <configuration>
           <!-- Excludes integration tests when unit tests are run. -->
           <excludes>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -23,57 +23,22 @@
 
   <profiles>
     <profile>
-      <id>native-2</id>
-      <dependencies>
-        <dependency>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-          <version>5.9.3</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.graalvm.buildtools</groupId>
-          <artifactId>junit-platform-native</artifactId>
-          <version>0.9.28</version>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
+      <id>native-test</id>
       <build>
-       <plugins>
-         <plugin>
-         <groupId>org.apache.maven.plugins</groupId>
-         <artifactId>maven-surefire-plugin</artifactId>
-         <configuration>
-         <!-- Include all tests during native image testing. -->
-          <excludes combine.self="override"/>
-          <includes>
-            <include>**/IT*.java</include>
-            <include>**/functional/*.java</include>
-          </includes>
-          </configuration>
+        <plugins>
+          <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>3.0.0-M5</version>
+            <configuration>
+              <excludes combine.self="override"></excludes>
+              <includes>
+                <include>**/IT*.java</include>
+                <include>**/functional/*.java</include>
+            </includes>
+            </configuration>
           </plugin>
-         <plugin>
-           <groupId>org.graalvm.buildtools</groupId>
-           <artifactId>native-maven-plugin</artifactId>
-           <version>0.9.28</version>
-           <extensions>true</extensions>
-           <executions>
-             <execution>
-               <id>test-native</id>
-               <goals>
-                 <goal>test</goal>
-               </goals>
-               <phase>test</phase>
-             </execution>
-           </executions>
-           <configuration>
-             <buildArgs>
-               <buildArg>--no-fallback</buildArg>
-               <buildArg>--no-server</buildArg>
-             </buildArgs>
-           </configuration>
-         </plugin>
-      </plugins>
+        </plugins>
       </build>
     </profile>
   </profiles>
@@ -179,13 +144,6 @@
           </excludes>
           <reportNameSuffix>sponge_log</reportNameSuffix>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.apache.maven.surefire</groupId>
-            <artifactId>surefire-junit47</artifactId>
-            <version>3.0.0-M5</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -33,7 +33,7 @@
             <configuration>
               <excludes combine.self="override"></excludes>
               <includes>
-                <include>**/IT*.java</include>
+<!--                <include>**/IT*.java</include>-->
                 <include>**/functional/*.java</include>
             </includes>
             </configuration>

--- a/owlbot.py
+++ b/owlbot.py
@@ -36,6 +36,7 @@ java.common_templates(
         ".kokoro/nightly/integration.cfg",
         ".kokoro/presubmit/integration.cfg",
         ".kokoro/presubmit/graalvm-native.cfg",
-        ".kokoro/presubmit/graalvm-native-17.cfg"
+        ".kokoro/presubmit/graalvm-native-17.cfg",
+        ".kokoro/build.sh"
     ]
 )

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-shared-config</artifactId>
     <version>1.6.1</version>
-    <relativePath/>
   </parent>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -117,10 +117,6 @@
         <version>${project.findbugs.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.auto.value</groupId>
-        <artifactId>auto-value-annotations</artifactId>
-      </dependency>
-      <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${project.junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,13 @@
   </description>
   <url>https://github.com/googleapis/google-auth-library-java</url>
 
+  <parent>
+    <groupId>com.google.cloud</groupId>
+    <artifactId>google-cloud-shared-config</artifactId>
+    <version>1.6.1</version>
+    <relativePath/>
+  </parent>
+
   <distributionManagement>
     <snapshotRepository>
       <id>sonatype-nexus-snapshots</id>

--- a/pom.xml
+++ b/pom.xml
@@ -216,14 +216,6 @@
           <version>3.6.1</version>
         </plugin>
         <plugin>
-          <groupId>com.coveo</groupId>
-          <artifactId>fmt-maven-plugin</artifactId>
-          <version>2.13</version>
-          <configuration>
-            <verbose>true</verbose>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
           <version>2.8</version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
       <dependency>
         <groupId>com.google.auto.value</groupId>
         <artifactId>auto-value-annotations</artifactId>
-        <version>${auto-value-annotation.version}</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,6 @@
     <project.appengine.version>2.0.21</project.appengine.version>
     <project.findbugs.version>3.0.2</project.findbugs.version>
     <deploy.autorelease>false</deploy.autorelease>
-    <project.autovalue.version>1.8.2</project.autovalue.version>
-    <auto-value-annotation.version>1.10.4</auto-value-annotation.version>
   </properties>
 
   <dependencyManagement>
@@ -424,49 +422,6 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>autovalue-java8</id>
-      <activation>
-        <jdk>[1.8,)</jdk>
-        <file>
-          <exists>${basedir}/EnableAutoValue.txt</exists>
-        </file>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <annotationProcessorPaths>
-                <path>
-                  <groupId>com.google.auto.value</groupId>
-                  <artifactId>auto-value</artifactId>
-                  <version>${auto-value-annotation.version}</version>
-                </path>
-                <!--
-                Manually pull in auto-service-annotations so that it is part of the
-                processor path because auto-value has it set to provided scope.
-                This dependency is needed due to the retention change in
-                https://github.com/google/auto/commit/628df548685b4fc0f2a9af856f97cc2a68da246b
-                where the RetentionPolicy changed from SOURCE to CLASS.
-                Due to the RetentionPolicy change to CLASS we must have the
-                annotations available on the processor path otherwise the following
-                error will be thrown. (This is a particular problem with the
-                annotation processor configuration in IntelliJ)
-                Error:java: java.lang.NoClassDefFoundError: com/google/auto/service/AutoService
-                  com.google.auto.service.AutoService
-                -->
-                <path>
-                  <groupId>com.google.auto.service</groupId>
-                  <artifactId>auto-service-annotations</artifactId>
-                  <version>1.1.1</version>
-                </path>
-              </annotationProcessorPaths>
-            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Notable Changes:
- Removed surefire-junit47 provider which was conflicting with the native-maven-plugin's testing support. See https://github.com/googleapis/google-auth-library-java/pull/1329#discussion_r1388205323 for details. 
- Removed `fmt-maven-plugin ` to rely on the one defined in java-shared-config.
- Removed native profile to rely on the one defined in java-shared-config
- Removed `autovalue-java8` profile and the autovalue dependency declaration to use the one defined in java-shared-config. 
- Added `native-test` profile to explicitly include ITs and functional tests for native image compilation. 

