### PR TITLE
fix: Remove Base64 padding in DefaultPKCEProvider

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultPKCEProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultPKCEProvider.java
@@ -90,7 +90,7 @@ public class DefaultPKCEProvider implements PKCEProvider {
 
         byte[] digest = md.digest();
 
-        this.codeChallenge = Base64.getUrlEncoder().encodeToString(digest);
+        this.codeChallenge = Base64.getUrlEncoder().encodeToString(digest).replace("=", "");
         this.codeChallengeMethod = "S256";
       } catch (NoSuchAlgorithmException e) {
         this.codeChallenge = codeVerifier;

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultPKCEProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultPKCEProviderTest.java
@@ -32,6 +32,7 @@
 package com.google.auth.oauth2;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -57,5 +58,12 @@ public final class DefaultPKCEProviderTest {
 
     assertEquals(pkce.getCodeChallenge(), expectedCodeChallenge);
     assertEquals(pkce.getCodeChallengeMethod(), expectedCodeChallengeMethod);
+  }
+
+  @Test
+  public void testNoBase64Padding() throws NoSuchAlgorithmException {
+    PKCEProvider pkce = new DefaultPKCEProvider();
+    assertFalse(pkce.getCodeChallenge().endsWith("="));
+    assertFalse(pkce.getCodeChallenge().contains("="));
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultPKCEProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultPKCEProviderTest.java
@@ -53,7 +53,7 @@ public final class DefaultPKCEProviderTest {
 
     byte[] digest = md.digest();
 
-    String expectedCodeChallenge = Base64.getUrlEncoder().encodeToString(digest);
+    String expectedCodeChallenge = Base64.getUrlEncoder().encodeToString(digest).replace("=", "");
     String expectedCodeChallengeMethod = "S256";
 
     assertEquals(pkce.getCodeChallenge(), expectedCodeChallenge);


### PR DESCRIPTION
Fixes
https://github.com/googleapis/google-auth-library-java/issues/1373.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
