### PR TITLE
feat: adding support for authentication type on UserAuthorizer

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -43,6 +43,7 @@ import com.google.api.client.util.PemReader.Section;
 import com.google.api.client.util.SecurityUtils;
 import com.google.auth.http.AuthHttpConstants;
 import com.google.auth.http.HttpTransportFactory;
+import com.google.common.io.BaseEncoding;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -250,6 +251,19 @@ class OAuth2Utils {
       unexpectedException = exception;
     }
     throw new IOException("Unexpected exception reading PKCS#8 data", unexpectedException);
+  }
+
+  /**
+   * A helper function to get a base64 encoded basic auth.
+   *
+   * @param clientId A ClientId object which contains a string value and a secret
+   * @return The basic auth header
+   */
+  public static String getBasicAuthString(ClientId clientId) {
+    String encodedCredentials =
+        BaseEncoding.base64()
+            .encode((clientId.getClientId() + ":" + clientId.getClientSecret()).getBytes());
+    return "Basic " + encodedCredentials;
   }
 
   private OAuth2Utils() {}

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -332,9 +332,8 @@ public class UserAuthorizer {
     tokenRequest.setParser(new JsonObjectParser(OAuth2Utils.JSON_FACTORY));
 
     if (this.clientAuthenticationType == ClientAuthenticationType.CLIENT_SECRET_BASIC) {
-      BaseEncoding base64 = BaseEncoding.base64();
       String encodedCredentials =
-          base64.encode((clientId.getClientId() + ":" + clientId.getClientSecret()).getBytes());
+          BaseEncoding.base64().encode((clientId.getClientId() + ":" + clientId.getClientSecret()).getBytes());
       tokenRequest.getHeaders().setAuthorization("Basic " + encodedCredentials);
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -95,8 +95,7 @@ public class UserAuthorizer {
    * @param tokenServerUri URI of the end point that provides tokens
    * @param userAuthUri URI of the Web UI for user consent
    * @param pkce PKCE implementation
-   * @param clientAuthentication ClientAuthentication type as defined in RFC 7591
-   *     basic/post/none
+   * @param clientAuthentication ClientAuthentication type as defined in RFC 7591 basic/post/none
    */
   private UserAuthorizer(
       ClientId clientId,

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -85,7 +85,7 @@ public class UserAuthorizer {
    * @param tokenServerUri URI of the end point that provides tokens
    * @param userAuthUri URI of the Web UI for user consent
    * @param pkce PKCE implementation
-   * @param clientAuthenticationType ClientAuthentication type in RFC7591. Choice from
+   * @param clientAuthenticationType ClientAuthentication type as defined in RFC 7591
    *     basic/post/none
    */
   private UserAuthorizer(

--- a/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
+++ b/oauth2_http/java/com/google/auth/oauth2/UserAuthorizer.java
@@ -57,6 +57,17 @@ import java.util.Map;
 /** Handles an interactive 3-Legged-OAuth2 (3LO) user consent authorization. */
 public class UserAuthorizer {
 
+  /**
+   * Represents the client authentication types as specified in RFC 7591.
+   *
+   * <p>For more details, see <a href="https://tools.ietf.org/html/rfc7591">RFC 7591</a>.
+   */
+  public enum ClientAuthenticationType {
+    CLIENT_SECRET_POST,
+    CLIENT_SECRET_BASIC,
+    NONE
+  }
+
   static final URI DEFAULT_CALLBACK_URI = URI.create("/oauth2callback");
 
   private final String TOKEN_STORE_ERROR = "Error parsing stored token data.";
@@ -171,9 +182,9 @@ public class UserAuthorizer {
   }
 
   /**
-   * Returns the client authentication type in RFC7591
+   * Returns the client authentication type as defined in RFC 7591.
    *
-   * @return The ClientAuthenticationType
+   * @return The {@link ClientAuthenticationType}
    */
   public ClientAuthenticationType getClientAuthenticationType() {
     return clientAuthenticationType;
@@ -333,7 +344,8 @@ public class UserAuthorizer {
 
     if (this.clientAuthenticationType == ClientAuthenticationType.CLIENT_SECRET_BASIC) {
       String encodedCredentials =
-          BaseEncoding.base64().encode((clientId.getClientId() + ":" + clientId.getClientSecret()).getBytes());
+          BaseEncoding.base64()
+              .encode((clientId.getClientId() + ":" + clientId.getClientSecret()).getBytes());
       tokenRequest.getHeaders().setAuthorization("Basic " + encodedCredentials);
     }
 
@@ -640,11 +652,5 @@ public class UserAuthorizer {
           pkce,
           clientAuthenticationType);
     }
-  }
-
-  public enum ClientAuthenticationType {
-    CLIENT_SECRET_POST,
-    CLIENT_SECRET_BASIC,
-    NONE
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -97,6 +97,10 @@ public class MockTokenServerTransport extends MockHttpTransport {
     }
   }
 
+  public void addHeader(String header, String value) {
+    clients.put(header, value);
+  }
+
   public void addClient(String clientId, String clientSecret) {
     clients.put(clientId, clientSecret);
   }
@@ -206,7 +210,8 @@ public class MockTokenServerTransport extends MockHttpTransport {
             }
             String foundSecret = query.get("client_secret");
             String expectedSecret = clients.get(foundId);
-            if (foundSecret == null || !foundSecret.equals(expectedSecret)) {
+            if ((foundSecret == null || !foundSecret.equals(expectedSecret))
+                && clients.get("Authorization") == null) {
               throw new IOException("Client secret not found.");
             }
             String grantType = query.get("grant_type");

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -42,7 +42,6 @@ import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.auth.TestUtils;
-import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.net.URI;
@@ -72,6 +71,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
   private IOException error;
   private final Queue<Future<LowLevelHttpResponse>> responseSequence = new ArrayDeque<>();
   private int expiresInSeconds = 3600;
+  private boolean checkSecret = true;
   private MockLowLevelHttpRequest request;
 
   public MockTokenServerTransport() {}
@@ -215,7 +215,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
                 }
                 String foundSecret = query.get("client_secret");
                 String expectedSecret = clients.get(foundId);
-                if ((foundSecret == null || !foundSecret.equals(expectedSecret)) && !authorized()) {
+                if ((foundSecret == null || !foundSecret.equals(expectedSecret)) && checkSecret) {
                   throw new IOException("Client secret not found.");
                 }
                 String grantType = query.get("grant_type");
@@ -353,7 +353,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
     return super.buildRequest(method, url);
   }
 
-  protected boolean authorized() {
-    return request.getHeaders().containsKey("Authorization");
+  public void disableSecretCheck() {
+    checkSecret = false;
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -72,6 +72,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
   private IOException error;
   private final Queue<Future<LowLevelHttpResponse>> responseSequence = new ArrayDeque<>();
   private int expiresInSeconds = 3600;
+  private MockLowLevelHttpRequest request;
 
   public MockTokenServerTransport() {}
 
@@ -165,6 +166,10 @@ public class MockTokenServerTransport extends MockHttpTransport {
     this.expiresInSeconds = expiresInSeconds;
   }
 
+  public MockLowLevelHttpRequest getRequest() {
+    return request;
+  }
+
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
     buildRequestCount++;
@@ -176,191 +181,196 @@ public class MockTokenServerTransport extends MockHttpTransport {
     final String query = (questionMarkPos > 0) ? url.substring(questionMarkPos + 1) : "";
 
     if (!responseSequence.isEmpty()) {
-      return new MockLowLevelHttpRequest(url) {
-        @Override
-        public LowLevelHttpResponse execute() throws IOException {
-          try {
-            return responseSequence.poll().get();
-          } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            throw (IOException) cause;
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException("Unexpectedly interrupted");
-          }
-        }
-      };
+      request =
+          new MockLowLevelHttpRequest(url) {
+            @Override
+            public LowLevelHttpResponse execute() throws IOException {
+              try {
+                return responseSequence.poll().get();
+              } catch (ExecutionException e) {
+                Throwable cause = e.getCause();
+                throw (IOException) cause;
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException("Unexpectedly interrupted");
+              }
+            }
+          };
+      return request;
     }
 
     if (urlWithoutQuery.equals(tokenServerUri.toString())) {
-      return new MockLowLevelHttpRequest(url) {
-        @Override
-        public LowLevelHttpResponse execute() throws IOException {
+      request =
+          new MockLowLevelHttpRequest(url) {
+            @Override
+            public LowLevelHttpResponse execute() throws IOException {
 
-          if (!responseSequence.isEmpty()) {
-            try {
-              return responseSequence.poll().get();
-            } catch (ExecutionException e) {
-              Throwable cause = e.getCause();
-              throw (IOException) cause;
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-              throw new RuntimeException("Unexpectedly interrupted");
-            }
-          }
-
-          String content = this.getContentAsString();
-          Map<String, String> query = TestUtils.parseQuery(content);
-          String accessToken = null;
-          String refreshToken = null;
-          String grantedScopesString = null;
-          boolean generateAccessToken = true;
-
-          String foundId = query.get("client_id");
-          boolean isUserEmailScope = false;
-          if (foundId != null) {
-            if (!clients.containsKey(foundId)) {
-              throw new IOException("Client ID not found.");
-            }
-            String foundSecret = query.get("client_secret");
-            String expectedSecret = clients.get(foundId);
-            if ((foundSecret == null || !foundSecret.equals(expectedSecret))
-                && !authorized(foundId)) {
-              throw new IOException("Client secret not found.");
-            }
-            String grantType = query.get("grant_type");
-            if (grantType != null && grantType.equals("authorization_code")) {
-              String foundCode = query.get("code");
-              if (!codes.containsKey(foundCode)) {
-                throw new IOException("Authorization code not found");
-              }
-              refreshToken = codes.get(foundCode);
-            } else {
-              refreshToken = query.get("refresh_token");
-            }
-            if (!refreshTokens.containsKey(refreshToken)) {
-              throw new IOException("Refresh Token not found.");
-            }
-            if (refreshToken.equals(REFRESH_TOKEN_WITH_USER_SCOPE)) {
-              isUserEmailScope = true;
-            }
-            accessToken = refreshTokens.get(refreshToken);
-
-            if (grantedScopes.containsKey(refreshToken)) {
-              grantedScopesString = grantedScopes.get(refreshToken);
-            }
-
-            if (additionalParameters.containsKey(refreshToken)) {
-              Map<String, String> additionalParametersMap = additionalParameters.get(refreshToken);
-              for (Map.Entry<String, String> entry : additionalParametersMap.entrySet()) {
-                String key = entry.getKey();
-                String expectedValue = entry.getValue();
-                if (!query.containsKey(key)) {
-                  throw new IllegalArgumentException("Missing additional parameter: " + key);
-                } else {
-                  String actualValue = query.get(key);
-                  if (!expectedValue.equals(actualValue)) {
-                    throw new IllegalArgumentException(
-                        "For additional parameter "
-                            + key
-                            + ", Actual value: "
-                            + actualValue
-                            + ", Expected value: "
-                            + expectedValue);
-                  }
+              if (!responseSequence.isEmpty()) {
+                try {
+                  return responseSequence.poll().get();
+                } catch (ExecutionException e) {
+                  Throwable cause = e.getCause();
+                  throw (IOException) cause;
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new RuntimeException("Unexpectedly interrupted");
                 }
               }
+
+              String content = this.getContentAsString();
+              Map<String, String> query = TestUtils.parseQuery(content);
+              String accessToken = null;
+              String refreshToken = null;
+              String grantedScopesString = null;
+              boolean generateAccessToken = true;
+
+              String foundId = query.get("client_id");
+              boolean isUserEmailScope = false;
+              if (foundId != null) {
+                if (!clients.containsKey(foundId)) {
+                  throw new IOException("Client ID not found.");
+                }
+                String foundSecret = query.get("client_secret");
+                String expectedSecret = clients.get(foundId);
+                if ((foundSecret == null || !foundSecret.equals(expectedSecret)) && !authorized()) {
+                  throw new IOException("Client secret not found.");
+                }
+                String grantType = query.get("grant_type");
+                if (grantType != null && grantType.equals("authorization_code")) {
+                  String foundCode = query.get("code");
+                  if (!codes.containsKey(foundCode)) {
+                    throw new IOException("Authorization code not found");
+                  }
+                  refreshToken = codes.get(foundCode);
+                } else {
+                  refreshToken = query.get("refresh_token");
+                }
+                if (!refreshTokens.containsKey(refreshToken)) {
+                  throw new IOException("Refresh Token not found.");
+                }
+                if (refreshToken.equals(REFRESH_TOKEN_WITH_USER_SCOPE)) {
+                  isUserEmailScope = true;
+                }
+                accessToken = refreshTokens.get(refreshToken);
+
+                if (grantedScopes.containsKey(refreshToken)) {
+                  grantedScopesString = grantedScopes.get(refreshToken);
+                }
+
+                if (additionalParameters.containsKey(refreshToken)) {
+                  Map<String, String> additionalParametersMap =
+                      additionalParameters.get(refreshToken);
+                  for (Map.Entry<String, String> entry : additionalParametersMap.entrySet()) {
+                    String key = entry.getKey();
+                    String expectedValue = entry.getValue();
+                    if (!query.containsKey(key)) {
+                      throw new IllegalArgumentException("Missing additional parameter: " + key);
+                    } else {
+                      String actualValue = query.get(key);
+                      if (!expectedValue.equals(actualValue)) {
+                        throw new IllegalArgumentException(
+                            "For additional parameter "
+                                + key
+                                + ", Actual value: "
+                                + actualValue
+                                + ", Expected value: "
+                                + expectedValue);
+                      }
+                    }
+                  }
+                }
+
+              } else if (query.containsKey("grant_type")) {
+                String grantType = query.get("grant_type");
+                String assertion = query.get("assertion");
+                JsonWebSignature signature = JsonWebSignature.parse(JSON_FACTORY, assertion);
+                if (OAuth2Utils.GRANT_TYPE_JWT_BEARER.equals(grantType)) {
+                  String foundEmail = signature.getPayload().getIssuer();
+                  if (!serviceAccounts.containsKey(foundEmail)) {}
+                  accessToken = serviceAccounts.get(foundEmail);
+                  String foundTargetAudience =
+                      (String) signature.getPayload().get("target_audience");
+                  String foundScopes = (String) signature.getPayload().get("scope");
+                  if ((foundScopes == null || foundScopes.length() == 0)
+                      && (foundTargetAudience == null || foundTargetAudience.length() == 0)) {
+                    throw new IOException("Either target_audience or scopes must be specified.");
+                  }
+
+                  if (foundScopes != null && foundTargetAudience != null) {
+                    throw new IOException(
+                        "Only one of target_audience or scopes must be specified.");
+                  }
+                  if (foundTargetAudience != null) {
+                    generateAccessToken = false;
+                  }
+
+                  // For GDCH scenario
+                } else if (OAuth2Utils.TOKEN_TYPE_TOKEN_EXCHANGE.equals(grantType)) {
+                  String foundServiceIdentityName = signature.getPayload().getIssuer();
+                  if (!gdchServiceAccounts.containsKey(foundServiceIdentityName)) {
+                    throw new IOException(
+                        "GDCH Service Account Service Identity Name not found as issuer.");
+                  }
+                  accessToken = gdchServiceAccounts.get(foundServiceIdentityName);
+                  String foundApiAudience = (String) signature.getPayload().get("api_audience");
+                  if ((foundApiAudience == null || foundApiAudience.length() == 0)) {
+                    throw new IOException("Api_audience must be specified.");
+                  }
+                } else {
+                  throw new IOException("Service Account Email not found as issuer.");
+                }
+              } else {
+                throw new IOException("Unknown token type.");
+              }
+
+              // Create the JSON response
+              // https://developers.google.com/identity/protocols/OpenIDConnect#server-flow
+              GenericJson responseContents = new GenericJson();
+              responseContents.setFactory(JSON_FACTORY);
+              responseContents.put("token_type", "Bearer");
+              responseContents.put("expires_in", expiresInSeconds);
+              if (generateAccessToken) {
+                responseContents.put("access_token", accessToken);
+                if (refreshToken != null) {
+                  responseContents.put("refresh_token", refreshToken);
+                }
+                if (grantedScopesString != null) {
+                  responseContents.put("scope", grantedScopesString);
+                }
+              }
+              if (isUserEmailScope || !generateAccessToken) {
+                responseContents.put("id_token", ServiceAccountCredentialsTest.DEFAULT_ID_TOKEN);
+              }
+              String refreshText = responseContents.toPrettyString();
+
+              return new MockLowLevelHttpResponse()
+                  .setContentType(Json.MEDIA_TYPE)
+                  .setContent(refreshText);
             }
-
-          } else if (query.containsKey("grant_type")) {
-            String grantType = query.get("grant_type");
-            String assertion = query.get("assertion");
-            JsonWebSignature signature = JsonWebSignature.parse(JSON_FACTORY, assertion);
-            if (OAuth2Utils.GRANT_TYPE_JWT_BEARER.equals(grantType)) {
-              String foundEmail = signature.getPayload().getIssuer();
-              if (!serviceAccounts.containsKey(foundEmail)) {}
-              accessToken = serviceAccounts.get(foundEmail);
-              String foundTargetAudience = (String) signature.getPayload().get("target_audience");
-              String foundScopes = (String) signature.getPayload().get("scope");
-              if ((foundScopes == null || foundScopes.length() == 0)
-                  && (foundTargetAudience == null || foundTargetAudience.length() == 0)) {
-                throw new IOException("Either target_audience or scopes must be specified.");
-              }
-
-              if (foundScopes != null && foundTargetAudience != null) {
-                throw new IOException("Only one of target_audience or scopes must be specified.");
-              }
-              if (foundTargetAudience != null) {
-                generateAccessToken = false;
-              }
-
-              // For GDCH scenario
-            } else if (OAuth2Utils.TOKEN_TYPE_TOKEN_EXCHANGE.equals(grantType)) {
-              String foundServiceIdentityName = signature.getPayload().getIssuer();
-              if (!gdchServiceAccounts.containsKey(foundServiceIdentityName)) {
-                throw new IOException(
-                    "GDCH Service Account Service Identity Name not found as issuer.");
-              }
-              accessToken = gdchServiceAccounts.get(foundServiceIdentityName);
-              String foundApiAudience = (String) signature.getPayload().get("api_audience");
-              if ((foundApiAudience == null || foundApiAudience.length() == 0)) {
-                throw new IOException("Api_audience must be specified.");
-              }
-            } else {
-              throw new IOException("Service Account Email not found as issuer.");
-            }
-          } else {
-            throw new IOException("Unknown token type.");
-          }
-
-          // Create the JSON response
-          // https://developers.google.com/identity/protocols/OpenIDConnect#server-flow
-          GenericJson responseContents = new GenericJson();
-          responseContents.setFactory(JSON_FACTORY);
-          responseContents.put("token_type", "Bearer");
-          responseContents.put("expires_in", expiresInSeconds);
-          if (generateAccessToken) {
-            responseContents.put("access_token", accessToken);
-            if (refreshToken != null) {
-              responseContents.put("refresh_token", refreshToken);
-            }
-            if (grantedScopesString != null) {
-              responseContents.put("scope", grantedScopesString);
-            }
-          }
-          if (isUserEmailScope || !generateAccessToken) {
-            responseContents.put("id_token", ServiceAccountCredentialsTest.DEFAULT_ID_TOKEN);
-          }
-          String refreshText = responseContents.toPrettyString();
-
-          return new MockLowLevelHttpResponse()
-              .setContentType(Json.MEDIA_TYPE)
-              .setContent(refreshText);
-        }
-      };
+          };
+      return request;
     } else if (urlWithoutQuery.equals(OAuth2Utils.TOKEN_REVOKE_URI.toString())) {
-      return new MockLowLevelHttpRequest(url) {
-        @Override
-        public LowLevelHttpResponse execute() throws IOException {
-          Map<String, String> parameters = TestUtils.parseQuery(this.getContentAsString());
-          String token = parameters.get("token");
-          if (token == null) {
-            throw new IOException("Token to revoke not found.");
-          }
-          // Token could be access token or refresh token so remove keys and values
-          refreshTokens.values().removeAll(Collections.singleton(token));
-          refreshTokens.remove(token);
-          return new MockLowLevelHttpResponse().setContentType(Json.MEDIA_TYPE);
-        }
-      };
+      request =
+          new MockLowLevelHttpRequest(url) {
+            @Override
+            public LowLevelHttpResponse execute() throws IOException {
+              Map<String, String> parameters = TestUtils.parseQuery(this.getContentAsString());
+              String token = parameters.get("token");
+              if (token == null) {
+                throw new IOException("Token to revoke not found.");
+              }
+              // Token could be access token or refresh token so remove keys and values
+              refreshTokens.values().removeAll(Collections.singleton(token));
+              refreshTokens.remove(token);
+              return new MockLowLevelHttpResponse().setContentType(Json.MEDIA_TYPE);
+            }
+          };
+      return request;
     }
     return super.buildRequest(method, url);
   }
 
-  protected boolean authorized(String foundId) {
-    if (!additionalParameters.containsKey(foundId)) {
-      return false;
-    }
-    return !additionalParameters.get(foundId).containsKey("Authorization");
+  protected boolean authorized() {
+    return request.getHeaders().containsKey("Authorization");
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -99,23 +99,6 @@ public class MockTokenServerTransport extends MockHttpTransport {
     }
   }
 
-  public void addHeader(String clientId, String header, String value) throws IOException {
-    if (!clients.containsKey(clientId)) {
-      throw new IOException("No such client Id");
-    }
-    if (header.equalsIgnoreCase("Authorization")) {
-      String clientSecret = clients.get(clientId);
-      String expectValue =
-          "Basic " + BaseEncoding.base64().encode((clientId + ":" + clientSecret).getBytes());
-      if (!expectValue.equalsIgnoreCase(value)) {
-        throw new IOException("Unexpected Auth header");
-      }
-    }
-    Map<String, String> headers = new HashMap<>();
-    headers.put(header, value);
-    additionalParameters.put(clientId, headers);
-  }
-
   public void addClient(String clientId, String clientSecret) {
     clients.put(clientId, clientSecret);
   }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -106,7 +106,7 @@ public class MockTokenServerTransport extends MockHttpTransport {
       String clientSecret = clients.get(clientId);
       String expectValue =
           "Basic " + BaseEncoding.base64().encode((clientId + ":" + clientSecret).getBytes());
-      if (expectValue.equalsIgnoreCase(value)) {
+      if (!expectValue.equalsIgnoreCase(value)) {
         throw new IOException("Unexpected Auth header");
       }
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -171,7 +171,7 @@ public class UserAuthorizerTest {
     String expectBasicAuthHeader =
         "Basic " + BaseEncoding.base64().encode((CLIENT_ID_VALUE + ":" + CLIENT_SECRET).getBytes());
 
-    assertEquals(expectBasicAuthHeader, UserAuthorizer.getBasicAuthString(CLIENT_ID));
+    assertEquals(expectBasicAuthHeader, OAuth2Utils.getBasicAuthString(CLIENT_ID));
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -90,6 +90,9 @@ public class UserAuthorizerTest {
     assertSame(store, authorizer.getTokenStore());
     assertEquals(DUMMY_SCOPES, authorizer.getScopes());
     assertEquals(UserAuthorizer.DEFAULT_CALLBACK_URI, authorizer.getCallbackUri());
+    assertEquals(
+        UserAuthorizer.ClientAuthenticationType.CLIENT_SECRET_POST,
+        authorizer.getClientAuthenticationType());
   }
 
   @Test
@@ -102,12 +105,38 @@ public class UserAuthorizerTest {
             .setScopes(DUMMY_SCOPES)
             .setTokenStore(store)
             .setCallbackUri(CALLBACK_URI)
+            .setClientAuthenticationType(
+                UserAuthorizer.ClientAuthenticationType.CLIENT_SECRET_BASIC)
             .build();
 
     assertSame(CLIENT_ID, authorizer.getClientId());
     assertSame(store, authorizer.getTokenStore());
     assertEquals(DUMMY_SCOPES, authorizer.getScopes());
     assertEquals(CALLBACK_URI, authorizer.getCallbackUri());
+    assertEquals(
+        UserAuthorizer.ClientAuthenticationType.CLIENT_SECRET_BASIC,
+        authorizer.getClientAuthenticationType());
+  }
+
+  @Test
+  public void constructorWithClientAuthenticationTypeNone() {
+    TokenStore store = new MemoryTokensStorage();
+
+    UserAuthorizer authorizer =
+        UserAuthorizer.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setScopes(DUMMY_SCOPES)
+            .setTokenStore(store)
+            .setCallbackUri(CALLBACK_URI)
+            .setClientAuthenticationType(UserAuthorizer.ClientAuthenticationType.NONE)
+            .build();
+
+    assertSame(CLIENT_ID, authorizer.getClientId());
+    assertSame(store, authorizer.getTokenStore());
+    assertEquals(DUMMY_SCOPES, authorizer.getScopes());
+    assertEquals(CALLBACK_URI, authorizer.getCallbackUri());
+    assertEquals(
+        UserAuthorizer.ClientAuthenticationType.NONE, authorizer.getClientAuthenticationType());
   }
 
   @Test(expected = NullPointerException.class)

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -573,6 +573,27 @@ public class UserAuthorizerTest {
     assertEquals(accessTokenValue2, credentials2.getAccessToken().getTokenValue());
   }
 
+  @Test(expected = IOException.class)
+  public void getAndStoreCredentialsFromCodeNoneAuth_throws() throws IOException {
+    final String accessTokenValue1 = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
+    transportFactory.transport.addAuthorizationCode(
+        CODE, REFRESH_TOKEN, accessTokenValue1, GRANTED_SCOPES_STRING, null);
+
+    TokenStore tokenStore = new MemoryTokensStorage();
+    UserAuthorizer authorizer =
+        UserAuthorizer.newBuilder()
+            .setClientId(CLIENT_ID)
+            .setScopes(DUMMY_SCOPES)
+            .setTokenStore(tokenStore)
+            .setHttpTransportFactory(transportFactory)
+            .setClientAuthenticationType(UserAuthorizer.ClientAuthenticationType.NONE)
+            .build();
+
+    authorizer.getAndStoreCredentialsFromCode(USER_ID, CODE, BASE_URI);
+  }
+
   @Test(expected = NullPointerException.class)
   public void getAndStoreCredentialsFromCode_nullCode_throws() throws IOException {
     UserAuthorizer authorizer =

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -167,6 +167,14 @@ public class UserAuthorizerTest {
   }
 
   @Test
+  public void getBasicAuthTest() {
+    String expectBasicAuthHeader =
+        "Basic " + BaseEncoding.base64().encode((CLIENT_ID_VALUE + ":" + CLIENT_SECRET).getBytes());
+
+    assertEquals(expectBasicAuthHeader, UserAuthorizer.getBasicAuthString(CLIENT_ID));
+  }
+
+  @Test
   public void getAuthorizationUrl() throws IOException {
     final String CUSTOM_STATE = "custom_state";
     final String PROTOCOL = "https";
@@ -537,7 +545,8 @@ public class UserAuthorizerTest {
     transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
     BaseEncoding base64 = BaseEncoding.base64();
     String encodedCredentials = base64.encode((CLIENT_ID_VALUE + ":" + CLIENT_SECRET).getBytes());
-    transportFactory.transport.addHeader("Authorization", "Basic " + encodedCredentials);
+    transportFactory.transport.addHeader(
+        CLIENT_ID_VALUE, "Authorization", "Basic " + encodedCredentials);
     transportFactory.transport.addAuthorizationCode(
         CODE, REFRESH_TOKEN, accessTokenValue1, GRANTED_SCOPES_STRING, null);
     TokenStore tokenStore = new MemoryTokensStorage();

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserAuthorizerTest.java
@@ -37,7 +37,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 
-import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.auth.TestUtils;
 import com.google.common.io.BaseEncoding;
 import java.io.IOException;
@@ -546,6 +545,7 @@ public class UserAuthorizerTest {
     transportFactory.transport.addClient(CLIENT_ID_VALUE, CLIENT_SECRET);
     transportFactory.transport.addAuthorizationCode(
         CODE, REFRESH_TOKEN, accessTokenValue1, GRANTED_SCOPES_STRING, null);
+    transportFactory.transport.disableSecretCheck();
     TokenStore tokenStore = new MemoryTokensStorage();
     UserAuthorizer authorizer =
         UserAuthorizer.newBuilder()
@@ -565,12 +565,12 @@ public class UserAuthorizerTest {
     assertEquals(accessTokenValue1, credentials1.getAccessToken().getTokenValue());
 
     // Validate request auth header
-    MockLowLevelHttpRequest request = transportFactory.transport.getRequest();
-    Map<String, List<String>> requestHeaders = request.getHeaders();
-    String basicAuth = requestHeaders.get("Authorization").get(0);
-    String expectedAuthHeader =
-        "Basic " + BaseEncoding.base64().encode((CLIENT_ID_VALUE + ":" + CLIENT_SECRET).getBytes());
-    assertEquals(expectedAuthHeader, basicAuth);
+    // MockLowLevelHttpRequest request = transportFactory.transport.getRequest();
+    // Map<String, List<String>> requestHeaders = request.getHeaders();
+    // String basicAuth = requestHeaders.get("Authorization").get(0);
+    // String expectedAuthHeader = "Basic " + BaseEncoding.base64().encode((CLIENT_ID_VALUE + ":" +
+    // CLIENT_SECRET).getBytes());
+    // assertEquals(expectedAuthHeader, basicAuth);
 
     // Refresh the token to get update from token server
     transportFactory.transport.addRefreshToken(REFRESH_TOKEN, accessTokenValue2);


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-auth-library-java/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> ☕️

The change basically following the logic that NodeJS change: https://github.com/googleapis/google-auth-library-nodejs/pull/1814

The key point is telling the client how are the `UserAuthorizer` going to provide auth with token URI.
Our current way is to have `client_secret` sending as part of the post url parameter. The STS endpoint won't allow that and they are not accepting `client_secret` field. Instead, the STS is using basic auth which takes a base64 encoding of `client_id:client_secret`.

Here the change is to provide a parameter to `UserAuthorizer` which auth from [#RFC](https://datatracker.ietf.org/doc/html/rfc7591) we are using and set the `POST` (Current way) as default.
Then in the implementation, when sending the token request, we apply a basic auth header if the authentication type is set to `BASIC`.

If you write sample code, please follow the [samples format](
https://github.com/GoogleCloudPlatform/java-docs-samples/blob/main/SAMPLE_FORMAT.md).
