### PR TITLE
chore: Control each response for calls to the IAM Mock Server

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/GoogleAuthException.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleAuthException.java
@@ -158,11 +158,10 @@ class GoogleAuthException extends IOException implements Retryable {
     if (message == null) {
       // TODO: temporarily setting retry Count to service account default to remove a direct
       // dependency, to be reverted after release
-      return new GoogleAuthException(
-          true, ServiceAccountCredentials.DEFAULT_NUMBER_OF_RETRIES, ioException);
+      return new GoogleAuthException(true, OAuth2Utils.DEFAULT_NUMBER_OF_RETRIES, ioException);
     } else {
       return new GoogleAuthException(
-          true, ServiceAccountCredentials.DEFAULT_NUMBER_OF_RETRIES, message, ioException);
+          true, OAuth2Utils.DEFAULT_NUMBER_OF_RETRIES, message, ioException);
     }
   }
 

--- a/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IamUtils.java
@@ -32,13 +32,17 @@
 package com.google.auth.oauth2;
 
 import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
+import com.google.api.client.http.HttpBackOffUnsuccessfulResponseHandler;
 import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.json.JsonHttpContent;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.GenericData;
 import com.google.auth.Credentials;
 import com.google.auth.ServiceAccountSigner;
@@ -78,11 +82,12 @@ class IamUtils {
       byte[] toSign,
       Map<String, ?> additionalFields) {
     BaseEncoding base64 = BaseEncoding.base64();
+    HttpRequestFactory factory =
+        transport.createRequestFactory(new HttpCredentialsAdapter(credentials));
     String signature;
     try {
       signature =
-          getSignature(
-              serviceAccountEmail, credentials, transport, base64.encode(toSign), additionalFields);
+          getSignature(serviceAccountEmail, base64.encode(toSign), additionalFields, factory);
     } catch (IOException ex) {
       throw new ServiceAccountSigner.SigningException("Failed to sign the provided bytes", ex);
     }
@@ -91,10 +96,9 @@ class IamUtils {
 
   private static String getSignature(
       String serviceAccountEmail,
-      Credentials credentials,
-      HttpTransport transport,
       String bytes,
-      Map<String, ?> additionalFields)
+      Map<String, ?> additionalFields,
+      HttpRequestFactory factory)
       throws IOException {
     String signBlobUrl = String.format(SIGN_BLOB_URL_FORMAT, serviceAccountEmail);
     GenericUrl genericUrl = new GenericUrl(signBlobUrl);
@@ -106,13 +110,27 @@ class IamUtils {
     }
     JsonHttpContent signContent = new JsonHttpContent(OAuth2Utils.JSON_FACTORY, signRequest);
 
-    HttpCredentialsAdapter adapter = new HttpCredentialsAdapter(credentials);
-    HttpRequest request =
-        transport.createRequestFactory(adapter).buildPostRequest(genericUrl, signContent);
+    HttpRequest request = factory.buildPostRequest(genericUrl, signContent);
 
     JsonObjectParser parser = new JsonObjectParser(OAuth2Utils.JSON_FACTORY);
     request.setParser(parser);
     request.setThrowExceptionOnExecuteError(false);
+    request.setNumberOfRetries(OAuth2Utils.DEFAULT_NUMBER_OF_RETRIES);
+
+    ExponentialBackOff backoff =
+        new ExponentialBackOff.Builder()
+            .setInitialIntervalMillis(OAuth2Utils.INITIAL_RETRY_INTERVAL_MILLIS)
+            .setRandomizationFactor(OAuth2Utils.RETRY_RANDOMIZATION_FACTOR)
+            .setMultiplier(OAuth2Utils.RETRY_MULTIPLIER)
+            .build();
+
+    // Retry on 500, 502, 503, and 503 status codes
+    request.setUnsuccessfulResponseHandler(
+        new HttpBackOffUnsuccessfulResponseHandler(backoff)
+            .setBackOffRequired(
+                response ->
+                    OAuth2Utils.IAM_RETRYABLE_STATUS_CODES.contains(response.getStatusCode())));
+    request.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(backoff));
 
     HttpResponse response = request.execute();
     int statusCode = response.getStatusCode();
@@ -125,6 +143,8 @@ class IamUtils {
           String.format(
               "Error code %s trying to sign provided bytes: %s", statusCode, errorMessage));
     }
