### PR TITLE
fix: handle error-prone warnings

### DIFF
--- a/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
+++ b/appengine/java/com/google/auth/appengine/AppEngineCredentials.java
@@ -139,6 +139,7 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
     return new Builder();
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -175,6 +176,7 @@ public class AppEngineCredentials extends GoogleCredentials implements ServiceAc
       return appIdentityService;
     }
 
+    @Override
     public AppEngineCredentials build() {
       return new AppEngineCredentials(scopes, appIdentityService);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/CloudShellCredentials.java
@@ -115,6 +115,7 @@ public class CloudShellCredentials extends GoogleCredentials {
     return this.authPort == other.authPort;
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -142,6 +143,7 @@ public class CloudShellCredentials extends GoogleCredentials {
       return authPort;
     }
 
+    @Override
     public CloudShellCredentials build() {
       return new CloudShellCredentials(authPort);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -457,6 +457,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
     transportFactory = newInstance(transportFactoryClassName);
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -570,6 +571,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
       return scopes;
     }
 
+    @Override
     public ComputeEngineCredentials build() {
       return new ComputeEngineCredentials(transportFactory, scopes, null);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java
@@ -185,6 +185,7 @@ public final class DownscopedCredentials extends OAuth2Credentials {
       return this;
     }
 
+    @Override
     public DownscopedCredentials build() {
       return new DownscopedCredentials(
           sourceCredential, credentialAccessBoundary, transportFactory);

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountAuthorizedUserCredentials.java
@@ -292,6 +292,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
         && Objects.equals(this.quotaProjectId, credentials.quotaProjectId);
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -499,6 +500,7 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @param quotaProjectId the quota and billing project id to set
      * @return this {@code Builder} object
      */
+    @Override
     @CanIgnoreReturnValue
     public Builder setQuotaProjectId(String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
@@ -511,12 +513,14 @@ public class ExternalAccountAuthorizedUserCredentials extends GoogleCredentials 
      * @param accessToken the access token
      * @return this {@code Builder} object
      */
+    @Override
     @CanIgnoreReturnValue
     public Builder setAccessToken(AccessToken accessToken) {
       super.setAccessToken(accessToken);
       return this;
     }
 
+    @Override
     public ExternalAccountAuthorizedUserCredentials build() {
       return new ExternalAccountAuthorizedUserCredentials(this);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -853,6 +853,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      * @param quotaProjectId the quota and billing project id to set
      * @return this {@code Builder} object
      */
+    @Override
     @CanIgnoreReturnValue
     public Builder setQuotaProjectId(String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
@@ -945,6 +946,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
       return this;
     }
 
+    @Override
     public abstract ExternalAccountCredentials build();
   }
 }

--- a/oauth2_http/java/com/google/auth/oauth2/GdchCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GdchCredentials.java
@@ -311,6 +311,7 @@ public class GdchCredentials extends GoogleCredentials {
     return new Builder();
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -475,6 +476,7 @@ public class GdchCredentials extends GoogleCredentials {
       return lifetime;
     }
 
+    @Override
     public GdchCredentials build() {
       return new GdchCredentials(this);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -270,6 +270,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     return new Builder();
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -356,6 +357,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
       this.quotaProjectId = credentials.quotaProjectId;
     }
 
+    @Override
     public GoogleCredentials build() {
       return new GoogleCredentials(this);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdTokenCredentials.java
@@ -149,6 +149,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
         && Objects.equals(this.targetAudience, other.targetAudience);
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder()
         .setIdTokenProvider(this.idTokenProvider)
@@ -198,6 +199,7 @@ public class IdTokenCredentials extends OAuth2Credentials {
       return this.options;
     }
 
+    @Override
     public IdTokenCredentials build() {
       return new IdTokenCredentials(this);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -183,6 +183,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
       super(credentials);
     }
 
+    @Override
     @CanIgnoreReturnValue
     public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
       super.setWorkforcePoolUserProject(workforcePoolUserProject);

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -600,6 +600,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
         && Objects.equals(this.iamEndpointOverride, other.iamEndpointOverride);
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this.sourceCredentials, this.targetPrincipal);
   }
@@ -686,6 +687,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
       return transportFactory;
     }
 
+    @Override
     @CanIgnoreReturnValue
     public Builder setQuotaProjectId(String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
@@ -708,6 +710,7 @@ public class ImpersonatedCredentials extends GoogleCredentials
       return this.calendar;
     }
 
+    @Override
     public ImpersonatedCredentials build() {
       return new ImpersonatedCredentials(this);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -630,6 +630,7 @@ public class OAuth2Credentials extends Credentials {
       return this.task;
     }
 
+    @Override
     public void run() {
       task.run();
     }

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java
@@ -113,6 +113,7 @@ public class OAuth2CredentialsWithRefresh extends OAuth2Credentials {
       return this;
     }
 
+    @Override
     public OAuth2CredentialsWithRefresh build() {
       return new OAuth2CredentialsWithRefresh(this);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -99,6 +99,7 @@ class OAuth2Utils {
 
   static class DefaultHttpTransportFactory implements HttpTransportFactory {
 
+    @Override
     public HttpTransport create() {
       return HTTP_TRANSPORT;
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -967,6 +967,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return new Builder();
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -1074,6 +1075,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return this;
     }
 
+    @Override
     @CanIgnoreReturnValue
     public Builder setQuotaProjectId(String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
@@ -1150,6 +1152,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return defaultRetriesEnabled;
     }
 
+    @Override
     public ServiceAccountCredentials build() {
       return new ServiceAccountCredentials(this);
     }

--- a/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserCredentials.java
@@ -366,6 +366,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
     return new Builder();
   }
 
+  @Override
   public Builder toBuilder() {
     return new Builder(this);
   }
@@ -419,24 +420,28 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
       return this;
     }
 
+    @Override
     @CanIgnoreReturnValue
     public Builder setAccessToken(AccessToken token) {
       super.setAccessToken(token);
       return this;
     }
 
+    @Override
     @CanIgnoreReturnValue
     public Builder setExpirationMargin(Duration expirationMargin) {
       super.setExpirationMargin(expirationMargin);
       return this;
     }
 
+    @Override
     @CanIgnoreReturnValue
     public Builder setRefreshMargin(Duration refreshMargin) {
       super.setRefreshMargin(refreshMargin);
       return this;
     }
 
+    @Override
     @CanIgnoreReturnValue
     public Builder setQuotaProjectId(String quotaProjectId) {
       super.setQuotaProjectId(quotaProjectId);
@@ -463,6 +468,7 @@ public class UserCredentials extends GoogleCredentials implements IdTokenProvide
       return transportFactory;
     }
 
+    @Override
     public UserCredentials build() {
       return new UserCredentials(this);
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -616,6 +616,7 @@ public class DefaultCredentialsProviderTest {
   private class LogHandler extends Handler {
     LogRecord lastRecord;
 
+    @Override
     public void publish(LogRecord record) {
       lastRecord = record;
     }
@@ -624,8 +625,10 @@ public class DefaultCredentialsProviderTest {
       return lastRecord;
     }
 
+    @Override
     public void close() {}
 
+    @Override
     public void flush() {}
   }
 

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -169,6 +169,14 @@
             <include>**/functional/*.java</include>
           </includes>
         </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -189,18 +197,6 @@
             <version>3.0.0-M5</version>
           </dependency>
         </dependencies>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -244,12 +240,6 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
[ErrorProne](https://errorprone.info/) flags several issues in the codebase, this pull request fixes some of them:

- Missing `@Override` annotations where needed
- Using of deprecated or incompatibel APIs for Base64 encoding

There's also a warning by maven due to conflicting / duplicate dependencies in pom.xml, this is also fixed.