### PR TITLE
feat: Quality of life improvements for building external account credentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -40,6 +40,7 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonParser;
+import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -352,6 +353,86 @@ public class AwsCredentials extends ExternalAccountCredentials {
 
     Builder(AwsCredentials credentials) {
       super(credentials);
+    }
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      super.setHttpTransportFactory(transportFactory);
+      return this;
+    }
+
+    public Builder setAudience(String audience) {
+      super.setAudience(audience);
+      return this;
+    }
+
+    public Builder setSubjectTokenType(String subjectTokenType) {
+      super.setSubjectTokenType(subjectTokenType);
+      return this;
+    }
+
+    public Builder setSubjectTokenType(SubjectTokenTypes subjectTokenType) {
+      super.setSubjectTokenType(subjectTokenType);
+      return this;
+    }
+
+    public Builder setTokenUrl(String tokenUrl) {
+      super.setTokenUrl(tokenUrl);
+      return this;
+    }
+
+    public Builder setCredentialSource(AwsCredentialSource credentialSource) {
+      super.setCredentialSource(credentialSource);
+      return this;
+    }
+
+    public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
+      super.setServiceAccountImpersonationUrl(serviceAccountImpersonationUrl);
+      return this;
+    }
+
+    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+      super.setTokenInfoUrl(tokenInfoUrl);
+      return this;
+    }
+
+    public Builder setQuotaProjectId(String quotaProjectId) {
+      super.setQuotaProjectId(quotaProjectId);
+      return this;
+    }
+
+    public Builder setClientId(String clientId) {
+      super.setClientId(clientId);
+      return this;
+    }
+
+    public Builder setClientSecret(String clientSecret) {
+      super.setClientSecret(clientSecret);
+      return this;
+    }
+
+    public Builder setScopes(Collection<String> scopes) {
+      super.setScopes(scopes);
+      return this;
+    }
+
+    public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
+      super.setWorkforcePoolUserProject(workforcePoolUserProject);
+      return this;
+    }
+
+    public Builder setServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
+      super.setServiceAccountImpersonationOptions(optionsMap);
+      return this;
+    }
+
+    public Builder setUniverseDomain(String universeDomain) {
+      super.setUniverseDomain(universeDomain);
+      return this;
+    }
+
+    Builder setEnvironmentProvider(EnvironmentProvider environmentProvider) {
+      super.setEnvironmentProvider(environmentProvider);
+      return this;
     }
 
     @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -70,7 +70,8 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
   public enum SubjectTokenTypes {
     AWS4("urn:ietf:params:aws:token-type:aws4_request"),
     JWT("urn:ietf:params:oauth:token-type:jwt"),
-    SAML2("urn:ietf:params:oauth:token-type:saml2");
+    SAML2("urn:ietf:params:oauth:token-type:saml2"),
+    ID_TOKEN("urn:ietf:params:oauth:token-type:id_token");
 
     public final String value;
 

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -66,7 +66,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
   /**
    * Enum to specify values for the subjectTokenType field in {@code ExternalAccountCredentials}.
    */
-  public enum SubjectTokenTypes{
+  public enum SubjectTokenTypes {
     AWS4("urn:ietf:params:aws:token-type:aws4_request"),
     JWT("urn:ietf:params:oauth:token-type:jwt"),
     SAML2("urn:ietf:params:oauth:token-type:saml2");

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -63,6 +63,21 @@ import javax.annotation.Nullable;
  */
 public abstract class ExternalAccountCredentials extends GoogleCredentials {
 
+  /**
+   * Enum to specify values for the subjectTokenType field in {@code ExternalAccountCredentials}.
+   */
+  public enum SubjectTokenTypes{
+    AWS4("urn:ietf:params:aws:token-type:aws4_request"),
+    JWT("urn:ietf:params:oauth:token-type:jwt"),
+    SAML2("urn:ietf:params:oauth:token-type:saml2");
+
+    public final String value;
+
+    private SubjectTokenTypes(String value) {
+      this.value = value;
+    }
+  }
+
   private static final long serialVersionUID = 8049126194174465023L;
 
   /** Base credential source class. Dictates the retrieval method of the external credential. */
@@ -788,6 +803,18 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
      */
     public Builder setSubjectTokenType(String subjectTokenType) {
       this.subjectTokenType = subjectTokenType;
+      return this;
+    }
+
+    /**
+     * Sets the Security Token Service subject token type based on the OAuth 2.0 token exchange
+     * spec. Indicates the type of the security token in the credential file.
+     *
+     * @param subjectTokenType the {@code SubjectTokenType} to set
+     * @return this {@code Builder} object
+     */
+    public Builder setSubjectTokenType(SubjectTokenTypes subjectTokenType) {
+      this.subjectTokenType = subjectTokenType.value;
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -184,7 +184,6 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
       super(credentials);
     }
 
-
     public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
       super.setHttpTransportFactory(transportFactory);
       return this;
@@ -250,8 +249,7 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
       return this;
     }
 
-    public Builder setServiceAccountImpersonationOptions(
-        Map<String, Object> optionsMap) {
+    public Builder setServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
       super.setServiceAccountImpersonationOptions(optionsMap);
       return this;
     }

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -37,6 +37,7 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonObjectParser;
+import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.IdentityPoolCredentialSource.CredentialFormatType;
 import com.google.auth.oauth2.IdentityPoolCredentialSource.IdentityPoolCredentialSourceType;
 import com.google.common.io.CharStreams;
@@ -52,6 +53,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * Url-sourced and file-sourced external account credentials.
@@ -182,8 +184,85 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
       super(credentials);
     }
 
+
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      super.setHttpTransportFactory(transportFactory);
+      return this;
+    }
+
+    public Builder setAudience(String audience) {
+      super.setAudience(audience);
+      return this;
+    }
+
+    public Builder setSubjectTokenType(String subjectTokenType) {
+      super.setSubjectTokenType(subjectTokenType);
+      return this;
+    }
+
+    public Builder setSubjectTokenType(SubjectTokenTypes subjectTokenType) {
+      super.setSubjectTokenType(subjectTokenType);
+      return this;
+    }
+
+    public Builder setTokenUrl(String tokenUrl) {
+      super.setTokenUrl(tokenUrl);
+      return this;
+    }
+
+    public Builder setCredentialSource(IdentityPoolCredentialSource credentialSource) {
+      super.setCredentialSource(credentialSource);
+      return this;
+    }
+
+    public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
+      super.setServiceAccountImpersonationUrl(serviceAccountImpersonationUrl);
+      return this;
+    }
+
+    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+      super.setTokenInfoUrl(tokenInfoUrl);
+      return this;
+    }
+
+    public Builder setQuotaProjectId(String quotaProjectId) {
+      super.setQuotaProjectId(quotaProjectId);
+      return this;
+    }
+
+    public Builder setClientId(String clientId) {
+      super.setClientId(clientId);
+      return this;
+    }
+
+    public Builder setClientSecret(String clientSecret) {
+      super.setClientSecret(clientSecret);
+      return this;
+    }
+
+    public Builder setScopes(Collection<String> scopes) {
+      super.setScopes(scopes);
+      return this;
+    }
+
     public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
       super.setWorkforcePoolUserProject(workforcePoolUserProject);
