### PR TITLE
docs: Update README.md to link to Cloud authentication documentation rather than AIPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ libraryDependencies += "com.google.auth" % "google-auth-library-oauth2-http" % "
 
 ### Application Default Credentials
 
-This library provides an implementation of [Application Default Credentials](https://google.aip.dev/auth/4110)
-for Java. The [Application Default Credentials](https://google.aip.dev/auth/4110) 
-provide a simple way to get authorization credentials for use in calling Google APIs.
+This library provides an implementation of
+[Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+for Java. Application Default Credentials provide a simple way to get authorization
+credentials for use in calling Google APIs.
 
 They are best suited for cases when the call needs to have the same identity and 
 authorization level for the application independent of the user. This is the recommended 


### PR DESCRIPTION
The AIPs are not a good experience for customers, they are more of an internal resource, at least for auth. The Cloud authentication documentation includes a section about Application Default Credentials now, so that's a better place to send users.