### PR TITLE
feat: adds universe domain support for compute credentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -205,8 +205,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
    *
    * <p>Returns an explicit universe domain if it was provided during credential initialization.
    *
-   * <p>Returns the {@link Credentials#GOOGLE_DEFAULT_UNIVERSE} if universe domain endpoint is
-   * not found (404) or returns an empty string.
+   * <p>Returns the {@link Credentials#GOOGLE_DEFAULT_UNIVERSE} if universe domain endpoint is not
+   * found (404) or returns an empty string.
    *
    * <p>Otherwise, returns universe domain from GCE metadata service.
    *

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -221,12 +221,14 @@ public class ComputeEngineCredentials extends GoogleCredentials
       return super.getUniverseDomain();
     }
 
-    if (universeDomainFromMetadata != null) {
+    synchronized (this) {
+      if (universeDomainFromMetadata != null) {
+        return universeDomainFromMetadata;
+      }
+
+      universeDomainFromMetadata = getUniverseDomainFromMetadata();
       return universeDomainFromMetadata;
     }
-
-    universeDomainFromMetadata = getUniverseDomainFromMetadata();
-    return universeDomainFromMetadata;
   }
 
   private String getUniverseDomainFromMetadata() throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -657,6 +657,12 @@ public class ComputeEngineCredentials extends GoogleCredentials
       return this;
     }
 
+    @CanIgnoreReturnValue
+    public Builder setQuotaProjectId(String quotaProjectId) {
+      super.quotaProjectId = quotaProjectId;
+      return this;
+    }
+
     public HttpTransportFactory getHttpTransportFactory() {
       return transportFactory;
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -156,7 +156,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
   @Override
   public GoogleCredentials createScoped(Collection<String> newScopes) {
     ComputeEngineCredentials.Builder builder =
-        ComputeEngineCredentials.newBuilder()
+        this.toBuilder()
             .setHttpTransportFactory(transportFactory)
             .setScopes(newScopes);
     return new ComputeEngineCredentials(builder);
@@ -219,7 +219,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
    */
   @Override
   public String getUniverseDomain() throws IOException {
-    if (!isDefaultUniverseDomain()) {
+    if (isExplicitUniverseDomain()) {
       return super.getUniverseDomain();
     }
 
@@ -252,6 +252,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
       throw new GoogleAuthException(true, cause);
     }
     String responseString = response.parseAsString();
+
+    /* Earlier versions of MDS that supports universe_domain return empty string instead of GDU. */
     if (responseString.isEmpty()) {
       return Credentials.GOOGLE_DEFAULT_UNIVERSE;
     }
@@ -521,6 +523,9 @@ public class ComputeEngineCredentials extends GoogleCredentials
     if (!(obj instanceof ComputeEngineCredentials)) {
       return false;
     }
+    if (!super.equals(obj)) {
+      return false;
+    }
     ComputeEngineCredentials other = (ComputeEngineCredentials) obj;
     return Objects.equals(this.transportFactoryClassName, other.transportFactoryClassName)
         && Objects.equals(this.scopes, other.scopes)
@@ -625,6 +630,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
     }
 
     protected Builder(ComputeEngineCredentials credentials) {
+      super(credentials);
       this.transportFactory = credentials.transportFactory;
       this.scopes = credentials.scopes;
     }

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -155,9 +155,10 @@ public class ComputeEngineCredentials extends GoogleCredentials
   /** Clones the compute engine account with the specified scopes. */
   @Override
   public GoogleCredentials createScoped(Collection<String> newScopes) {
-    ComputeEngineCredentials.Builder builder = ComputeEngineCredentials.newBuilder()
-        .setHttpTransportFactory(transportFactory)
-        .setScopes(newScopes);
+    ComputeEngineCredentials.Builder builder =
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setScopes(newScopes);
     return new ComputeEngineCredentials(builder);
   }
 
@@ -165,10 +166,11 @@ public class ComputeEngineCredentials extends GoogleCredentials
   @Override
   public GoogleCredentials createScoped(
       Collection<String> newScopes, Collection<String> newDefaultScopes) {
-    ComputeEngineCredentials.Builder builder = ComputeEngineCredentials.newBuilder()
-        .setHttpTransportFactory(transportFactory)
-        .setScopes(newScopes)
-        .setDefaultScopes(newDefaultScopes);
+    ComputeEngineCredentials.Builder builder =
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(transportFactory)
+            .setScopes(newScopes)
+            .setDefaultScopes(newDefaultScopes);
     return new ComputeEngineCredentials(builder);
   }
 
@@ -199,20 +201,21 @@ public class ComputeEngineCredentials extends GoogleCredentials
     return tokenUrl.toString();
   }
 
-  /** Gets the universe domain from the GCE metadata server.
+  /**
+   * Gets the universe domain from the GCE metadata server.
    *
    * <p>Returns an explicit universe domain if it was provided during credential initialization.
    *
-   * <p>Returns the {@link Credentials#GOOGLE_DEFAULT_UNIVERSE} if universe domain endpoint
-   * is unavailable or returns an empty string.
+   * <p>Returns the {@link Credentials#GOOGLE_DEFAULT_UNIVERSE} if universe domain endpoint is
+   * unavailable or returns an empty string.
    *
    * <p>Otherwise, returns universe domain from GCE metadata service.
    *
    * <p>Any above value is cached for the credential lifetime.
    *
    * @throws IOException if a call to GCE metadata service was unsuccessful. Check if exception
-   * implements the {@link Retryable} and {@code isRetryable()} will return true if the operation
-   * may be retried.
+   *     implements the {@link Retryable} and {@code isRetryable()} will return true if the
+   *     operation may be retried.
    * @return string representing a universe domain in the format some-domain.xyz
    */
   @Override
@@ -238,10 +241,12 @@ public class ComputeEngineCredentials extends GoogleCredentials
       return Credentials.GOOGLE_DEFAULT_UNIVERSE;
     }
     if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