+      return this;
+    }
+
+    public Builder setServiceAccountImpersonationOptions(
+        Map<String, Object> optionsMap) {
+      super.setServiceAccountImpersonationOptions(optionsMap);
+      return this;
+    }
+
+    public Builder setUniverseDomain(String universeDomain) {
+      super.setUniverseDomain(universeDomain);
+      return this;
+    }
+
+    Builder setEnvironmentProvider(EnvironmentProvider environmentProvider) {
+      super.setEnvironmentProvider(environmentProvider);
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
@@ -304,6 +304,7 @@ public class PluggableAuthCredentials extends ExternalAccountCredentials {
       super.setEnvironmentProvider(environmentProvider);
       return this;
     }
+
     @Override
     public PluggableAuthCredentials build() {
       return new PluggableAuthCredentials(this);

--- a/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
@@ -31,6 +31,7 @@
 
 package com.google.auth.oauth2;
 
+import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.ExecutableHandler.ExecutableOptions;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -224,6 +225,85 @@ public class PluggableAuthCredentials extends ExternalAccountCredentials {
       return this;
     }
 
+    public Builder setHttpTransportFactory(HttpTransportFactory transportFactory) {
+      super.setHttpTransportFactory(transportFactory);
+      return this;
+    }
+
+    public Builder setAudience(String audience) {
+      super.setAudience(audience);
+      return this;
+    }
+
+    public Builder setSubjectTokenType(String subjectTokenType) {
+      super.setSubjectTokenType(subjectTokenType);
+      return this;
+    }
+
+    public Builder setSubjectTokenType(SubjectTokenTypes subjectTokenType) {
+      super.setSubjectTokenType(subjectTokenType);
+      return this;
+    }
+
+    public Builder setTokenUrl(String tokenUrl) {
+      super.setTokenUrl(tokenUrl);
+      return this;
+    }
+
+    public Builder setCredentialSource(PluggableAuthCredentialSource credentialSource) {
+      super.setCredentialSource(credentialSource);
+      return this;
+    }
+
+    public Builder setServiceAccountImpersonationUrl(String serviceAccountImpersonationUrl) {
+      super.setServiceAccountImpersonationUrl(serviceAccountImpersonationUrl);
+      return this;
+    }
+
+    public Builder setTokenInfoUrl(String tokenInfoUrl) {
+      super.setTokenInfoUrl(tokenInfoUrl);
+      return this;
+    }
+
+    public Builder setQuotaProjectId(String quotaProjectId) {
+      super.setQuotaProjectId(quotaProjectId);
+      return this;
+    }
+
+    public Builder setClientId(String clientId) {
+      super.setClientId(clientId);
+      return this;
+    }
+
+    public Builder setClientSecret(String clientSecret) {
+      super.setClientSecret(clientSecret);
+      return this;
+    }
+
+    public Builder setScopes(Collection<String> scopes) {
+      super.setScopes(scopes);
+      return this;
+    }
+
+    public Builder setWorkforcePoolUserProject(String workforcePoolUserProject) {
+      super.setWorkforcePoolUserProject(workforcePoolUserProject);
+      return this;
+    }
+
+    public Builder setServiceAccountImpersonationOptions(Map<String, Object> optionsMap) {
+      super.setServiceAccountImpersonationOptions(optionsMap);
+      return this;
+    }
+
+    public Builder setUniverseDomain(String universeDomain) {
+      super.setUniverseDomain(universeDomain);
+      return this;
+    }
+
+    Builder setEnvironmentProvider(EnvironmentProvider environmentProvider) {
+      super.setEnvironmentProvider(environmentProvider);
+      return this;
+    }
     @Override
     public PluggableAuthCredentials build() {
       return new PluggableAuthCredentials(this);

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -92,7 +92,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
       new AwsCredentialSource(AWS_CREDENTIAL_SOURCE_MAP);
 
   private static final AwsCredentials AWS_CREDENTIAL =
-      (AwsCredentials)
           AwsCredentials.newBuilder()
               .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
               .setAudience("audience")
@@ -120,7 +119,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setTokenUrl(transportFactory.transport.getStsUrl())
                 .setHttpTransportFactory(transportFactory)
@@ -145,7 +143,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder()
                 .setHttpTransportFactory(transportFactory)
                 .setAudience("audience")
@@ -176,7 +173,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder()
                 .setHttpTransportFactory(transportFactory)
                 .setAudience("audience")
@@ -215,7 +211,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -259,7 +254,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -331,7 +325,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SESSION_TOKEN", "awsToken");
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -378,7 +371,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SESSION_TOKEN", "awsToken");
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -419,7 +411,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseErrorSequence(response);
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -449,7 +440,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseSequence(true, false);
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -482,7 +472,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseSequence(true, true, false);
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -518,7 +507,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     credentialSource.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(new AwsCredentialSource(credentialSource))
@@ -547,7 +535,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
 
     AwsCredentials testAwsCredentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setEnvironmentProvider(environmentProvider)
                 .build();
@@ -580,7 +567,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
             });
 
     AwsCredentials testAwsCredentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setEnvironmentProvider(environmentProvider)
                 .setCredentialSource(credSource)
@@ -604,7 +590,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SESSION_TOKEN", "awsSessionToken");
 
     AwsCredentials testAwsCredentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setEnvironmentProvider(environmentProvider)
                 .build();
@@ -623,7 +608,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -656,7 +640,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     credentialSource.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
 
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(new AwsCredentialSource(credentialSource))
@@ -685,7 +668,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -711,7 +693,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -734,7 +715,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsCredentialSource(transportFactory))
@@ -760,7 +740,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_clonedCredentialWithAddedScopes() {
     AwsCredentials credentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
                 .setQuotaProjectId("quotaProjectId")
@@ -848,7 +827,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
           .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
           .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
       AwsCredentials awsCredential =
-          (AwsCredentials)
               AwsCredentials.newBuilder(AWS_CREDENTIAL)
                   .setHttpTransportFactory(transportFactory)
                   .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -868,7 +846,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
         .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -891,7 +868,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
           .setEnv(regionKey, "awsRegion")
           .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
       AwsCredentials awsCredential =
-          (AwsCredentials)
               AwsCredentials.newBuilder(AWS_CREDENTIAL)
                   .setHttpTransportFactory(transportFactory)
                   .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -915,7 +891,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
           .setEnv(regionKey, "awsRegion")
           .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId");
       AwsCredentials awsCredential =
-          (AwsCredentials)
               AwsCredentials.newBuilder(AWS_CREDENTIAL)
                   .setHttpTransportFactory(transportFactory)
                   .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -938,7 +913,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
       // Not set here.
       environmentProvider.setEnv(regionKey, "awsRegion");
       AwsCredentials awsCredential =
-          (AwsCredentials)
               AwsCredentials.newBuilder(AWS_CREDENTIAL)
                   .setHttpTransportFactory(transportFactory)
                   .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -953,7 +927,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredential =
-        (AwsCredentials)
             AwsCredentials.newBuilder(AWS_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
@@ -966,7 +939,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
     AwsCredentials credentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder()
                 .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
                 .setAudience("audience")
@@ -1001,7 +973,6 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
     AwsCredentials testCredentials =
-        (AwsCredentials)
             AwsCredentials.newBuilder()
                 .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
                 .setAudience("audience")

--- a/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/AwsCredentialsTest.java
@@ -92,14 +92,14 @@ public class AwsCredentialsTest extends BaseSerializationTest {
       new AwsCredentialSource(AWS_CREDENTIAL_SOURCE_MAP);
 
   private static final AwsCredentials AWS_CREDENTIAL =
-          AwsCredentials.newBuilder()
-              .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-              .setAudience("audience")
-              .setSubjectTokenType("subjectTokenType")
-              .setTokenUrl(STS_URL)
-              .setTokenInfoUrl("tokenInfoUrl")
-              .setCredentialSource(AWS_CREDENTIAL_SOURCE)
-              .build();
+      AwsCredentials.newBuilder()
+          .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+          .setAudience("audience")
+          .setSubjectTokenType("subjectTokenType")
+          .setTokenUrl(STS_URL)
+          .setTokenInfoUrl("tokenInfoUrl")
+          .setCredentialSource(AWS_CREDENTIAL_SOURCE)
+          .build();
 
   @Test
   public void test_awsCredentialSource() {
@@ -119,11 +119,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -143,16 +143,16 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder()
-                .setHttpTransportFactory(transportFactory)
-                .setAudience("audience")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .build();
+        AwsCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setAudience("audience")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -173,18 +173,18 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder()
-                .setHttpTransportFactory(transportFactory)
-                .setAudience("audience")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .setServiceAccountImpersonationOptions(
-                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
-                .build();
+        AwsCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setAudience("audience")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .setServiceAccountImpersonationOptions(
+                ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
+            .build();
 
     AccessToken accessToken = awsCredential.refreshAccessToken();
 
@@ -211,10 +211,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .build();
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -254,10 +254,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+            .build();
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -325,11 +325,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SESSION_TOKEN", "awsToken");
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .setEnvironmentProvider(environmentProvider)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .setEnvironmentProvider(environmentProvider)
+            .build();
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -371,11 +371,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SESSION_TOKEN", "awsToken");
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                .setEnvironmentProvider(environmentProvider)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+            .setEnvironmentProvider(environmentProvider)
+            .build();
 
     String subjectToken = URLDecoder.decode(awsCredential.retrieveSubjectToken(), "UTF-8");
 
@@ -411,10 +411,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseErrorSequence(response);
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .build();
 
     try {
       awsCredential.retrieveSubjectToken();
@@ -440,10 +440,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseSequence(true, false);
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .build();
 
     try {
       awsCredential.retrieveSubjectToken();
@@ -472,10 +472,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseSequence(true, true, false);
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .build();
 
     try {
       awsCredential.retrieveSubjectToken();
@@ -507,10 +507,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     credentialSource.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(new AwsCredentialSource(credentialSource))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(new AwsCredentialSource(credentialSource))
+            .build();
 
     try {
       awsCredential.retrieveSubjectToken();
@@ -535,9 +535,9 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
 
     AwsCredentials testAwsCredentials =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setEnvironmentProvider(environmentProvider)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setEnvironmentProvider(environmentProvider)
+            .build();
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);
@@ -567,10 +567,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
             });
 
     AwsCredentials testAwsCredentials =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setEnvironmentProvider(environmentProvider)
-                .setCredentialSource(credSource)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setEnvironmentProvider(environmentProvider)
+            .setCredentialSource(credSource)
+            .build();
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);
@@ -590,9 +590,9 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_SESSION_TOKEN", "awsSessionToken");
 
     AwsCredentials testAwsCredentials =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setEnvironmentProvider(environmentProvider)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setEnvironmentProvider(environmentProvider)
+            .build();
 
     AwsSecurityCredentials credentials =
         testAwsCredentials.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);
@@ -608,10 +608,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .build();
 
     AwsSecurityCredentials credentials =
         awsCredential.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);
@@ -640,10 +640,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     credentialSource.put("regional_cred_verification_url", GET_CALLER_IDENTITY_URL);
 
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(new AwsCredentialSource(credentialSource))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(new AwsCredentialSource(credentialSource))
+            .build();
 
     try {
       awsCredential.getAwsSecurityCredentials(EMPTY_METADATA_HEADERS);
@@ -668,11 +668,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredentials =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .setEnvironmentProvider(environmentProvider)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .setEnvironmentProvider(environmentProvider)
+            .build();
 
     String region = awsCredentials.getAwsRegion(EMPTY_METADATA_HEADERS);
 
@@ -693,11 +693,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredentials =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .setEnvironmentProvider(environmentProvider)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .setEnvironmentProvider(environmentProvider)
+            .build();
 
     String region = awsCredentials.getAwsRegion(EMPTY_METADATA_HEADERS);
 
@@ -715,10 +715,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredentials =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsCredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsCredentialSource(transportFactory))
+            .build();
 
     String region = awsCredentials.getAwsRegion(EMPTY_METADATA_HEADERS);
 
@@ -740,13 +740,13 @@ public class AwsCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_clonedCredentialWithAddedScopes() {
     AwsCredentials credentials =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setUniverseDomain("universeDomain")
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setUniverseDomain("universeDomain")
+            .build();
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
@@ -827,11 +827,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
           .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
           .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
       AwsCredentials awsCredential =
-              AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                  .setHttpTransportFactory(transportFactory)
-                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                  .setEnvironmentProvider(environmentProvider)
-                  .build();
+          AwsCredentials.newBuilder(AWS_CREDENTIAL)
+              .setHttpTransportFactory(transportFactory)
+              .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+              .setEnvironmentProvider(environmentProvider)
+              .build();
       assertFalse(awsCredential.shouldUseMetadataServer());
     }
   }
@@ -846,11 +846,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
         .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId")
         .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                .setEnvironmentProvider(environmentProvider)
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+            .setEnvironmentProvider(environmentProvider)
+            .build();
     assertTrue(awsCredential.shouldUseMetadataServer());
   }
 
@@ -868,11 +868,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
           .setEnv(regionKey, "awsRegion")
           .setEnv("AWS_SECRET_ACCESS_KEY", "awsSecretAccessKey");
       AwsCredentials awsCredential =
-              AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                  .setHttpTransportFactory(transportFactory)
-                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                  .setEnvironmentProvider(environmentProvider)
-                  .build();
+          AwsCredentials.newBuilder(AWS_CREDENTIAL)
+              .setHttpTransportFactory(transportFactory)
+              .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+              .setEnvironmentProvider(environmentProvider)
+              .build();
       assertTrue(awsCredential.shouldUseMetadataServer());
     }
   }
