### PR TITLE
fix: switch to universe-domain endpoint for ComputeEngineCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -507,7 +507,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
 
   public static String getUniverseDomainUrl() {
     return getMetadataServerUrl(DefaultCredentialsProvider.DEFAULT)
-        + "/computeMetadata/v1/universe/universe_domain";
+        + "/computeMetadata/v1/universe/universe-domain";
   }
 
   public static String getServiceAccountsUrl() {


### PR DESCRIPTION
for context: b/339455969