+
+    // Request will have retried a 5xx error 3 times and is still receiving a 5xx error code
     if (statusCode != HttpStatusCodes.STATUS_CODE_OK) {
       throw new IOException(
           String.format(
@@ -152,8 +172,8 @@ class IamUtils {
    * @param additionalFields additional fields to send in the IAM call
    * @return IdToken issed to the serviceAccount
    * @throws IOException if the IdToken cannot be issued.
-   * @see
-   *     https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateIdToken
+   * @see <a
+   *     href="https://cloud.google.com/iam/credentials/reference/rest/v1/projects.serviceAccounts/generateIdToken">...</a>
    */
   static IdToken getIdToken(
       String serviceAccountEmail,

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -92,10 +92,20 @@ class OAuth2Utils {
 
   static final String TOKEN_RESPONSE_SCOPE = "scope";
 
+  static final int INITIAL_RETRY_INTERVAL_MILLIS = 1000;
+  static final double RETRY_RANDOMIZATION_FACTOR = 0.1;
+  static final double RETRY_MULTIPLIER = 2;
+  static final int DEFAULT_NUMBER_OF_RETRIES = 3;
+
   // Includes expected server errors from Google token endpoint
   // Other 5xx codes are either not used or retries are unlikely to succeed
   public static final Set<Integer> TOKEN_ENDPOINT_RETRYABLE_STATUS_CODES =
       new HashSet<>(Arrays.asList(500, 503, 408, 429));
+
+  // Following guidance for IAM retries:
+  // https://cloud.google.com/iam/docs/retry-strategy#errors-to-retry
+  static final Set<Integer> IAM_RETRYABLE_STATUS_CODES =
+      new HashSet<>(Arrays.asList(500, 502, 503, 504));
 
   static class DefaultHttpTransportFactory implements HttpTransportFactory {
 

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -89,10 +89,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
   private static final String PARSE_ERROR_PREFIX = "Error parsing token refresh response. ";
   private static final int TWELVE_HOURS_IN_SECONDS = 43200;
   private static final int DEFAULT_LIFETIME_IN_SECONDS = 3600;
-  private static final int INITIAL_RETRY_INTERVAL_MILLIS = 1000;
-  private static final double RETRY_RANDOMIZATION_FACTOR = 0.1;
-  private static final double RETRY_MULTIPLIER = 2;
-  static final int DEFAULT_NUMBER_OF_RETRIES = 3;
 
   private final String clientId;
   private final String clientEmail;
@@ -505,7 +501,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     HttpRequest request = requestFactory.buildPostRequest(new GenericUrl(tokenServerUri), content);
 
     if (this.defaultRetriesEnabled) {
-      request.setNumberOfRetries(DEFAULT_NUMBER_OF_RETRIES);
+      request.setNumberOfRetries(OAuth2Utils.DEFAULT_NUMBER_OF_RETRIES);
     } else {
       request.setNumberOfRetries(0);
     }
@@ -513,9 +509,9 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
     ExponentialBackOff backoff =
         new ExponentialBackOff.Builder()
-            .setInitialIntervalMillis(INITIAL_RETRY_INTERVAL_MILLIS)
-            .setRandomizationFactor(RETRY_RANDOMIZATION_FACTOR)
-            .setMultiplier(RETRY_MULTIPLIER)
+            .setInitialIntervalMillis(OAuth2Utils.INITIAL_RETRY_INTERVAL_MILLIS)
+            .setRandomizationFactor(OAuth2Utils.RETRY_RANDOMIZATION_FACTOR)
+            .setMultiplier(OAuth2Utils.RETRY_MULTIPLIER)
             .build();
 
     request.setUnsuccessfulResponseHandler(

--- a/oauth2_http/java/com/google/auth/oauth2/TokenVerifier.java
+++ b/oauth2_http/java/com/google/auth/oauth2/TokenVerifier.java
@@ -279,9 +279,6 @@ public class TokenVerifier {
   /** Custom CacheLoader for mapping certificate urls to the contained public keys. */
   static class PublicKeyLoader extends CacheLoader<String, Map<String, PublicKey>> {
     private static final int DEFAULT_NUMBER_OF_RETRIES = 2;
-    private static final int INITIAL_RETRY_INTERVAL_MILLIS = 1000;
-    private static final double RETRY_RANDOMIZATION_FACTOR = 0.1;
-    private static final double RETRY_MULTIPLIER = 2;
     private final HttpTransportFactory httpTransportFactory;
 
     /**
@@ -330,9 +327,9 @@ public class TokenVerifier {
 
       ExponentialBackOff backoff =
           new ExponentialBackOff.Builder()
-              .setInitialIntervalMillis(INITIAL_RETRY_INTERVAL_MILLIS)
-              .setRandomizationFactor(RETRY_RANDOMIZATION_FACTOR)
-              .setMultiplier(RETRY_MULTIPLIER)
+              .setInitialIntervalMillis(OAuth2Utils.INITIAL_RETRY_INTERVAL_MILLIS)
+              .setRandomizationFactor(OAuth2Utils.RETRY_RANDOMIZATION_FACTOR)
+              .setMultiplier(OAuth2Utils.RETRY_MULTIPLIER)
               .build();
 
       request.setUnsuccessfulResponseHandler(

--- a/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/GoogleCredentialsTest.java
@@ -33,6 +33,7 @@ package com.google.auth.oauth2;
 
 import static org.junit.Assert.*;
 
+import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.util.Clock;
 import com.google.auth.Credentials;
@@ -609,6 +610,7 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(ImpersonatedCredentialsTest.getDefaultExpireTime());
     transportFactory.transport.setAccessTokenEndpoint(
         ImpersonatedCredentialsTest.IMPERSONATION_URL);
+    transportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
 
     InputStream impersonationCredentialsStream =
         ImpersonatedCredentialsTest.writeImpersonationCredentialsStream(
@@ -669,6 +671,7 @@ public class GoogleCredentialsTest extends BaseSerializationTest {
     transportFactory.transport.setExpireTime(ImpersonatedCredentialsTest.getDefaultExpireTime());
     transportFactory.transport.setAccessTokenEndpoint(
         ImpersonatedCredentialsTest.IMPERSONATION_URL);
+    transportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
 
     InputStream impersonationCredentialsStream =
         ImpersonatedCredentialsTest.writeImpersonationCredentialsStream(

--- a/oauth2_http/javatests/com/google/auth/oauth2/IamUtilsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IamUtilsTest.java
@@ -53,7 +53,8 @@ public class IamUtilsTest {
   public void sign_noRetry() throws IOException {
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
 
-    // Mock this call because signing requires an access token
+    // Mock this call because signing requires an access token. The call is initialized with
+    // HttpCredentialsAdapter which will make a call to get the access token
     ServiceAccountCredentials credentials = Mockito.mock(ServiceAccountCredentials.class);
     Mockito.when(credentials.getRequestMetadata(Mockito.any())).thenReturn(ImmutableMap.of());
 
@@ -76,7 +77,8 @@ public class IamUtilsTest {
   public void sign_4xxServerError_exception() throws IOException {
     byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
 
-    // Mock this call because signing requires an access token
+    // Mock this call because signing requires an access token. The call is initialized with
+    // HttpCredentialsAdapter which will make a call to get the access token
     ServiceAccountCredentials credentials = Mockito.mock(ServiceAccountCredentials.class);
     Mockito.when(credentials.getRequestMetadata(Mockito.any())).thenReturn(ImmutableMap.of());
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/IamUtilsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IamUtilsTest.java
@@ -1,0 +1,77 @@
+package com.google.auth.oauth2;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.auth.ServiceAccountSigner;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class IamUtilsTest {
+
+  private static final String CLIENT_EMAIL =
+      "36680232662-vrd7ji19qe3nelgchd0ah2csanun6bnr@developer.gserviceaccount.com";
+
+  @Test
+  public void sign_noRetry() throws IOException {
+    byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
+
+    // Mock this call because signing requires an access token
+    ServiceAccountCredentials credentials = Mockito.mock(ServiceAccountCredentials.class);
+    Mockito.when(credentials.getRequestMetadata(Mockito.any())).thenReturn(ImmutableMap.of());
+
+    ImpersonatedCredentialsTest.MockIAMCredentialsServiceTransportFactory transportFactory =
+        new ImpersonatedCredentialsTest.MockIAMCredentialsServiceTransportFactory();
+    transportFactory.transport.setSignedBlob(expectedSignature);
+    transportFactory.transport.setTargetPrincipal(CLIENT_EMAIL);
+
+    byte[] signature =
+        IamUtils.sign(
+            CLIENT_EMAIL,
+            credentials,
+            transportFactory.transport,
+            expectedSignature,
+            ImmutableMap.of());
+    assertArrayEquals(expectedSignature, signature);
+  }
+
+  @Test
+  public void sign_4xxServerError_exception() throws IOException {
+    byte[] expectedSignature = {0xD, 0xE, 0xA, 0xD};
+
+    // Mock this call because signing requires an access token
+    ServiceAccountCredentials credentials = Mockito.mock(ServiceAccountCredentials.class);
+    Mockito.when(credentials.getRequestMetadata(Mockito.any())).thenReturn(ImmutableMap.of());
+
+    ImpersonatedCredentialsTest.MockIAMCredentialsServiceTransportFactory transportFactory =
+        new ImpersonatedCredentialsTest.MockIAMCredentialsServiceTransportFactory();
+    transportFactory.transport.setSignedBlob(expectedSignature);
+    transportFactory.transport.setTargetPrincipal(CLIENT_EMAIL);
+    transportFactory.transport.setErrorResponseCodeAndMessage(
+        HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, "Failed to sign the provided bytes");
+
+    ServiceAccountSigner.SigningException exception =
+        assertThrows(
+            ServiceAccountSigner.SigningException.class,
+            () ->
+                IamUtils.sign(
+                    CLIENT_EMAIL,
+                    credentials,
+                    transportFactory.transport,
+                    expectedSignature,
+                    ImmutableMap.of()));
+    assertTrue(exception.getMessage().contains("Failed to sign the provided bytes"));
+    assertTrue(
+        exception
+            .getCause()
+            .getMessage()
+            .contains("Error code 401 trying to sign provided bytes:"));
+  }
+}

--- a/oauth2_http/javatests/com/google/auth/oauth2/IamUtilsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/IamUtilsTest.java
@@ -1,3 +1,33 @@
+/*
+ * Copyright 2024, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package com.google.auth.oauth2;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -363,14 +363,13 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void refreshAccessToken_unauthorized() throws IOException {
-
     String expectedMessage = "The caller does not have permission";
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
-    mockTransportFactory.transport.setTokenResponseErrorCode(
-        HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
-    mockTransportFactory.transport.setTokenResponseErrorContent(
+    mockTransportFactory.transport.addStatusCodeAndMessage(
+        HttpStatusCodes.STATUS_CODE_UNAUTHORIZED,
         generateErrorJson(
-            HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, expectedMessage, "global", "forbidden"));
+            HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, expectedMessage, "global", "forbidden"),
+        true);
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -395,9 +394,8 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     String invalidTargetEmail = "foo";
     String expectedMessage = "Request contains an invalid argument";
     mockTransportFactory.transport.setTargetPrincipal(invalidTargetEmail);
-    mockTransportFactory.transport.setTokenResponseErrorCode(
-        HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
-    mockTransportFactory.transport.setTokenResponseErrorContent(
+    mockTransportFactory.transport.addStatusCodeAndMessage(
+        HttpStatusCodes.STATUS_CODE_BAD_REQUEST,
         generateErrorJson(
             HttpStatusCodes.STATUS_CODE_BAD_REQUEST, expectedMessage, "global", "badRequest"));
     ImpersonatedCredentials targetCredentials =
@@ -465,10 +463,10 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
   @Test()
   public void refreshAccessToken_success() throws IOException, IllegalStateException {
-
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -488,6 +486,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
     mockTransportFactory.transport.setAccessTokenEndpoint(IMPERSONATION_URL);
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
 
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
@@ -506,10 +505,10 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
   @Test()
   public void getRequestMetadata_withQuotaProjectId() throws IOException, IllegalStateException {
-
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -529,10 +528,10 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
   @Test()
   public void getRequestMetadata_withoutQuotaProjectId() throws IOException, IllegalStateException {
-
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -548,10 +547,10 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
   @Test()
   public void refreshAccessToken_delegates_success() throws IOException, IllegalStateException {
-
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     List<String> delegates = Arrays.asList("delegate-account@iam.gserviceaccount.com");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
@@ -574,6 +573,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getFormattedTime(c.getTime()));
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
                 sourceCredentials,
@@ -600,6 +600,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getFormattedTime(c.getTime()));
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
                 sourceCredentials,
@@ -619,11 +620,11 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void refreshAccessToken_invalidDate() throws IllegalStateException {
-
     String expectedMessage = "Unparseable date";
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken("foo");
     mockTransportFactory.transport.setExpireTime("1973-09-29T15:01:23");
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -663,6 +664,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -685,6 +687,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -724,6 +727,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
             sourceCredentials,
@@ -762,7 +766,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setSignedBlob(expectedSignature);
-    mockTransportFactory.transport.setErrorResponseCodeAndMessage(
+    mockTransportFactory.transport.addStatusCodeAndMessage(
         HttpStatusCodes.STATUS_CODE_FORBIDDEN, "Sign Error");
 
     try {
@@ -794,8 +798,8 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
 
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setSignedBlob(expectedSignature);
-    mockTransportFactory.transport.setErrorResponseCodeAndMessage(
-        HttpStatusCodes.STATUS_CODE_SERVER_ERROR, "Sign Error");
+    mockTransportFactory.transport.addStatusCodeAndMessage(
+        HttpStatusCodes.STATUS_CODE_NOT_FOUND, "Sign Error");
 
     try {
       byte[] bytes = {0xD, 0xE, 0xA, 0xD};
@@ -804,7 +808,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     } catch (SigningException e) {
       assertEquals("Failed to sign the provided bytes", e.getMessage());
       assertNotNull(e.getCause());
-      assertTrue(e.getCause().getMessage().contains("500"));
+      assertTrue(e.getCause().getMessage().contains("404"));
     }
   }
 
@@ -813,6 +817,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
 
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
@@ -844,6 +849,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     mockTransportFactory.transport.setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.transport.setAccessToken(ACCESS_TOKEN);
     mockTransportFactory.transport.setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.transport.addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "");
 
     ImpersonatedCredentials targetCredentials =
         ImpersonatedCredentials.create(
@@ -885,7 +891,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
             mockTransportFactory);
 
     mockTransportFactory.transport.setIdToken(STANDARD_ID_TOKEN);
-    mockTransportFactory.transport.setErrorResponseCodeAndMessage(
+    mockTransportFactory.transport.addStatusCodeAndMessage(
         HttpStatusCodes.STATUS_CODE_SERVER_ERROR, "Internal Server Error");
 
     String targetAudience = "https://foo.bar";
@@ -918,7 +924,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
             mockTransportFactory);
 
     mockTransportFactory.transport.setIdToken(STANDARD_ID_TOKEN);
-    mockTransportFactory.transport.setErrorResponseCodeAndMessage(
+    mockTransportFactory.transport.addStatusCodeAndMessage(
         HttpStatusCodes.STATUS_CODE_MOVED_PERMANENTLY, "Redirect");
 
     String targetAudience = "https://foo.bar";

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
@@ -42,9 +42,23 @@ import com.google.api.client.testing.http.MockLowLevelHttpResponse;
 import com.google.auth.TestUtils;
 import com.google.common.io.BaseEncoding;
 import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /** Transport that simulates the IAMCredentials server for access tokens. */
 public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
+
+  private static class ServerResponse {
+    private final int statusCode;
+    private final String response;
+    private final boolean repeatServerResponse;
+
+    public ServerResponse(int statusCode, String response, boolean repeatServerResponse) {
+      this.statusCode = statusCode;
+      this.response = response;
+      this.repeatServerResponse = repeatServerResponse;
+    }
+  }
 
   private static final String DEFAULT_IAM_ACCESS_TOKEN_ENDPOINT =
       "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken";
@@ -52,12 +66,11 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
       "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateIdToken";
   private static final String IAM_SIGN_ENDPOINT =
       "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:signBlob";
-  private Integer tokenResponseErrorCode;
-  private String tokenResponseErrorContent;
+
+  private final Deque<ServerResponse> serverResponses;
+
   private String targetPrincipal;
   private byte[] signedBlob;
-  private int responseCode = HttpStatusCodes.STATUS_CODE_OK;
-  private String errorMessage;
   private String iamAccessTokenEndpoint;
 
   private String accessToken;
@@ -67,14 +80,8 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
 
   private MockLowLevelHttpRequest request;
 
-  public MockIAMCredentialsServiceTransport() {}
-
-  public void setTokenResponseErrorCode(Integer tokenResponseErrorCode) {
-    this.tokenResponseErrorCode = tokenResponseErrorCode;
-  }
-
-  public void setTokenResponseErrorContent(String tokenResponseErrorContent) {
-    this.tokenResponseErrorContent = tokenResponseErrorContent;
+  public MockIAMCredentialsServiceTransport() {
+    this.serverResponses = new ArrayDeque<>();
   }
 
   public void setTargetPrincipal(String targetPrincipal) {
@@ -93,9 +100,15 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
     this.signedBlob = signedBlob;
   }
 
-  public void setErrorResponseCodeAndMessage(int responseCode, String errorMessage) {
-    this.responseCode = responseCode;
-    this.errorMessage = errorMessage;
+  public void addStatusCodeAndMessage(int responseCode, String message) {
+    addStatusCodeAndMessage(responseCode, message, false);
+  }
+
+  // repeat to ensure simulate scenarios where retrying returns the same status over and over.
+  // Setting repeat will result in this status code being returned until the connection is
+  // terminated.
+  public void addStatusCodeAndMessage(int responseCode, String message, boolean repeat) {
+    serverResponses.offer(new ServerResponse(responseCode, message, repeat));
   }
 
   public void setIdToken(String idToken) {
@@ -112,24 +125,27 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
 
   @Override
   public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
-
-    String iamAccesssTokenformattedUrl =
+    String iamAccessTokenformattedUrl =
         iamAccessTokenEndpoint != null
             ? iamAccessTokenEndpoint
             : String.format(DEFAULT_IAM_ACCESS_TOKEN_ENDPOINT, this.targetPrincipal);
     String iamSignBlobformattedUrl = String.format(IAM_SIGN_ENDPOINT, this.targetPrincipal);
     String iamIdTokenformattedUrl = String.format(IAM_ID_TOKEN_ENDPOINT, this.targetPrincipal);
-    if (url.equals(iamAccesssTokenformattedUrl)) {
+    ServerResponse serverResponse = serverResponses.poll();
+    // Status code was configured to be repeated until connection is terminated
+    if (serverResponse.repeatServerResponse) {
+      serverResponses.offerFirst(serverResponse);
+    }
+    if (url.equals(iamAccessTokenformattedUrl)) {
       this.request =
           new MockLowLevelHttpRequest(url) {
             @Override
             public LowLevelHttpResponse execute() throws IOException {
-
-              if (tokenResponseErrorCode != null) {
+              if (serverResponse.statusCode != HttpStatusCodes.STATUS_CODE_OK) {
                 return new MockLowLevelHttpResponse()
-                    .setStatusCode(tokenResponseErrorCode)
+                    .setStatusCode(serverResponse.statusCode)
                     .setContentType(Json.MEDIA_TYPE)
-                    .setContent(tokenResponseErrorContent);
+                    .setContent(serverResponse.response);
               }
 
               // Create the JSON response
@@ -143,45 +159,20 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
                   .setContent(refreshText);
             }
           };
-    } else if (url.equals(iamSignBlobformattedUrl)
-        && responseCode != HttpStatusCodes.STATUS_CODE_OK) {
-      this.request =
-          new MockLowLevelHttpRequest(url) {
-            @Override
-            public LowLevelHttpResponse execute() throws IOException {
-
-              if (tokenResponseErrorCode != null) {
-                return new MockLowLevelHttpResponse()
-                    .setStatusCode(tokenResponseErrorCode)
-                    .setContentType(Json.MEDIA_TYPE)
-                    .setContent(tokenResponseErrorContent);
-              }
-
-              BaseEncoding base64 = BaseEncoding.base64();
-              GenericJson refreshContents = new GenericJson();
-              refreshContents.setFactory(OAuth2Utils.JSON_FACTORY);
-              refreshContents.put("signedBlob", base64.encode(signedBlob));
-              return new MockLowLevelHttpResponse()
-                  .setStatusCode(responseCode)
-                  .setContent(TestUtils.errorJson(errorMessage));
-            }
-          };
     } else if (url.equals(iamSignBlobformattedUrl)) {
       this.request =
           new MockLowLevelHttpRequest(url) {
             @Override
             public LowLevelHttpResponse execute() throws IOException {
-
-              if (tokenResponseErrorCode != null) {
-                return new MockLowLevelHttpResponse()
-                    .setStatusCode(tokenResponseErrorCode)
-                    .setContentType(Json.MEDIA_TYPE)
-                    .setContent(tokenResponseErrorContent);
-              }
-
               BaseEncoding base64 = BaseEncoding.base64();
               GenericJson refreshContents = new GenericJson();
               refreshContents.setFactory(OAuth2Utils.JSON_FACTORY);
+
+              if (serverResponse.statusCode != HttpStatusCodes.STATUS_CODE_OK) {
+                return new MockLowLevelHttpResponse()
+                    .setStatusCode(serverResponse.statusCode)
+                    .setContent(TestUtils.errorJson(serverResponse.response));
+              }
               refreshContents.put("signedBlob", base64.encode(signedBlob));
               String refreshText = refreshContents.toPrettyString();
               return new MockLowLevelHttpResponse()
@@ -194,12 +185,11 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
           new MockLowLevelHttpRequest(url) {
             @Override
             public LowLevelHttpResponse execute() throws IOException {
-
-              if (responseCode != HttpStatusCodes.STATUS_CODE_OK) {
+              if (serverResponse.statusCode != HttpStatusCodes.STATUS_CODE_OK) {
                 return new MockLowLevelHttpResponse()
-                    .setStatusCode(responseCode)
+                    .setStatusCode(serverResponse.statusCode)
                     .setContentType(Json.MEDIA_TYPE)
-                    .setContent(errorMessage);
+                    .setContent(serverResponse.response);
               }
 
               GenericJson refreshContents = new GenericJson();


### PR DESCRIPTION
This is part 2 that follows up on: https://github.com/googleapis/google-auth-library-java/pull/1452

Once Part 1 is merged, I can rebase this PR to show the diffs (mostly testing related changes) to allow us to test for retrying the IAM Sign Blob RPC.