@@ -891,11 +891,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
           .setEnv(regionKey, "awsRegion")
           .setEnv("AWS_ACCESS_KEY_ID", "awsAccessKeyId");
       AwsCredentials awsCredential =
-              AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                  .setHttpTransportFactory(transportFactory)
-                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                  .setEnvironmentProvider(environmentProvider)
-                  .build();
+          AwsCredentials.newBuilder(AWS_CREDENTIAL)
+              .setHttpTransportFactory(transportFactory)
+              .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+              .setEnvironmentProvider(environmentProvider)
+              .build();
       assertTrue(awsCredential.shouldUseMetadataServer());
     }
   }
@@ -913,11 +913,11 @@ public class AwsCredentialsTest extends BaseSerializationTest {
       // Not set here.
       environmentProvider.setEnv(regionKey, "awsRegion");
       AwsCredentials awsCredential =
-              AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                  .setHttpTransportFactory(transportFactory)
-                  .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                  .setEnvironmentProvider(environmentProvider)
-                  .build();
+          AwsCredentials.newBuilder(AWS_CREDENTIAL)
+              .setHttpTransportFactory(transportFactory)
+              .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+              .setEnvironmentProvider(environmentProvider)
+              .build();
       assertTrue(awsCredential.shouldUseMetadataServer());
     }
   }
