### PR TITLE
chore: migrate graalvm jobs to kokoro instance pool

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -74,10 +74,11 @@ graalvmA)
     # Run Unit and Integration Tests with Native Image
     echo "HELLOOOO"
     bash .kokoro/populate-secrets.sh
-    if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
-      echo "HELLO1"
-      export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
-    fi
+    export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS}
+#    if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
+#      echo "HELLO1"
+#      export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
+#    fi
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -73,13 +73,13 @@ integration)
 graalvmA)
     # Run Unit and Integration Tests with Native Image
     echo "HELLOOOO"
-    $(dirname $0)/populate-secrets.sh
+    bash .kokoro/populate-secrets.sh
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 graalvmB)
     # Run Unit and Integration Tests with Native Image
-    $(dirname $0)/populate-secrets.sh
+    bash .kokoro/populate-secrets.sh
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -73,7 +73,6 @@ integration)
 graalvmA)
     # Run Unit and Integration Tests with Native Image
     bash .kokoro/populate-secrets.sh
-    echo $GOOGLE_APPLICATION_CREDENTIALS
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -75,6 +75,7 @@ graalvmA)
     echo "HELLOOOO"
     bash .kokoro/populate-secrets.sh
     if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
+      echo "HELLO1"
       export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
     fi
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,19 +72,15 @@ integration)
     ;;
 graalvmA)
     # Run Unit and Integration Tests with Native Image
-    echo "HELLOOOO"
     bash .kokoro/populate-secrets.sh
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
-#    if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
-#      echo "HELLO1"
-#      export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
-#    fi
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 graalvmB)
     # Run Unit and Integration Tests with Native Image
-#    bash .kokoro/populate-secrets.sh
+    bash .kokoro/populate-secrets.sh
+    export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,11 +72,13 @@ integration)
     ;;
 graalvmA)
     # Run Unit and Integration Tests with Native Image
+    $(dirname $0)/populate-secrets.sh
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 graalvmB)
     # Run Unit and Integration Tests with Native Image
+    $(dirname $0)/populate-secrets.sh
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -72,6 +72,7 @@ integration)
     ;;
 graalvmA)
     # Run Unit and Integration Tests with Native Image
+    echo "HELLOOOO"
     $(dirname $0)/populate-secrets.sh
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -38,6 +38,7 @@ retry_with_backoff 3 10 \
     -T 1C
 
 # if GOOGLE_APPLICATION_CREDENTIALS is specified as a relative path, prepend Kokoro root directory onto it
+bash .kokoro/populate-secrets.sh
 if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
     export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
 fi
@@ -73,13 +74,12 @@ integration)
 graalvmA)
     # Run Unit and Integration Tests with Native Image
     echo "HELLOOOO"
-    bash .kokoro/populate-secrets.sh
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 graalvmB)
     # Run Unit and Integration Tests with Native Image
-    bash .kokoro/populate-secrets.sh
+#    bash .kokoro/populate-secrets.sh
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -73,6 +73,7 @@ integration)
 graalvmA)
     # Run Unit and Integration Tests with Native Image
     bash .kokoro/populate-secrets.sh
+    echo $GOOGLE_APPLICATION_CREDENTIALS
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -38,7 +38,6 @@ retry_with_backoff 3 10 \
     -T 1C
 
 # if GOOGLE_APPLICATION_CREDENTIALS is specified as a relative path, prepend Kokoro root directory onto it
-bash .kokoro/populate-secrets.sh
 if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
     export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
 fi
@@ -74,6 +73,10 @@ integration)
 graalvmA)
     # Run Unit and Integration Tests with Native Image
     echo "HELLOOOO"
+    bash .kokoro/populate-secrets.sh
+    if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
+      export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})
+    fi
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -74,7 +74,7 @@ graalvmA)
     # Run Unit and Integration Tests with Native Image
     echo "HELLOOOO"
     bash .kokoro/populate-secrets.sh
-    export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS}
+    export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
 #    if [[ ! -z "${GOOGLE_APPLICATION_CREDENTIALS}" && "${GOOGLE_APPLICATION_CREDENTIALS}" != /* ]]; then
 #      echo "HELLO1"
 #      export GOOGLE_APPLICATION_CREDENTIALS=$(realpath ${KOKORO_GFILE_DIR}/${GOOGLE_APPLICATION_CREDENTIALS})

--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -30,7 +30,7 @@ do
   msg "Retrieving secret ${key}"
   gcloud secrets versions access latest \
   --project cloud-devrel-kokoro-resources \
-  --secret "${key}" > "${SECRET_LOCATION}/${key}"
+  --secret ${key} > "${SECRET_LOCATION}/${key}"
 #  docker run --entrypoint=gcloud \
 #    --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
 #    gcr.io/google.com/cloudsdktool/cloud-sdk \

--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -38,6 +38,9 @@ do
 #    --project cloud-devrel-kokoro-resources \
 #    --secret ${key} > \
 #    "${SECRET_LOCATION}/${key}"
