### PR TITLE
chore: disable major version updates in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,15 @@
   ],
   "packageRules": [
     {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "enabled": false
+    },
+    {
       "packagePatterns": [
         "^com.google.guava:"
       ],


### PR DESCRIPTION
This will avoid prs for deps major version updates be created by renovate bot. e.g. [hamcrest-core 1.3 -> 3.0](https://github.com/googleapis/google-auth-library-java/pull/1454)

This rule aligns with what sdk-platform-java's config [here](https://github.com/googleapis/sdk-platform-java/blob/9972e4791eba8e25955177693100815d1e99f66f/renovate.json#L88C20-L97C7)