### PR TITLE
chore: use assertEquals to improve test error message

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/ExecutableResponseTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExecutableResponseTest.java
@@ -63,8 +63,8 @@ public class ExecutableResponseTest {
     assertEquals(EXECUTABLE_SUPPORTED_MAX_VERSION, response.getVersion());
     assertEquals(TOKEN_TYPE_OIDC, response.getTokenType());
     assertEquals(ID_TOKEN, response.getSubjectToken());
-    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
-        (long) response.getExpirationTime());
+    assertEquals(
+        Instant.now().getEpochSecond() + EXPIRATION_DURATION, (long) response.getExpirationTime());
   }
 
   @Test
@@ -93,8 +93,8 @@ public class ExecutableResponseTest {
     assertEquals(EXECUTABLE_SUPPORTED_MAX_VERSION, response.getVersion());
     assertEquals(TOKEN_TYPE_SAML, response.getTokenType());
     assertEquals(SAML_RESPONSE, response.getSubjectToken());
-    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
-        (long) response.getExpirationTime());
+    assertEquals(
+        Instant.now().getEpochSecond() + EXPIRATION_DURATION, (long) response.getExpirationTime());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/ExecutableResponseTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ExecutableResponseTest.java
@@ -63,8 +63,8 @@ public class ExecutableResponseTest {
     assertEquals(EXECUTABLE_SUPPORTED_MAX_VERSION, response.getVersion());
     assertEquals(TOKEN_TYPE_OIDC, response.getTokenType());
     assertEquals(ID_TOKEN, response.getSubjectToken());
-    assertTrue(
-        Instant.now().getEpochSecond() + EXPIRATION_DURATION == response.getExpirationTime());
+    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
+        (long) response.getExpirationTime());
   }
 
   @Test
@@ -93,8 +93,8 @@ public class ExecutableResponseTest {
     assertEquals(EXECUTABLE_SUPPORTED_MAX_VERSION, response.getVersion());
     assertEquals(TOKEN_TYPE_SAML, response.getTokenType());
     assertEquals(SAML_RESPONSE, response.getSubjectToken());
-    assertTrue(
-        Instant.now().getEpochSecond() + EXPIRATION_DURATION == response.getExpirationTime());
+    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
+        (long) response.getExpirationTime());
   }
 
   @Test

--- a/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthHandlerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthHandlerTest.java
@@ -741,8 +741,8 @@ public class PluggableAuthHandlerTest {
     assertTrue(response.isSuccessful());
     assertEquals(TOKEN_TYPE_OIDC, response.getTokenType());
     assertEquals(ID_TOKEN, response.getSubjectToken());
-    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
-        (long) response.getExpirationTime());
+    assertEquals(
+        Instant.now().getEpochSecond() + EXPIRATION_DURATION, (long) response.getExpirationTime());
     // Current env map should include the mappings from options.
     assertEquals(4, currentEnv.size());
     assertEquals(expectedMap, currentEnv);
@@ -788,8 +788,8 @@ public class PluggableAuthHandlerTest {
     assertTrue(response.isSuccessful());
     assertEquals(TOKEN_TYPE_SAML, response.getTokenType());
     assertEquals(SAML_RESPONSE, response.getSubjectToken());
-    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
-        (long) response.getExpirationTime());
+    assertEquals(
+        Instant.now().getEpochSecond() + EXPIRATION_DURATION, (long) response.getExpirationTime());
 
     // Current env map should include the mappings from options.
     assertEquals(4, currentEnv.size());

--- a/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthHandlerTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/PluggableAuthHandlerTest.java
@@ -741,8 +741,8 @@ public class PluggableAuthHandlerTest {
     assertTrue(response.isSuccessful());
     assertEquals(TOKEN_TYPE_OIDC, response.getTokenType());
     assertEquals(ID_TOKEN, response.getSubjectToken());
-    assertTrue(
-        Instant.now().getEpochSecond() + EXPIRATION_DURATION == response.getExpirationTime());
+    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
+        (long) response.getExpirationTime());
     // Current env map should include the mappings from options.
     assertEquals(4, currentEnv.size());
     assertEquals(expectedMap, currentEnv);
@@ -788,8 +788,8 @@ public class PluggableAuthHandlerTest {
     assertTrue(response.isSuccessful());
     assertEquals(TOKEN_TYPE_SAML, response.getTokenType());
     assertEquals(SAML_RESPONSE, response.getSubjectToken());
-    assertTrue(
-        Instant.now().getEpochSecond() + EXPIRATION_DURATION == response.getExpirationTime());
+    assertEquals(Instant.now().getEpochSecond() + EXPIRATION_DURATION,
+        (long) response.getExpirationTime());
 
     // Current env map should include the mappings from options.
     assertEquals(4, currentEnv.size());


### PR DESCRIPTION
Improve test error message to show expected and actual values on failure.

Example of unhelpful assertion message when using `assertTrue`: https://fusion2.corp.google.com/ci/kokoro/prod:cloud-devrel%2Fclient-libraries%2Fjava%2Fgoogle-auth-library-java%2Fnightly%2Fintegration/activity/210e3a70-92c9-4601-8bcb-49e2a9bf5753/log
```
[ERROR] com.google.auth.oauth2.PluggableAuthHandlerTest.getExecutableResponse_oidcResponse -- Time elapsed: 0.011 s <<< FAILURE!
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at com.google.auth.oauth2.PluggableAuthHandlerTest.getExecutableResponse_oidcResponse(PluggableAuthHandlerTest.java:744)
```