+  if [[ -f "${SECRET_LOCATION}/${key}" ]]; then
+    msg "Secret file exists: ${SECRET_LOCATION}/${key}"
+  fi
   if [[ $? == 0 ]]; then
     msg "Secret written to ${SECRET_LOCATION}/${key}"
   else

--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -28,13 +28,16 @@ mkdir -p ${SECRET_LOCATION}
 for key in $(echo ${SECRET_MANAGER_KEYS} | sed "s/,/ /g")
 do
   msg "Retrieving secret ${key}"
-  docker run --entrypoint=gcloud \
-    --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
-    gcr.io/google.com/cloudsdktool/cloud-sdk \
-    secrets versions access latest \
-    --project cloud-devrel-kokoro-resources \
-    --secret ${key} > \
-    "${SECRET_LOCATION}/${key}"
+  gcloud secrets versions access latest \
+  --project cloud-devrel-kokoro-resources \
+  --secret "${key}" > "${SECRET_LOCATION}/${key}"
+#  docker run --entrypoint=gcloud \
+#    --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
+#    gcr.io/google.com/cloudsdktool/cloud-sdk \
+#    secrets versions access latest \
+#    --project cloud-devrel-kokoro-resources \
+#    --secret ${key} > \
+#    "${SECRET_LOCATION}/${key}"
   if [[ $? == 0 ]]; then
     msg "Secret written to ${SECRET_LOCATION}/${key}"
   else

--- a/.kokoro/populate-secrets.sh
+++ b/.kokoro/populate-secrets.sh
@@ -28,18 +28,18 @@ mkdir -p ${SECRET_LOCATION}
 for key in $(echo ${SECRET_MANAGER_KEYS} | sed "s/,/ /g")
 do
   msg "Retrieving secret ${key}"
-  gcloud secrets versions access latest \
-  --project cloud-devrel-kokoro-resources \
-  --secret ${key} > "${SECRET_LOCATION}/${key}"
-#  docker run --entrypoint=gcloud \
-#    --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
-#    gcr.io/google.com/cloudsdktool/cloud-sdk \
-#    secrets versions access latest \
-#    --project cloud-devrel-kokoro-resources \
-#    --secret ${key} > \
-#    "${SECRET_LOCATION}/${key}"
-  if [[ -f "${SECRET_LOCATION}/${key}" ]]; then
-    msg "Secret file exists: ${SECRET_LOCATION}/${key}"
+  if [[ "${JOB_TYPE}" == *"graalvm"* ]]; then
+    gcloud secrets versions access latest \
+    --project cloud-devrel-kokoro-resources \
+    --secret ${key} > "${SECRET_LOCATION}/${key}"
+  else
+    docker run --entrypoint=gcloud \
+      --volume=${KOKORO_GFILE_DIR}:${KOKORO_GFILE_DIR} \
+      gcr.io/google.com/cloudsdktool/cloud-sdk \
+      secrets versions access latest \
+      --project cloud-devrel-kokoro-resources \
+      --secret ${key} > \
+      "${SECRET_LOCATION}/${key}"
   fi
   if [[ $? == 0 ]]; then
     msg "Secret written to ${SECRET_LOCATION}/${key}"

--- a/.kokoro/presubmit/common.cfg
+++ b/.kokoro/presubmit/common.cfg
@@ -23,12 +23,3 @@ env_vars: {
   key: "JOB_TYPE"
   value: "test"
 }