@@ -927,10 +927,10 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     MockExternalAccountCredentialsTransportFactory transportFactory =
         new MockExternalAccountCredentialsTransportFactory();
     AwsCredentials awsCredential =
-            AwsCredentials.newBuilder(AWS_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
-                .build();
+        AwsCredentials.newBuilder(AWS_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(buildAwsImdsv2CredentialSource(transportFactory))
+            .build();
     assertTrue(awsCredential.shouldUseMetadataServer());
   }
 
@@ -939,20 +939,20 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
     AwsCredentials credentials =
-            AwsCredentials.newBuilder()
-                .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-                .setAudience("audience")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenUrl(STS_URL)
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(AWS_CREDENTIAL_SOURCE)
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setScopes(scopes)
-                .build();
+        AwsCredentials.newBuilder()
+            .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+            .setAudience("audience")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(AWS_CREDENTIAL_SOURCE)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setScopes(scopes)
+            .build();
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -973,21 +973,21 @@ public class AwsCredentialsTest extends BaseSerializationTest {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
     AwsCredentials testCredentials =
-            AwsCredentials.newBuilder()
-                .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-                .setAudience("audience")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenUrl(STS_URL)
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(AWS_CREDENTIAL_SOURCE)
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setUniverseDomain("universeDomain")
-                .setScopes(scopes)
-                .build();
+        AwsCredentials.newBuilder()
+            .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+            .setAudience("audience")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(AWS_CREDENTIAL_SOURCE)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setUniverseDomain("universeDomain")
+            .setScopes(scopes)
+            .build();
 
     AwsCredentials deserializedCredentials = serializeAndDeserialize(testCredentials);
     assertEquals(testCredentials, deserializedCredentials);

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExternalAccountCredentialsTest.java
@@ -44,6 +44,7 @@ import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Clock;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.ExternalAccountCredentials.SubjectTokenTypes;
 import com.google.auth.oauth2.ExternalAccountCredentialsTest.TestExternalAccountCredentials.TestCredentialSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -556,6 +557,24 @@ public class ExternalAccountCredentialsTest extends BaseSerializationTest {
     assertEquals("workforcePoolUserProject", credentials.getWorkforcePoolUserProject());
     assertEquals("universeDomain", credentials.getUniverseDomain());
     assertNotNull(credentials.getCredentialSource());
+  }
+
+  @Test
+  public void constructor_builder_subjectTokenTypeEnum() {
+    HashMap<String, Object> credentialSource = new HashMap<>();
+    credentialSource.put("file", "file");
+
+    ExternalAccountCredentials credentials =
+        IdentityPoolCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setSubjectTokenType(SubjectTokenTypes.SAML2)
+            .setTokenUrl(STS_URL)
+            .setCredentialSource(new TestCredentialSource(credentialSource))
+            .build();
+
+    assertEquals(SubjectTokenTypes.SAML2.value, credentials.getSubjectTokenType());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -71,7 +71,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
       new IdentityPoolCredentialSource(FILE_CREDENTIAL_SOURCE_MAP);
 
   private static final IdentityPoolCredentials FILE_SOURCED_CREDENTIAL =
-      (IdentityPoolCredentials)
           IdentityPoolCredentials.newBuilder()
               .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
               .setAudience(
@@ -96,7 +95,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_clonedCredentialWithAddedScopes() {
     IdentityPoolCredentials credentials =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
                 .setQuotaProjectId("quotaProjectId")
@@ -142,7 +140,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new IdentityPoolCredentialSource(credentialSourceMap);
 
     IdentityPoolCredentials credentials =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setCredentialSource(credentialSource)
                 .build();
@@ -183,7 +180,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         file.getAbsolutePath());
 
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(credentialSource)
@@ -224,7 +220,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new IdentityPoolCredentialSource(credentialSourceMap);
 
     IdentityPoolCredentials credentials =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setCredentialSource(credentialSource)
                 .build();
@@ -245,7 +240,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(
@@ -272,7 +266,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl(), formatMap);
 
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(credentialSource)
@@ -292,7 +285,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseErrorSequence(response);
 
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setHttpTransportFactory(transportFactory)
                 .setCredentialSource(
@@ -316,7 +308,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder()
                 .setAudience(
                     "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
@@ -345,7 +336,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setWorkforcePoolUserProject("userProject")
                 .setAudience(
@@ -380,7 +370,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder()
                 .setAudience(
                     "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
@@ -412,7 +401,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder()
                 .setAudience(
                     "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
@@ -454,7 +442,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setAudience(
                     "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
@@ -491,7 +478,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setAudience(
                     "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
@@ -676,7 +662,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
     IdentityPoolCredentials credentials =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder()
                 .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
                 .setAudience("audience")
@@ -744,7 +729,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
   public void builder_emptyWorkforceUserProjectWithWorkforceAudience() {
     // No exception should be thrown.
     IdentityPoolCredentials credentials =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder()
                 .setWorkforcePoolUserProject("")
                 .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
@@ -763,7 +747,6 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
     IdentityPoolCredentials testCredentials =
-        (IdentityPoolCredentials)
             IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
                 .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
                 .setQuotaProjectId("quotaProjectId")

--- a/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IdentityPoolCredentialsTest.java
@@ -71,15 +71,15 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
       new IdentityPoolCredentialSource(FILE_CREDENTIAL_SOURCE_MAP);
 
   private static final IdentityPoolCredentials FILE_SOURCED_CREDENTIAL =
-          IdentityPoolCredentials.newBuilder()
-              .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-              .setAudience(
-                  "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-              .setSubjectTokenType("subjectTokenType")
-              .setTokenUrl(STS_URL)
-              .setTokenInfoUrl("tokenInfoUrl")
-              .setCredentialSource(FILE_CREDENTIAL_SOURCE)
-              .build();
+      IdentityPoolCredentials.newBuilder()
+          .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+          .setAudience(
+              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+          .setSubjectTokenType("subjectTokenType")
+          .setTokenUrl(STS_URL)
+          .setTokenInfoUrl("tokenInfoUrl")
+          .setCredentialSource(FILE_CREDENTIAL_SOURCE)
+          .build();
 
   static class MockExternalAccountCredentialsTransportFactory implements HttpTransportFactory {
 
@@ -95,13 +95,13 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_clonedCredentialWithAddedScopes() {
     IdentityPoolCredentials credentials =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setUniverseDomain("universeDomain")
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setUniverseDomain("universeDomain")
+            .build();
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
@@ -140,9 +140,9 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new IdentityPoolCredentialSource(credentialSourceMap);
 
     IdentityPoolCredentials credentials =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setCredentialSource(credentialSource)
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setCredentialSource(credentialSource)
+            .build();
 
     String subjectToken = credentials.retrieveSubjectToken();
 
@@ -180,10 +180,10 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         file.getAbsolutePath());
 
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(credentialSource)
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(credentialSource)
+            .build();
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -220,9 +220,9 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new IdentityPoolCredentialSource(credentialSourceMap);
 
     IdentityPoolCredentials credentials =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setCredentialSource(credentialSource)
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setCredentialSource(credentialSource)
+            .build();
 
     try {
       credentials.retrieveSubjectToken();
@@ -240,11 +240,11 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .build();
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -266,10 +266,10 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl(), formatMap);
 
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(credentialSource)
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(credentialSource)
+            .build();
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -285,11 +285,11 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.addResponseErrorSequence(response);
 
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .build();
 
     try {
       credential.retrieveSubjectToken();
@@ -308,17 +308,17 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder()
-                .setAudience(
-                    "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(FILE_CREDENTIAL_SOURCE)
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .build();
+        IdentityPoolCredentials.newBuilder()
+            .setAudience(
+                "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(FILE_CREDENTIAL_SOURCE)
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -336,15 +336,15 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
         new MockExternalAccountCredentialsTransportFactory();
 
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setWorkforcePoolUserProject("userProject")
-                .setAudience(
-                    "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setWorkforcePoolUserProject("userProject")
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -370,18 +370,18 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder()
-                .setAudience(
-                    "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .build();
+        IdentityPoolCredentials.newBuilder()
+            .setAudience(
+                "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -401,20 +401,20 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder()
-                .setAudience(
-                    "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setHttpTransportFactory(transportFactory)
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .setServiceAccountImpersonationOptions(
-                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
-                .build();
+        IdentityPoolCredentials.newBuilder()
+            .setAudience(
+                "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setHttpTransportFactory(transportFactory)
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .setServiceAccountImpersonationOptions(
+                ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
+            .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -442,17 +442,17 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setAudience(
-                    "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .setWorkforcePoolUserProject("userProject")
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .setWorkforcePoolUserProject("userProject")
+            .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -478,19 +478,19 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
 
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
     IdentityPoolCredentials credential =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setAudience(
-                    "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .setHttpTransportFactory(transportFactory)
-                .setCredentialSource(
-                    buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
-                .setWorkforcePoolUserProject("userProject")
-                .setServiceAccountImpersonationOptions(
-                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .setHttpTransportFactory(transportFactory)
+            .setCredentialSource(
+                buildUrlBasedCredentialSource(transportFactory.transport.getMetadataUrl()))
+            .setWorkforcePoolUserProject("userProject")
+            .setServiceAccountImpersonationOptions(
+                ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
+            .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -662,19 +662,19 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
     IdentityPoolCredentials credentials =
-            IdentityPoolCredentials.newBuilder()
-                .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-                .setAudience("audience")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenUrl(STS_URL)
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(FILE_CREDENTIAL_SOURCE)
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setScopes(scopes)
-                .build();
+        IdentityPoolCredentials.newBuilder()
+            .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+            .setAudience("audience")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(FILE_CREDENTIAL_SOURCE)
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setScopes(scopes)
+            .build();
 
     assertEquals("audience", credentials.getAudience());
     assertEquals("subjectTokenType", credentials.getSubjectTokenType());
@@ -729,17 +729,17 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
   public void builder_emptyWorkforceUserProjectWithWorkforceAudience() {
     // No exception should be thrown.
     IdentityPoolCredentials credentials =
-            IdentityPoolCredentials.newBuilder()
-                .setWorkforcePoolUserProject("")
-                .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-                .setAudience(
-                    "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenUrl(STS_URL)
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(FILE_CREDENTIAL_SOURCE)
-                .setQuotaProjectId("quotaProjectId")
-                .build();
+        IdentityPoolCredentials.newBuilder()
+            .setWorkforcePoolUserProject("")
+            .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+            .setAudience(
+                "//iam.googleapis.com/locations/global/workforcePools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(FILE_CREDENTIAL_SOURCE)
+            .setQuotaProjectId("quotaProjectId")
+            .build();
 
     assertTrue(credentials.isWorkforcePoolConfiguration());
   }
@@ -747,13 +747,13 @@ public class IdentityPoolCredentialsTest extends BaseSerializationTest {
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
     IdentityPoolCredentials testCredentials =
-            IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setUniverseDomain("universeDomain")
-                .build();
+        IdentityPoolCredentials.newBuilder(FILE_SOURCED_CREDENTIAL)
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setUniverseDomain("universeDomain")
+            .build();
 
     IdentityPoolCredentials deserializedCredentials = serializeAndDeserialize(testCredentials);
     assertEquals(testCredentials, deserializedCredentials);

--- a/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
@@ -39,7 +39,6 @@ import com.google.api.client.json.GenericJson;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.ExecutableHandler.ExecutableOptions;
-import com.google.auth.oauth2.ExternalAccountCredentials.CredentialSource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.NotSerializableException;
@@ -62,15 +61,15 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
   private static final String STS_URL = "https://sts.googleapis.com";
 
   private static final PluggableAuthCredentials CREDENTIAL =
-          PluggableAuthCredentials.newBuilder()
-              .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-              .setAudience(
-                  "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-              .setSubjectTokenType("subjectTokenType")
-              .setTokenUrl(STS_URL)
-              .setTokenInfoUrl("tokenInfoUrl")
-              .setCredentialSource(buildCredentialSource())
-              .build();
+      PluggableAuthCredentials.newBuilder()
+          .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+          .setAudience(
+              "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+          .setSubjectTokenType("subjectTokenType")
+          .setTokenUrl(STS_URL)
+          .setTokenInfoUrl("tokenInfoUrl")
+          .setCredentialSource(buildCredentialSource())
+          .build();
 
   static class MockExternalAccountCredentialsTransportFactory implements HttpTransportFactory {
 
@@ -107,11 +106,11 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
         };
 
     PluggableAuthCredentials credential =
-            PluggableAuthCredentials.newBuilder(CREDENTIAL)
-                .setExecutableHandler(executableHandler)
-                .setCredentialSource(buildCredentialSource(command, timeout, outputFile))
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .build();
+        PluggableAuthCredentials.newBuilder(CREDENTIAL)
+            .setExecutableHandler(executableHandler)
+            .setCredentialSource(buildCredentialSource(command, timeout, outputFile))
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .build();
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -147,11 +146,11 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
         };
 
     PluggableAuthCredentials credential =
-            PluggableAuthCredentials.newBuilder(CREDENTIAL)
-                .setExecutableHandler(executableHandler)
-                .setCredentialSource(
-                    buildCredentialSource(command, /* timeoutMs= */ null, /* outputFile= */ null))
-                .build();
+        PluggableAuthCredentials.newBuilder(CREDENTIAL)
+            .setExecutableHandler(executableHandler)
+            .setCredentialSource(
+                buildCredentialSource(command, /* timeoutMs= */ null, /* outputFile= */ null))
+            .build();
 
     String subjectToken = credential.retrieveSubjectToken();
 
@@ -181,11 +180,11 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     PluggableAuthCredentials credential =
-            PluggableAuthCredentials.newBuilder(CREDENTIAL)
-                .setExecutableHandler(options -> "pluggableAuthToken")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setHttpTransportFactory(transportFactory)
-                .build();
+        PluggableAuthCredentials.newBuilder(CREDENTIAL)
+            .setExecutableHandler(options -> "pluggableAuthToken")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setHttpTransportFactory(transportFactory)
+            .build();
 
     AccessToken accessToken = credential.refreshAccessToken();
 
@@ -210,17 +209,17 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     PluggableAuthCredentials credential =
-            PluggableAuthCredentials.newBuilder()
-                .setAudience(
-                    "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setCredentialSource(buildCredentialSource())
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .setHttpTransportFactory(transportFactory)
-                .build();
+        PluggableAuthCredentials.newBuilder()
+            .setAudience(
+                "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setCredentialSource(buildCredentialSource())
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .setHttpTransportFactory(transportFactory)
+            .build();
 
     credential =
         PluggableAuthCredentials.newBuilder(credential)
@@ -251,19 +250,19 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     PluggableAuthCredentials credential =
-            PluggableAuthCredentials.newBuilder()
-                .setAudience(
-                    "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setTokenUrl(transportFactory.transport.getStsUrl())
-                .setCredentialSource(buildCredentialSource())
-                .setServiceAccountImpersonationUrl(
-                    transportFactory.transport.getServiceAccountImpersonationUrl())
-                .setServiceAccountImpersonationOptions(
-                    ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
-                .setHttpTransportFactory(transportFactory)
-                .build();
+        PluggableAuthCredentials.newBuilder()
+            .setAudience(
+                "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setTokenUrl(transportFactory.transport.getStsUrl())
+            .setCredentialSource(buildCredentialSource())
+            .setServiceAccountImpersonationUrl(
+                transportFactory.transport.getServiceAccountImpersonationUrl())
+            .setServiceAccountImpersonationOptions(
+                ExternalAccountCredentialsTest.buildServiceAccountImpersonationOptions(2800))
+            .setHttpTransportFactory(transportFactory)
+            .build();
 
     credential =
         PluggableAuthCredentials.newBuilder(credential)
@@ -399,20 +398,20 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     ExecutableHandler handler = options -> "Token";
 
     PluggableAuthCredentials credentials =
-            PluggableAuthCredentials.newBuilder()
-                .setExecutableHandler(handler)
-                .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
-                .setAudience("audience")
-                .setSubjectTokenType("subjectTokenType")
-                .setTokenUrl(STS_URL)
-                .setTokenInfoUrl("tokenInfoUrl")
-                .setCredentialSource(source)
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setScopes(scopes)
-                .build();
+        PluggableAuthCredentials.newBuilder()
+            .setExecutableHandler(handler)
+            .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
+            .setAudience("audience")
+            .setSubjectTokenType("subjectTokenType")
+            .setTokenUrl(STS_URL)
+            .setTokenInfoUrl("tokenInfoUrl")
+            .setCredentialSource(source)
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setScopes(scopes)
+            .build();
 
     assertEquals(credentials.getExecutableHandler(), handler);
     assertEquals("audience", credentials.getAudience());
@@ -432,14 +431,14 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_clonedCredentialWithAddedScopes() {
     PluggableAuthCredentials credentials =
-            PluggableAuthCredentials.newBuilder(CREDENTIAL)
-                .setExecutableHandler(options -> "pluggableAuthToken")
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setUniverseDomain("universeDomain")
-                .build();
+        PluggableAuthCredentials.newBuilder(CREDENTIAL)
+            .setExecutableHandler(options -> "pluggableAuthToken")
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setUniverseDomain("universeDomain")
+            .build();
 
     List<String> newScopes = Arrays.asList("scope1", "scope2");
 
@@ -465,14 +464,14 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
     PluggableAuthCredentials testCredentials =
-            PluggableAuthCredentials.newBuilder(CREDENTIAL)
-                .setExecutableHandler(options -> "pluggableAuthToken")
-                .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
-                .setQuotaProjectId("quotaProjectId")
-                .setClientId("clientId")
-                .setClientSecret("clientSecret")
-                .setUniverseDomain("universeDomain")
-                .build();
+        PluggableAuthCredentials.newBuilder(CREDENTIAL)
+            .setExecutableHandler(options -> "pluggableAuthToken")
+            .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
+            .setQuotaProjectId("quotaProjectId")
+            .setClientId("clientId")
+            .setClientSecret("clientSecret")
+            .setUniverseDomain("universeDomain")
+            .build();
 
     // PluggableAuthCredentials are not serializable
     assertThrows(NotSerializableException.class, () -> serializeAndDeserialize(testCredentials));

--- a/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthCredentialsTest.java
@@ -62,7 +62,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
   private static final String STS_URL = "https://sts.googleapis.com";
 
   private static final PluggableAuthCredentials CREDENTIAL =
-      (PluggableAuthCredentials)
           PluggableAuthCredentials.newBuilder()
               .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
               .setAudience(
@@ -108,7 +107,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
         };
 
     PluggableAuthCredentials credential =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder(CREDENTIAL)
                 .setExecutableHandler(executableHandler)
                 .setCredentialSource(buildCredentialSource(command, timeout, outputFile))
@@ -149,7 +147,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
         };
 
     PluggableAuthCredentials credential =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder(CREDENTIAL)
                 .setExecutableHandler(executableHandler)
                 .setCredentialSource(
@@ -184,7 +181,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     PluggableAuthCredentials credential =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder(CREDENTIAL)
                 .setExecutableHandler(options -> "pluggableAuthToken")
                 .setTokenUrl(transportFactory.transport.getStsUrl())
@@ -214,7 +210,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     PluggableAuthCredentials credential =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder()
                 .setAudience(
                     "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
@@ -256,7 +251,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(TestUtils.getDefaultExpireTime());
 
     PluggableAuthCredentials credential =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder()
                 .setAudience(
                     "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/provider")
@@ -401,11 +395,10 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
   public void builder_allFields() {
     List<String> scopes = Arrays.asList("scope1", "scope2");
 
-    CredentialSource source = buildCredentialSource();
+    PluggableAuthCredentialSource source = buildCredentialSource();
     ExecutableHandler handler = options -> "Token";
 
     PluggableAuthCredentials credentials =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder()
                 .setExecutableHandler(handler)
                 .setHttpTransportFactory(OAuth2Utils.HTTP_TRANSPORT_FACTORY)
@@ -439,7 +432,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
   @Test
   public void createdScoped_clonedCredentialWithAddedScopes() {
     PluggableAuthCredentials credentials =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder(CREDENTIAL)
                 .setExecutableHandler(options -> "pluggableAuthToken")
                 .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
@@ -473,7 +465,6 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
   @Test
   public void serialize() throws IOException, ClassNotFoundException {
     PluggableAuthCredentials testCredentials =
-        (PluggableAuthCredentials)
             PluggableAuthCredentials.newBuilder(CREDENTIAL)
                 .setExecutableHandler(options -> "pluggableAuthToken")
                 .setServiceAccountImpersonationUrl(SERVICE_ACCOUNT_IMPERSONATION_URL)
@@ -487,11 +478,11 @@ public class PluggableAuthCredentialsTest extends BaseSerializationTest {
     assertThrows(NotSerializableException.class, () -> serializeAndDeserialize(testCredentials));
   }
 
-  private static CredentialSource buildCredentialSource() {
+  private static PluggableAuthCredentialSource buildCredentialSource() {
     return buildCredentialSource("command", null, null);
   }
 
-  private static CredentialSource buildCredentialSource(
+  private static PluggableAuthCredentialSource buildCredentialSource(
       String command, @Nullable String timeoutMs, @Nullable String outputFile) {
     Map<String, Object> source = new HashMap<>();
     Map<String, Object> executable = new HashMap<>();


### PR DESCRIPTION
Adds builder methods to the child classes of external account credentials so they do not need to be type casted when built. Also adds enum with common subject token types with associated builder method.
