### PR TITLE
chore: remove DocFX profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,54 +427,5 @@
         </plugins>
       </build>
     </profile>
-
-    <profile>
-      <id>docFX</id>
-      <activation>
-        <property>
-          <!-- Activate with -P docFX -->
-          <name>docFX</name>
-        </property>
-      </activation>
-      <properties>
-        <!-- default config values -->
-        <docletName>java-docfx-doclet-1.9.0</docletName>
-        <outputpath>${project.build.directory}/docfx-yml</outputpath>
-        <projectname>${project.artifactId}</projectname>
-        <excludeclasses></excludeclasses>
-        <excludePackages></excludePackages>
-        <source>8</source>
-        <sourceFileExclude></sourceFileExclude>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.0</version>
-            <configuration>
-              <doclet>com.microsoft.doclet.DocFxDoclet</doclet>
-              <useStandardDocletOptions>false</useStandardDocletOptions>
-              <!-- custom config with -Dproperty=value -->
-              <docletPath>${env.KOKORO_GFILE_DIR}/${docletName}.jar</docletPath>
-              <additionalOptions>
-                -outputpath ${outputpath}
-                -projectname ${projectname}
-                -excludeclasses ${excludeclasses}:
-                -excludepackages ${excludePackages}:
-              </additionalOptions>
-              <doclint>none</doclint>
-              <show>protected</show>
-              <nohelp>true</nohelp>
-              <source>${source}</source>
-              <sourceFileExcludes>
-                <exclude>${sourceFileExclude}</exclude>
-              </sourceFileExcludes>
-              <failOnError>false</failOnError>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
google-auth-library should inherit the DocFX profile from java-shared-config: https://github.com/googleapis/java-shared-config/blob/main/java-shared-config/pom.xml#L570

Removing this profile as it's causing issues with javadoc generation