-      IOException cause = new IOException(String.format(
-          "Unexpected Error code %s trying to get universe domain"
-              + " from Compute Engine metadata for the default service account: %s",
-          statusCode, response.parseAsString()));
+      IOException cause =
+          new IOException(
+              String.format(
+                  "Unexpected Error code %s trying to get universe domain"
+                      + " from Compute Engine metadata for the default service account: %s",
+                  statusCode, response.parseAsString()));
       throw new GoogleAuthException(true, cause);
     }
     String responseString = response.parseAsString();
@@ -650,7 +655,9 @@ public class ComputeEngineCredentials extends GoogleCredentials
       return scopes;
     }
 
-    public Collection<String> getDefaultScopes() { return defaultScopes; }
+    public Collection<String> getDefaultScopes() {
+      return defaultScopes;
+    }
 
     public ComputeEngineCredentials build() {
       return new ComputeEngineCredentials(this);

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -156,9 +156,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
   @Override
   public GoogleCredentials createScoped(Collection<String> newScopes) {
     ComputeEngineCredentials.Builder builder =
-        this.toBuilder()
-            .setHttpTransportFactory(transportFactory)
-            .setScopes(newScopes);
+        this.toBuilder().setHttpTransportFactory(transportFactory).setScopes(newScopes);
     return new ComputeEngineCredentials(builder);
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -180,8 +180,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
    * @return new ComputeEngineCredentials
    */
   public static ComputeEngineCredentials create() {
-    ComputeEngineCredentials.Builder builder = ComputeEngineCredentials.newBuilder();
-    return new ComputeEngineCredentials(builder);
+    return new ComputeEngineCredentials(ComputeEngineCredentials.newBuilder());
   }
 
   public final Collection<String> getScopes() {
@@ -207,7 +206,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
    * <p>Returns an explicit universe domain if it was provided during credential initialization.
    *
    * <p>Returns the {@link Credentials#GOOGLE_DEFAULT_UNIVERSE} if universe domain endpoint is
-   * unavailable or returns an empty string.
+   * not found (404) or returns an empty string.
    *
    * <p>Otherwise, returns universe domain from GCE metadata service.
    *
@@ -225,13 +224,16 @@ public class ComputeEngineCredentials extends GoogleCredentials
     }
 
     synchronized (this) {
-      if (universeDomainFromMetadata != null) {
-        return universeDomainFromMetadata;
+      if (this.universeDomainFromMetadata != null) {
+        return this.universeDomainFromMetadata;
       }
-
-      universeDomainFromMetadata = getUniverseDomainFromMetadata();
-      return universeDomainFromMetadata;
     }
+
+    String universeDomainFromMetadata = getUniverseDomainFromMetadata();
+    synchronized (this) {
+      this.universeDomainFromMetadata = universeDomainFromMetadata;
+    }
+    return universeDomainFromMetadata;
   }
 
   private String getUniverseDomainFromMetadata() throws IOException {

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -235,7 +235,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
   }
 
   private String getUniverseDomainFromMetadata() throws IOException {
-    HttpResponse response = getMetadataResponse(getUniverseDomainEncodedUrl());
+    HttpResponse response = getMetadataResponse(getUniverseDomainUrl());
     int statusCode = response.getStatusCode();
     if (statusCode == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
       return Credentials.GOOGLE_DEFAULT_UNIVERSE;
@@ -484,7 +484,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
     return getTokenServerEncodedUrl(DefaultCredentialsProvider.DEFAULT);
   }
 
-  public static String getUniverseDomainEncodedUrl() {
+  public static String getUniverseDomainUrl() {
     return getMetadataServerUrl(DefaultCredentialsProvider.DEFAULT)
         + "/computeMetadata/v1/universe/universe_domain";
   }

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -47,7 +47,7 @@ import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-import com.google.common.base.MoreObjects;
+import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.BufferedReader;
@@ -505,10 +505,13 @@ public class ComputeEngineCredentials extends GoogleCredentials
   }
 
   @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("transportFactoryClassName", transportFactoryClassName)
-        .toString();
+  protected ToStringHelper toStringHelper() {
+    synchronized (this) {
+      return super.toStringHelper()
+          .add("transportFactoryClassName", transportFactoryClassName)
+          .add("scopes", scopes)
+          .add("universeDomainFromMetadata", universeDomainFromMetadata);
+    }
   }
 
   @Override
@@ -518,7 +521,8 @@ public class ComputeEngineCredentials extends GoogleCredentials
     }
     ComputeEngineCredentials other = (ComputeEngineCredentials) obj;
     return Objects.equals(this.transportFactoryClassName, other.transportFactoryClassName)
-        && Objects.equals(this.scopes, other.scopes);
+        && Objects.equals(this.scopes, other.scopes)
+        && Objects.equals(this.universeDomainFromMetadata, other.universeDomainFromMetadata);
   }
 
   private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -307,7 +307,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @param builder an instance of a builder
    */
   protected GoogleCredentials(Builder builder) {
-    super(builder.getAccessToken());
+    super(builder.getAccessToken(), builder.getRefreshMargin(), builder.getExpirationMargin());
     this.quotaProjectId = builder.getQuotaProjectId();
 
     if (builder.universeDomain == null || builder.universeDomain.trim().isEmpty()) {

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -249,9 +249,10 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   /**
    * Gets the flag indicating whether universeDomain was explicitly set by the developer.
    *
-   * If subclass has requirements to give priority to developer-set universeDomain, this property
+   * <p>If subclass has requirements to give priority to developer-set universeDomain, this property
    * must be used to check if the universeDomain value was provided by the user. It could be a
    * default otherwise.
+   *
    * @return true if universeDomain value was provided by the developer, false otherwise
    */
   @VisibleForTesting
@@ -358,10 +359,11 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   protected GoogleCredentials(
       AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
     this(
-        (Builder) GoogleCredentials.newBuilder()
-            .setAccessToken(accessToken)
-            .setRefreshMargin(refreshMargin)
-            .setExpirationMargin(expirationMargin));
+        (Builder)
+            GoogleCredentials.newBuilder()
+                .setAccessToken(accessToken)
+                .setRefreshMargin(refreshMargin)
+                .setExpirationMargin(expirationMargin));
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -79,9 +79,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    * @return the credentials instance
    */
   public static GoogleCredentials create(AccessToken accessToken) {
-    return GoogleCredentials.newBuilder()
-        .setAccessToken(accessToken)
-        .build();
+    return GoogleCredentials.newBuilder().setAccessToken(accessToken).build();
   }
 
   /**
@@ -305,9 +303,10 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
    */
   @Deprecated
   protected GoogleCredentials(AccessToken accessToken, String quotaProjectId) {
-    this(GoogleCredentials.newBuilder()
-        .setAccessToken(accessToken)
-        .setQuotaProjectId(quotaProjectId));
+    this(
+        GoogleCredentials.newBuilder()
+            .setAccessToken(accessToken)
+            .setQuotaProjectId(quotaProjectId));
   }
 
   /**
@@ -350,10 +349,11 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   @Deprecated
   protected GoogleCredentials(
       AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
-    this(GoogleCredentials.newBuilder()
-        .setAccessToken(accessToken)
-        .setRefreshMargin(refreshMargin)
-        .setExpirationMargin(expirationMargin));
+    this(
+        GoogleCredentials.newBuilder()
+            .setAccessToken(accessToken)
+            .setRefreshMargin(refreshMargin)
+            .setExpirationMargin(expirationMargin));
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -481,7 +481,9 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     protected Builder(GoogleCredentials credentials) {
       super(credentials);
       this.quotaProjectId = credentials.quotaProjectId;
-      this.universeDomain = credentials.universeDomain;
+      if (credentials.isExplicitUniverseDomain) {
+        this.universeDomain = credentials.universeDomain;
+      }
     }
 
     protected Builder(GoogleCredentials.Builder builder) {

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -249,7 +249,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   /**
    * Gets the flag indicating whether universeDomain was explicitly set by the developer.
    *
-   * <p>If subclass has requirements to give priority to developer-set universeDomain, this property
+   * <p>If subclass has a requirement to give priority to developer-set universeDomain, this property
    * must be used to check if the universeDomain value was provided by the user. It could be a
    * default otherwise.
    *

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -246,6 +246,14 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     return this.universeDomain;
   }
 
+  /**
+   * Gets the flag indicating whether universeDomain was explicitly set by the developer.
+   *
+   * If subclass has requirements to give priority to developer-set universeDomain, this property
+   * must be used to check if the universeDomain value was provided by the user. It could be a
+   * default otherwise.
+   * @return true if universeDomain value was provided by the developer, false otherwise
+   */
   @VisibleForTesting
   protected boolean isExplicitUniverseDomain() {
     return this.isExplicitUniverseDomain;
@@ -350,7 +358,7 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   protected GoogleCredentials(
       AccessToken accessToken, Duration refreshMargin, Duration expirationMargin) {
     this(
-        GoogleCredentials.newBuilder()
+        (Builder) GoogleCredentials.newBuilder()
             .setAccessToken(accessToken)
             .setRefreshMargin(refreshMargin)
             .setExpirationMargin(expirationMargin));
@@ -519,18 +527,6 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     @CanIgnoreReturnValue
     public Builder setAccessToken(AccessToken token) {
       super.setAccessToken(token);
-      return this;
-    }
-
-    @CanIgnoreReturnValue
-    public Builder setExpirationMargin(Duration expirationMargin) {
-      super.setExpirationMargin(expirationMargin);
-      return this;
-    }
-
-    @CanIgnoreReturnValue
-    public Builder setRefreshMargin(Duration refreshMargin) {
-      super.setRefreshMargin(refreshMargin);
       return this;
     }
   }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -249,9 +249,9 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
   /**
    * Gets the flag indicating whether universeDomain was explicitly set by the developer.
    *
-   * <p>If subclass has a requirement to give priority to developer-set universeDomain, this property
-   * must be used to check if the universeDomain value was provided by the user. It could be a
-   * default otherwise.
+   * <p>If subclass has a requirement to give priority to developer-set universeDomain, this
+   * property must be used to check if the universeDomain value was provided by the user. It could
+   * be a default otherwise.
    *
    * @return true if universeDomain value was provided by the developer, false otherwise
    */

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -72,7 +72,9 @@ public class OAuth2Credentials extends Credentials {
   static final Duration DEFAULT_REFRESH_MARGIN = Duration.ofMinutes(6);
   private static final ImmutableMap<String, List<String>> EMPTY_EXTRA_HEADERS = ImmutableMap.of();
 
+  @VisibleForTesting
   private final Duration expirationMargin;
+  @VisibleForTesting
   private final Duration refreshMargin;
 
   // byte[] is serializable, so the lock variable can be final

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -72,10 +72,8 @@ public class OAuth2Credentials extends Credentials {
   static final Duration DEFAULT_REFRESH_MARGIN = Duration.ofMinutes(6);
   private static final ImmutableMap<String, List<String>> EMPTY_EXTRA_HEADERS = ImmutableMap.of();
 
-  @VisibleForTesting
-  private final Duration expirationMargin;
-  @VisibleForTesting
-  private final Duration refreshMargin;
+  @VisibleForTesting private final Duration expirationMargin;
+  @VisibleForTesting private final Duration refreshMargin;
 
   // byte[] is serializable, so the lock variable can be final
   @VisibleForTesting final Object lock = new byte[0];

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -60,7 +60,6 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -205,7 +205,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     GoogleCredentials credentials =
         ComputeEngineCredentials.create().createScoped(null, Arrays.asList("foo"));
 
-    assertEquals(ComputeEngineCredentials.COMPUTE_EXPIRATION_MARGIN, credentials.getExpirationMargin());
+    assertEquals(
+        ComputeEngineCredentials.COMPUTE_EXPIRATION_MARGIN, credentials.getExpirationMargin());
     assertEquals(ComputeEngineCredentials.COMPUTE_REFRESH_MARGIN, credentials.getRefreshMargin());
   }
 
@@ -661,7 +662,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void getUniverseDomain_explicitSet_NoMdsCall() throws IOException {
-    MockRequestCountingTransportFactory transportFactory = new MockRequestCountingTransportFactory();
+    MockRequestCountingTransportFactory transportFactory =
+        new MockRequestCountingTransportFactory();
 
     ComputeEngineCredentials credentials =
         ComputeEngineCredentials.newBuilder()

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -197,8 +197,11 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     ComputeEngineCredentials scopedCredentials =
         (ComputeEngineCredentials) credentials.createScoped(Arrays.asList("foo"));
 
-    assertEquals(ComputeEngineCredentials.COMPUTE_EXPIRATION_MARGIN, scopedCredentials.getExpirationMargin());
-    assertEquals(ComputeEngineCredentials.COMPUTE_REFRESH_MARGIN, scopedCredentials.getRefreshMargin());
+    assertEquals(
+        ComputeEngineCredentials.COMPUTE_EXPIRATION_MARGIN,
+        scopedCredentials.getExpirationMargin());
+    assertEquals(
+        ComputeEngineCredentials.COMPUTE_REFRESH_MARGIN, scopedCredentials.getRefreshMargin());
   }
 
   @Test
@@ -328,7 +331,11 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     String expectedToString =
         String.format(
             "ComputeEngineCredentials{quotaProjectId=%s, universeDomain=%s, isExplicitUniverseDomain=%s, transportFactoryClassName=%s, scopes=%s}",
-            "some-project", "some-domain", true, MockMetadataServerTransportFactory.class.getName(), "[some scope]");
+            "some-project",
+            "some-domain",
+            true,
+            MockMetadataServerTransportFactory.class.getName(),
+            "[some scope]");
     GoogleCredentials credentials =
         ComputeEngineCredentials.newBuilder()
             .setHttpTransportFactory(serverTransportFactory)

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -305,8 +305,8 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain(Credentials.GOOGLE_DEFAULT_UNIVERSE)
             .setHttpTransportFactory(transportFactory)
             .build();
-    assertFalse(explicitUniverseCredentials.equals(otherCredentials));
-    assertFalse(otherCredentials.equals(explicitUniverseCredentials));
+    assertTrue(explicitUniverseCredentials.equals(otherExplicitUniverseCredentials));
+    assertTrue(otherExplicitUniverseCredentials.equals(explicitUniverseCredentials));
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -60,6 +60,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -359,6 +360,19 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(serverTransportFactory)
             .build();
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
+  }
+
+  @Test
+  public void toBuilder() {
+    ComputeEngineCredentials credentials =
+        ComputeEngineCredentials.newBuilder()
+            .setHttpTransportFactory(new MockMetadataServerTransportFactory())
+            .setQuotaProjectId("quota-project")
+            .build();
+
+    ComputeEngineCredentials secondCredentials = credentials.toBuilder().build();
+
+    assertEquals(credentials, secondCredentials);
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -284,7 +284,7 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
-  
+
   @Test
   public void toString_containsFields() throws IOException {
     MockMetadataServerTransportFactory serverTransportFactory =

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -284,19 +284,21 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     assertFalse(credentials.equals(otherCredentials));
     assertFalse(otherCredentials.equals(credentials));
   }
-
+  
   @Test
   public void toString_containsFields() throws IOException {
     MockMetadataServerTransportFactory serverTransportFactory =
         new MockMetadataServerTransportFactory();
     String expectedToString =
         String.format(
-            "ComputeEngineCredentials{transportFactoryClassName=%s}",
-            MockMetadataServerTransportFactory.class.getName());
-    ComputeEngineCredentials credentials =
+            "ComputeEngineCredentials{universeDomain=%s, transportFactoryClassName=%s, scopes=%s}",
+            "googleapis.com", MockMetadataServerTransportFactory.class.getName(), "[some scope]");
+    GoogleCredentials credentials =
         ComputeEngineCredentials.newBuilder()
             .setHttpTransportFactory(serverTransportFactory)
+            .setQuotaProjectId("some-project")
             .build();
+    credentials = credentials.createScoped("some scope");
     assertEquals(expectedToString, credentials.toString());
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -47,6 +47,7 @@ import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.ComputeEngineCredentialsTest.MockMetadataServerTransportFactory;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -105,16 +106,6 @@ public class DefaultCredentialsProviderTest {
   private static final String QUOTA_PROJECT_FROM_ENVIRONMENT = "environment-quota-project-id";
   private static final String QUOTA_PROJECT_EXPLICIT = "explicit-quota-project-id";
   private static final String SMBIOS_PATH_LINUX = "/sys/class/dmi/id/product_name";
-
-  static class MockRequestCountingTransportFactory implements HttpTransportFactory {
-
-    MockRequestCountingTransport transport = new MockRequestCountingTransport();
-
-    @Override
-    public HttpTransport create() {
-      return transport;
-    }
-  }
 
   @Test
   public void getDefaultCredentials_noCredentials_throws() {
@@ -760,7 +751,7 @@ public class DefaultCredentialsProviderTest {
    * End of types simulating SystemProperty.environment.value() to detect App Engine.
    */
 
-  private static class MockRequestCountingTransport extends MockHttpTransport {
+  static class MockRequestCountingTransport extends MockHttpTransport {
     int requestCount = 0;
 
     MockRequestCountingTransport() {}
@@ -854,6 +845,16 @@ public class DefaultCredentialsProviderTest {
 
     void setFileSandbox(boolean fileSandbox) {
       this.fileSandbox = fileSandbox;
+    }
+  }
+
+  static class MockRequestCountingTransportFactory implements HttpTransportFactory {
+
+    MockRequestCountingTransport transport = new MockRequestCountingTransport();
+
+    @Override
+    public HttpTransport create() {
+      return transport;
     }
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -197,6 +197,18 @@ public class DefaultCredentialsProviderTest {
   @Test
   public void getDefaultCredentials_static_linux() throws IOException {
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
+    testProvider.setProperty("os.name", "linux");
+    String productFilePath = SMBIOS_PATH_LINUX;
+    File productFile = new File(productFilePath);
+    InputStream productStream = new ByteArrayInputStream("Googlekdjsfhg".getBytes());
+    testProvider.addFile(productFile.getAbsolutePath(), productStream);
+
+    assertTrue(ComputeEngineCredentials.checkStaticGceDetection(testProvider));
+  }
+
+  @Test
+  public void getDefaultCredentials_static_Linux() throws IOException {
+    TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setProperty("os.name", "Linux");
     String productFilePath = SMBIOS_PATH_LINUX;
     File productFile = new File(productFilePath);

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -47,7 +47,6 @@ import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.ComputeEngineCredentialsTest.MockMetadataServerTransportFactory;
-import com.google.common.annotations.VisibleForTesting;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -197,18 +197,6 @@ public class DefaultCredentialsProviderTest {
   @Test
   public void getDefaultCredentials_static_linux() throws IOException {
     TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
-    testProvider.setProperty("os.name", "linux");
-    String productFilePath = SMBIOS_PATH_LINUX;
-    File productFile = new File(productFilePath);
-    InputStream productStream = new ByteArrayInputStream("Googlekdjsfhg".getBytes());
-    testProvider.addFile(productFile.getAbsolutePath(), productStream);
-
-    assertTrue(ComputeEngineCredentials.checkStaticGceDetection(testProvider));
-  }
-
-  @Test
-  public void getDefaultCredentials_static_Linux() throws IOException {
-    TestDefaultCredentialsProvider testProvider = new TestDefaultCredentialsProvider();
     testProvider.setProperty("os.name", "Linux");
     String productFilePath = SMBIOS_PATH_LINUX;
     File productFile = new File(productFilePath);

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -38,7 +38,6 @@ import com.google.api.client.util.Clock;
 import com.google.auth.Credentials;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
-import com.google.auth.oauth2.ComputeEngineCredentialsTest.MockMetadataServerTransportFactory;
 import com.google.auth.oauth2.ExternalAccountAuthorizedUserCredentialsTest.MockExternalAccountAuthorizedUserCredentialsTransportFactory;
 import com.google.auth.oauth2.IdentityPoolCredentialsTest.MockExternalAccountCredentialsTransportFactory;
 import com.google.auth.oauth2.ImpersonatedCredentialsTest.MockIAMCredentialsServiceTransportFactory;
@@ -778,22 +777,16 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
             "GoogleCredentials{quotaProjectId=%s, universeDomain=%s, isExplicitUniverseDomain=%s}",
             "some-project", "googleapis.com", false, "[some scope]");
     GoogleCredentials credentials =
-        GoogleCredentials.newBuilder()
-            .setQuotaProjectId("some-project")
-            .build();
+        GoogleCredentials.newBuilder().setQuotaProjectId("some-project").build();
     assertEquals(expectedToString, credentials.toString());
   }
 
   @Test
   public void hashCode_equals() throws IOException {
     GoogleCredentials credentials =
-        GoogleCredentials.newBuilder()
-            .setUniverseDomain("some-domain")
-            .build();
+        GoogleCredentials.newBuilder().setUniverseDomain("some-domain").build();
     GoogleCredentials otherCredentials =
-        GoogleCredentials.newBuilder()
-            .setUniverseDomain("some-domain")
-            .build();
+        GoogleCredentials.newBuilder().setUniverseDomain("some-domain").build();
     assertEquals(credentials.hashCode(), otherCredentials.hashCode());
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -38,6 +38,7 @@ import com.google.api.client.util.Clock;
 import com.google.auth.Credentials;
 import com.google.auth.TestUtils;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.auth.oauth2.ComputeEngineCredentialsTest.MockMetadataServerTransportFactory;
 import com.google.auth.oauth2.ExternalAccountAuthorizedUserCredentialsTest.MockExternalAccountAuthorizedUserCredentialsTransportFactory;
 import com.google.auth.oauth2.IdentityPoolCredentialsTest.MockExternalAccountCredentialsTransportFactory;
 import com.google.auth.oauth2.ImpersonatedCredentialsTest.MockIAMCredentialsServiceTransportFactory;
@@ -176,6 +177,7 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
 
     assertNotNull(credentials);
     assertEquals(GOOGLE_DEFAULT_UNIVERSE, credentials.getUniverseDomain());
+    assertEquals(false, credentials.isExplicitUniverseDomain());
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
@@ -198,6 +200,7 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
 
     assertNotNull(credentials);
     assertEquals(TPC_UNIVERSE, credentials.getUniverseDomain());
+    assertEquals(true, credentials.isExplicitUniverseDomain());
     credentials = credentials.createScoped(SCOPES);
     Map<String, List<String>> metadata = credentials.getRequestMetadata(CALL_URI);
     assertNotNull(((ServiceAccountCredentials) credentials).getSelfSignedJwtCredentialsWithScope());
@@ -705,7 +708,25 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void createWithQuotaProject() {
+  public void create_withoutUniverse() throws IOException {
+    AccessToken token = AccessToken.newBuilder().setTokenValue(ACCESS_TOKEN).build();
+    GoogleCredentials credentials = GoogleCredentials.create(token);
+
+    assertEquals(GOOGLE_DEFAULT_UNIVERSE, credentials.getUniverseDomain());
+    assertEquals(false, credentials.isExplicitUniverseDomain());
+  }
+
+  @Test
+  public void create_withUniverse() throws IOException {
+    AccessToken token = AccessToken.newBuilder().setTokenValue(ACCESS_TOKEN).build();
+    GoogleCredentials credentials = GoogleCredentials.create("some-universe", token);
+
+    assertEquals("some-universe", credentials.getUniverseDomain());
+    assertEquals(true, credentials.isExplicitUniverseDomain());
+  }
+
+  @Test
+  public void buildWithQuotaProject() {
     final GoogleCredentials googleCredentials =
         new GoogleCredentials.Builder().setQuotaProjectId("old_quota").build();
     GoogleCredentials withUpdatedQuota = googleCredentials.createWithQuotaProject("new_quota");
@@ -727,13 +748,17 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
     GoogleCredentials updated = original.toBuilder().setUniverseDomain("universe2").build();
 
     assertEquals("universe1", original.getUniverseDomain());
+    assertEquals(true, original.isExplicitUniverseDomain());
     assertEquals("universe2", updated.getUniverseDomain());
+    assertEquals(true, updated.isExplicitUniverseDomain());
 
     GoogleCredentials withEmpty = original.toBuilder().setUniverseDomain("").build();
     assertEquals(GOOGLE_DEFAULT_UNIVERSE, withEmpty.getUniverseDomain());
+    assertEquals(false, withEmpty.isExplicitUniverseDomain());
 
     GoogleCredentials withNull = original.toBuilder().setUniverseDomain(null).build();
     assertEquals(GOOGLE_DEFAULT_UNIVERSE, withNull.getUniverseDomain());
+    assertEquals(false, withNull.isExplicitUniverseDomain());
   }
 
   @Test
@@ -744,6 +769,42 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
     assertEquals(testCredentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(testCredentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
+  }
+
+  @Test
+  public void toString_containsFields() throws IOException {
+    String expectedToString =
+        String.format(
+            "GoogleCredentials{quotaProjectId=%s, universeDomain=%s, isExplicitUniverseDomain=%s}",
+            "some-project", "googleapis.com", false, "[some scope]");
+    GoogleCredentials credentials =
+        GoogleCredentials.newBuilder()
+            .setQuotaProjectId("some-project")
+            .build();
+    assertEquals(expectedToString, credentials.toString());
+  }
+
+  @Test
+  public void hashCode_equals() throws IOException {
+    GoogleCredentials credentials =
+        GoogleCredentials.newBuilder()
+            .setUniverseDomain("some-domain")
+            .build();
+    GoogleCredentials otherCredentials =
+        GoogleCredentials.newBuilder()
+            .setUniverseDomain("some-domain")
+            .build();
+    assertEquals(credentials.hashCode(), otherCredentials.hashCode());
+  }
+
+  @Test
+  public void equals_true() throws IOException {
+    GoogleCredentials credentials =
+        GoogleCredentials.newBuilder().setUniverseDomain("some-domain").build();
+    GoogleCredentials otherCredentials =
+        GoogleCredentials.newBuilder().setUniverseDomain("some-domain").build();
+    assertTrue(credentials.equals(otherCredentials));
+    assertTrue(otherCredentials.equals(credentials));
   }
 
   private static void testFromStreamException(InputStream stream, String expectedMessageContent) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -39,17 +39,13 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.io.BaseEncoding;
-import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Queue;
-import java.util.concurrent.Future;
 
 /** Transport that simulates the GCE metadata server for access tokens. */
 public class MockMetadataServerTransport extends MockHttpTransport {
@@ -124,9 +120,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
 
         String signature = signContents.toPrettyString();
 
-        return new MockLowLevelHttpResponse()
-            .setContentType(Json.MEDIA_TYPE)
-            .setContent(signature);
+        return new MockLowLevelHttpResponse().setContentType(Json.MEDIA_TYPE).setContent(signature);
       }
     };
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -39,18 +39,24 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.common.io.BaseEncoding;
+import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.Future;
 
 /** Transport that simulates the GCE metadata server for access tokens. */
 public class MockMetadataServerTransport extends MockHttpTransport {
 
   private String accessToken;
 
-  private Integer tokenRequestStatusCode;
+  private Integer requestStatusCode;
 
   private String serviceAccountEmail;
 
@@ -64,8 +70,8 @@ public class MockMetadataServerTransport extends MockHttpTransport {
     this.accessToken = accessToken;
   }
 
-  public void setTokenRequestStatusCode(Integer tokenRequestStatusCode) {
-    this.tokenRequestStatusCode = tokenRequestStatusCode;
+  public void setRequestStatusCode(Integer requestStatusCode) {
+    this.requestStatusCode = requestStatusCode;
   }
 
   public void setServiceAccountEmail(String serviceAccountEmail) {
@@ -83,134 +89,154 @@ public class MockMetadataServerTransport extends MockHttpTransport {
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
     if (url.equals(ComputeEngineCredentials.getTokenServerEncodedUrl())) {
-
-      return new MockLowLevelHttpRequest(url) {
-        @Override
-        public LowLevelHttpResponse execute() throws IOException {
-
-          if (tokenRequestStatusCode != null) {
-            return new MockLowLevelHttpResponse()
-                .setStatusCode(tokenRequestStatusCode)
-                .setContent("Token Fetch Error");
-          }
-
-          String metadataRequestHeader = getFirstHeaderValue("Metadata-Flavor");
-          if (!"Google".equals(metadataRequestHeader)) {
-            throw new IOException("Metadata request header not found.");
-          }
-
-          // Create the JSON response
-          GenericJson refreshContents = new GenericJson();
-          refreshContents.setFactory(OAuth2Utils.JSON_FACTORY);
-          refreshContents.put("access_token", accessToken);
-          refreshContents.put("expires_in", 3600000);
-          refreshContents.put("token_type", "Bearer");
-          String refreshText = refreshContents.toPrettyString();
-
-          return new MockLowLevelHttpResponse()
-              .setContentType(Json.MEDIA_TYPE)
-              .setContent(refreshText);
-        }
-      };
-    } else if (url.equals(ComputeEngineCredentials.getMetadataServerUrl())) {
-      return new MockLowLevelHttpRequest(url) {
-        @Override
-        public LowLevelHttpResponse execute() {
-          MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-          response.addHeader("Metadata-Flavor", "Google");
-          return response;
-        }
-      };
+      return getMockRequestForTokenEndpoint(url);
     } else if (isGetServiceAccountsUrl(url)) {
-      return new MockLowLevelHttpRequest(url) {
-        @Override
-        public LowLevelHttpResponse execute() throws IOException {
-          // Create the JSON response
-          GenericJson serviceAccountsContents = new GenericJson();
-          serviceAccountsContents.setFactory(OAuth2Utils.JSON_FACTORY);
-          GenericJson defaultAccount = new GenericJson();
-          defaultAccount.put("email", serviceAccountEmail);
-          serviceAccountsContents.put("default", defaultAccount);
-
-          String serviceAccounts = serviceAccountsContents.toPrettyString();
-
-          return new MockLowLevelHttpResponse()
-              .setContentType(Json.MEDIA_TYPE)
-              .setContent(serviceAccounts);
-        }
-      };
+      return getMockRequestForServiceAccount(url);
     } else if (isSignRequestUrl(url)) {
-      return new MockLowLevelHttpRequest(url) {
-        @Override
-        public LowLevelHttpResponse execute() throws IOException {
-          // Create the JSON response
-          GenericJson signContents = new GenericJson();
-          signContents.setFactory(OAuth2Utils.JSON_FACTORY);
-          signContents.put("signedBlob", BaseEncoding.base64().encode(signature));
-
-          String signature = signContents.toPrettyString();
-
-          return new MockLowLevelHttpResponse()
-              .setContentType(Json.MEDIA_TYPE)
-              .setContent(signature);
-        }
-      };
+      return getMockRequestForSign(url);
     } else if (isIdentityDocumentUrl(url)) {
-      if (idToken != null) {
-        return new MockLowLevelHttpRequest(url) {
-          @Override
-          public LowLevelHttpResponse execute() throws IOException {
-            return new MockLowLevelHttpResponse().setContent(idToken);
-          }
-        };
-      }
-
-      // https://cloud.google.com/compute/docs/instances/verifying-instance-identity#token_format
-      Map<String, String> queryPairs = new HashMap<String, String>();
-      String query = (new URL(url)).getQuery();
-      String[] pairs = query.split("&");
-      for (String pair : pairs) {
-        int idx = pair.indexOf("=");
-        queryPairs.put(
-            URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
-            URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
-      }
-
-      if (queryPairs.containsKey("format")) {
-        if (((String) queryPairs.get("format")).equals("full")) {
-
-          // return license only if format=full is set
-          if (queryPairs.containsKey("license")) {
-            if (((String) queryPairs.get("license")).equals("TRUE")) {
-              return new MockLowLevelHttpRequest(url) {
-                @Override
-                public LowLevelHttpResponse execute() throws IOException {
-                  return new MockLowLevelHttpResponse()
-                      .setContent(ComputeEngineCredentialsTest.FULL_ID_TOKEN_WITH_LICENSE);
-                }
-              };
-            }
-          }
-          // otherwise return full format
-          return new MockLowLevelHttpRequest(url) {
-            @Override
-            public LowLevelHttpResponse execute() throws IOException {
-              return new MockLowLevelHttpResponse()
-                  .setContent(ComputeEngineCredentialsTest.FULL_ID_TOKEN);
-            }
-          };
+      return getMockRequestForIdentityDocument(url);
+    }
+    return new MockLowLevelHttpRequest(url) {
+      @Override
+      public LowLevelHttpResponse execute() {
+        if (requestStatusCode != null) {
+          return new MockLowLevelHttpResponse()
+              .setStatusCode(requestStatusCode)
+              .setContent("Metadata Error");
         }
+
+        MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
+        response.addHeader("Metadata-Flavor", "Google");
+        return response;
       }
-      // Return default format if nothing is set
+    };
+  }
+
+  private MockLowLevelHttpRequest getMockRequestForSign(String url) {
+    return new MockLowLevelHttpRequest(url) {
+      @Override
+      public LowLevelHttpResponse execute() throws IOException {
+        // Create the JSON response
+        GenericJson signContents = new GenericJson();
+        signContents.setFactory(OAuth2Utils.JSON_FACTORY);
+        signContents.put("signedBlob", BaseEncoding.base64().encode(signature));
+
+        String signature = signContents.toPrettyString();
+
+        return new MockLowLevelHttpResponse()
+            .setContentType(Json.MEDIA_TYPE)
+            .setContent(signature);
+      }
+    };
+  }
+
+  private MockLowLevelHttpRequest getMockRequestForServiceAccount(String url) {
+    return new MockLowLevelHttpRequest(url) {
+      @Override
+      public LowLevelHttpResponse execute() throws IOException {
+        // Create the JSON response
+        GenericJson serviceAccountsContents = new GenericJson();
+        serviceAccountsContents.setFactory(OAuth2Utils.JSON_FACTORY);
+        GenericJson defaultAccount = new GenericJson();
+        defaultAccount.put("email", serviceAccountEmail);
+        serviceAccountsContents.put("default", defaultAccount);
+
+        String serviceAccounts = serviceAccountsContents.toPrettyString();
+
+        return new MockLowLevelHttpResponse()
+            .setContentType(Json.MEDIA_TYPE)
+            .setContent(serviceAccounts);
+      }
+    };
+  }
+
+  private MockLowLevelHttpRequest getMockRequestForTokenEndpoint(String url) {
+    return new MockLowLevelHttpRequest(url) {
+      @Override
+      public LowLevelHttpResponse execute() throws IOException {
+
+        if (requestStatusCode != null) {
+          return new MockLowLevelHttpResponse()
+              .setStatusCode(requestStatusCode)
+              .setContent("Token Fetch Error");
+        }
+
+        String metadataRequestHeader = getFirstHeaderValue("Metadata-Flavor");
+        if (!"Google".equals(metadataRequestHeader)) {
+          throw new IOException("Metadata request header not found.");
+        }
+
+        // Create the JSON response
+        GenericJson refreshContents = new GenericJson();
+        refreshContents.setFactory(OAuth2Utils.JSON_FACTORY);
+        refreshContents.put("access_token", accessToken);
+        refreshContents.put("expires_in", 3600000);
+        refreshContents.put("token_type", "Bearer");
+        String refreshText = refreshContents.toPrettyString();
+
+        return new MockLowLevelHttpResponse()
+            .setContentType(Json.MEDIA_TYPE)
+            .setContent(refreshText);
+      }
+    };
+  }
+
+  private MockLowLevelHttpRequest getMockRequestForIdentityDocument(String url)
+      throws MalformedURLException, UnsupportedEncodingException {
+    if (idToken != null) {
       return new MockLowLevelHttpRequest(url) {
         @Override
         public LowLevelHttpResponse execute() throws IOException {
-          return new MockLowLevelHttpResponse()
-              .setContent(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
+          return new MockLowLevelHttpResponse().setContent(idToken);
         }
       };
     }
-    return super.buildRequest(method, url);
+
+    // https://cloud.google.com/compute/docs/instances/verifying-instance-identity#token_format
+    Map<String, String> queryPairs = new HashMap<String, String>();
+    String query = (new URL(url)).getQuery();
+    String[] pairs = query.split("&");
+    for (String pair : pairs) {
+      int idx = pair.indexOf("=");
+      queryPairs.put(
+          URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
+          URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+    }
+
+    if (queryPairs.containsKey("format")) {
+      if (((String) queryPairs.get("format")).equals("full")) {
+
+        // return license only if format=full is set
+        if (queryPairs.containsKey("license")) {
+          if (((String) queryPairs.get("license")).equals("TRUE")) {
+            return new MockLowLevelHttpRequest(url) {
+              @Override
+              public LowLevelHttpResponse execute() throws IOException {
+                return new MockLowLevelHttpResponse()
+                    .setContent(ComputeEngineCredentialsTest.FULL_ID_TOKEN_WITH_LICENSE);
+              }
+            };
+          }
+        }
+        // otherwise return full format
+        return new MockLowLevelHttpRequest(url) {
+          @Override
+          public LowLevelHttpResponse execute() throws IOException {
+            return new MockLowLevelHttpResponse()
+                .setContent(ComputeEngineCredentialsTest.FULL_ID_TOKEN);
+          }
+        };
+      }
+    }
+    // Return default format if nothing is set
+    return new MockLowLevelHttpRequest(url) {
+      @Override
+      public LowLevelHttpResponse execute() throws IOException {
+        return new MockLowLevelHttpResponse()
+            .setContent(ComputeEngineCredentialsTest.STANDARD_ID_TOKEN);
+      }
+    };
   }
 
   protected boolean isGetServiceAccountsUrl(String url) {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -382,6 +382,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     }
 
     GoogleCredentials scopedCredentials = credentials.createScoped(SCOPES);
+    assertEquals(false, credentials.isExplicitUniverseDomain());
+    assertEquals(GOOGLE_DEFAULT_UNIVERSE, credentials.getUniverseDomain());
     Map<String, List<String>> metadata = scopedCredentials.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadata, ACCESS_TOKEN);
   }
@@ -406,6 +408,8 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
     // Recreate to avoid jwt caching.
     scopedCredentials = credentials.createScoped("dummy.scope2");
+    assertEquals(true, scopedCredentials.isExplicitUniverseDomain());
+    assertEquals("foo.bar", scopedCredentials.getUniverseDomain());
     metadata = scopedCredentials.getRequestMetadata(CALL_URI);
     verifyJwtAccess(metadata, "dummy.scope2");
 
@@ -1154,7 +1158,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
     OAuth2Credentials credentials = ServiceAccountCredentials.fromPkcs8(PRIVATE_KEY_PKCS8, builder);
     String expectedToString =
         String.format(
-            "ServiceAccountCredentials{quotaProjectId=%s, universeDomain=%s, clientId=%s, clientEmail=%s, "
+            "ServiceAccountCredentials{quotaProjectId=%s, universeDomain=%s, isExplicitUniverseDomain=false, clientId=%s, clientEmail=%s, "
                 + "privateKeyId=%s, transportFactoryClassName=%s, tokenServerUri=%s, scopes=%s, defaultScopes=%s, "
                 + "serviceAccountUser=%s, lifetime=3600, useJwtAccessWithScope=false, defaultRetriesEnabled=true}",
             QUOTA_PROJECT,


### PR DESCRIPTION
This adds universe domain support to GCE credentials.


In case explicit universe_domain was provided - it takes priority
Otherwise - GCE credential tries to obtain a universe domain from Metadata service

If request fails with 404 or request returns an empty string - universe domain is set to GDU
If any other error - throws a retryable exception