-
-before_action {
-  fetch_keystore {
-    keystore_resource {
-      keystore_config_id: 73713
-      keyname: "dpebot_codecov_token"
-    }
-  }
-}

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -1,10 +1,6 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_a:1.11.3"
-}
+build_file: "google-auth-library-java/.kokoro/build.sh"
 
 env_vars: {
   key: "JOB_TYPE"
@@ -45,5 +41,9 @@ env_vars: {
 env_vars: {
   key: "GOOGLE_CLOUD_QUOTA_PROJECT"
   value: "gcloud-devel"
+}
+
+container_properties {
+  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_a:1.12.0"
 }
 

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -10,12 +10,12 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-graalvm-ci-prod"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-graalvm-ci-prod"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -1,5 +1,7 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
+gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
+
 build_file: "google-auth-library-java/.kokoro/build.sh"
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -1,7 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
-
 build_file: "google-auth-library-java/.kokoro/build.sh"
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -10,12 +10,12 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "java-graalvm-ci-prod"
+  value: "gcloud-devel"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "java-graalvm-ci-prod"
+  value: "gcloud-devel"
 }
 
 env_vars: {
@@ -40,7 +40,7 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_CLOUD_QUOTA_PROJECT"
-  value: "java-graalvm-ci-prod"
+  value: "gcloud-devel"
 }
 
 container_properties {

--- a/.kokoro/presubmit/graalvm-native-a.cfg
+++ b/.kokoro/presubmit/graalvm-native-a.cfg
@@ -40,7 +40,7 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_CLOUD_QUOTA_PROJECT"
-  value: "gcloud-devel"
+  value: "java-graalvm-ci-prod"
 }
 
 container_properties {

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -10,12 +10,12 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-graalvm-ci-prod"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "gcloud-devel"
+  value: "java-graalvm-ci-prod"
 }
 
 env_vars: {

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -1,10 +1,6 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-  key: "TRAMPOLINE_IMAGE"
-  value: "gcr.io/cloud-devrel-public-resources/graalvm_b:1.11.3"
-}
+build_file: "google-auth-library-java/.kokoro/build.sh"
 
 env_vars: {
   key: "JOB_TYPE"
@@ -45,4 +41,8 @@ env_vars: {
 env_vars: {
   key: "GOOGLE_CLOUD_QUOTA_PROJECT"
   value: "gcloud-devel"
+}
+
+container_properties {
+  docker_image: "us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm_b:1.12.0"
 }

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -10,12 +10,12 @@ env_vars: {
 # TODO: remove this after we've migrated all tests and scripts
 env_vars: {
   key: "GCLOUD_PROJECT"
-  value: "java-graalvm-ci-prod"
+  value: "gcloud-devel"
 }
 
 env_vars: {
   key: "GOOGLE_CLOUD_PROJECT"
-  value: "java-graalvm-ci-prod"
+  value: "gcloud-devel"
 }
 
 env_vars: {
@@ -40,7 +40,7 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_CLOUD_QUOTA_PROJECT"
-  value: "java-graalvm-ci-prod"
+  value: "gcloud-devel"
 }
 
 container_properties {

--- a/.kokoro/presubmit/graalvm-native-b.cfg
+++ b/.kokoro/presubmit/graalvm-native-b.cfg
@@ -40,7 +40,7 @@ env_vars: {
 
 env_vars: {
   key: "GOOGLE_CLOUD_QUOTA_PROJECT"
-  value: "gcloud-devel"
+  value: "java-graalvm-ci-prod"
 }
 
 container_properties {

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
@@ -437,6 +437,7 @@ public final class ITWorkloadIdentityFederationTest {
   private GenericJson getServiceAccountKeyFileAsJson() throws IOException {
     String credentialsPath = System.getenv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR);
     System.out.println(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
+    System.out.println(System.getenv("KOKORO_GFILE_DIR"));
     System.out.println("DEBUG");
     System.out.println(credentialsPath);
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
@@ -436,10 +436,6 @@ public final class ITWorkloadIdentityFederationTest {
 
   private GenericJson getServiceAccountKeyFileAsJson() throws IOException {
     String credentialsPath = System.getenv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR);
-    System.out.println(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
-    System.out.println(System.getenv("KOKORO_GFILE_DIR"));
-    System.out.println("DEBUG");
-    System.out.println(credentialsPath);
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     JsonObjectParser parser = new JsonObjectParser(jsonFactory);
     return parser.parseAndClose(

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
@@ -436,6 +436,7 @@ public final class ITWorkloadIdentityFederationTest {
 
   private GenericJson getServiceAccountKeyFileAsJson() throws IOException {
     String credentialsPath = System.getenv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR);
+    System.out.println(System.getenv("GOOGLE_APPLICATION_CREDENTIALS"));
     System.out.println("DEBUG");
     System.out.println(credentialsPath);
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;

--- a/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ITWorkloadIdentityFederationTest.java
@@ -436,6 +436,8 @@ public final class ITWorkloadIdentityFederationTest {
 
   private GenericJson getServiceAccountKeyFileAsJson() throws IOException {
     String credentialsPath = System.getenv(DefaultCredentialsProvider.CREDENTIAL_ENV_VAR);
+    System.out.println("DEBUG");
+    System.out.println(credentialsPath);
     JsonFactory jsonFactory = OAuth2Utils.JSON_FACTORY;
     JsonObjectParser parser = new JsonObjectParser(jsonFactory);
     return parser.parseAndClose(

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
       "fileMatch": [
         "^.kokoro/presubmit/graalvm-native.*.cfg$"
       ],
-      "matchStrings": ["value: \"gcr.io/cloud-devrel-public-resources/graalvm.*:(?<currentValue>.*?)\""],
+      "matchStrings": ["docker_image: \"us-docker.pkg.dev/java-graalvm-ci-prod/graalvm-integration-testing/graalvm.*:(?<currentValue>.*?)\""],
       "depNameTemplate": "com.google.cloud:google-cloud-shared-config",
       "datasourceTemplate": "maven"
     }


### PR DESCRIPTION
Notable Changes:

- Removed unused keystore settings.
- Replaced use of TRAMPOLINE_IMAGE environment variable with container_properties { docker_image ...}}
- Modified renovate bot settings to edit new docker_image property's value when a new version of java-shared-config is available.