### PR TITLE
feat: Support Workload Identity Federation on AWS ECS/Fargate

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockExternalAccountCredentialsTransport.java
@@ -66,6 +66,9 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
       "https://www.googleapis.com/auth/cloud-platform";
   private static final String ISSUED_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
   private static final String AWS_CREDENTIALS_URL = "https://169.254.169.254";
+
+  private static final String AWS_CREDENTIALS_URL_ON_ECS =
+      "http://169.254.170.2/v2/credentials/some-uuid";
   private static final String AWS_REGION_URL = "https://169.254.169.254/region";
   private static final String AWS_IMDSV2_SESSION_TOKEN_URL = "https://169.254.169.254/imdsv2";
   private static final String METADATA_SERVER_URL = "https://www.metadata.google.com";
@@ -142,6 +145,18 @@ public class MockExternalAccountCredentialsTransport extends MockHttpTransport {
             if ((AWS_CREDENTIALS_URL + "/" + "roleName").equals(url)) {
               GenericJson response = new GenericJson();
               response.setFactory(JSON_FACTORY);
+              response.put("AccessKeyId", "accessKeyId");
+              response.put("SecretAccessKey", "secretAccessKey");
+              response.put("Token", "token");
+
+              return new MockLowLevelHttpResponse()
+                  .setContentType(Json.MEDIA_TYPE)
+                  .setContent(response.toString());
+            }
+            if ((AWS_CREDENTIALS_URL_ON_ECS).equals(url)) {
+              GenericJson response = new GenericJson();
+              response.setFactory(JSON_FACTORY);
+              response.put("RoleArn", "arn:aws:iam::012345678912:role/ecs-task-role");
               response.put("AccessKeyId", "accessKeyId");
               response.put("SecretAccessKey", "secretAccessKey");
               response.put("Token", "token");


### PR DESCRIPTION
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #957 ☕️

This PR adds functionality to detect if the code is running in an ECS container. In that case, the private container metadata endpoint is used to obtain temporary credentials. 

This makes it possible to use Workload Identity Federation on ECS without using a workaround like manually obtaining temporary session credentials and exporting them as env vars (see [here](https://stackoverflow.com/a/72588646/2429404)).

I was able to successfully test this PR by running an ECS task which connects to Bigquery via Workload Identity Federation.