### PR TITLE
fix: JSON parsing of S2A addresses.

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -97,8 +97,8 @@ class OAuth2Utils {
 
   static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
-  static final String VALUE_NOT_FOUND_MESSAGE = "%sExpected value %s not found.";
-  static final String VALUE_WRONG_TYPE_MESSAGE = "%sExpected %s value %s of wrong type.";
+  private static String VALUE_NOT_FOUND_MESSAGE = "%sExpected value %s not found.";
+  private static String VALUE_WRONG_TYPE_MESSAGE = "%sExpected %s value %s of wrong type.";
 
   static final String BEARER_PREFIX = AuthHttpConstants.BEARER + " ";
 

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Utils.java
@@ -97,8 +97,8 @@ class OAuth2Utils {
 
   static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
 
-  private static String VALUE_NOT_FOUND_MESSAGE = "%sExpected value %s not found.";
-  private static String VALUE_WRONG_TYPE_MESSAGE = "%sExpected %s value %s of wrong type.";
+  static final String VALUE_NOT_FOUND_MESSAGE = "%sExpected value %s not found.";
+  static final String VALUE_WRONG_TYPE_MESSAGE = "%sExpected %s value %s of wrong type.";
 
   static final String BEARER_PREFIX = AuthHttpConstants.BEARER + " ";
 

--- a/oauth2_http/java/com/google/auth/oauth2/SecureSessionAgent.java
+++ b/oauth2_http/java/com/google/auth/oauth2/SecureSessionAgent.java
@@ -190,7 +190,7 @@ public class SecureSessionAgent {
 
     String plaintextS2AAddress = "";
     String mtlsS2AAddress = "";
-    Object s2aAddressConfig = responseData.get(S2A_JSON_KEY);
+    Map<String, Object> s2aAddressConfig = (Map<String, Object>) responseData.get(S2A_JSON_KEY);
     if (s2aAddressConfig == null) {
       /*
        * Return empty addresses in {@link SecureSessionAgentConfig} if endpoint doesn't return anything.
@@ -200,9 +200,7 @@ public class SecureSessionAgent {
     try {
       plaintextS2AAddress =
           OAuth2Utils.validateString(
-              (Map<String, Object>) s2aAddressConfig,
-              S2A_PLAINTEXT_ADDRESS_JSON_KEY,
-              PARSE_ERROR_S2A);
+              s2aAddressConfig, S2A_PLAINTEXT_ADDRESS_JSON_KEY, PARSE_ERROR_S2A);
     } catch (IOException ignore) {
       /*
        * Do not throw error because of parsing error, just leave the address as empty in {@link SecureSessionAgentConfig}.
@@ -210,8 +208,7 @@ public class SecureSessionAgent {
     }
     try {
       mtlsS2AAddress =
-          OAuth2Utils.validateString(
-              (Map<String, Object>) s2aAddressConfig, S2A_MTLS_ADDRESS_JSON_KEY, PARSE_ERROR_S2A);
+          OAuth2Utils.validateString(s2aAddressConfig, S2A_MTLS_ADDRESS_JSON_KEY, PARSE_ERROR_S2A);
     } catch (IOException ignore) {
       /*
        * Do not throw error because of parsing error, just leave the address as empty in {@link SecureSessionAgentConfig}.

--- a/oauth2_http/java/com/google/auth/oauth2/SecureSessionAgent.java
+++ b/oauth2_http/java/com/google/auth/oauth2/SecureSessionAgent.java
@@ -190,16 +190,28 @@ public class SecureSessionAgent {
 
     String plaintextS2AAddress = "";
     String mtlsS2AAddress = "";
+    Object s2aAddressConfig = responseData.get(S2A_JSON_KEY);
+    if (s2aAddressConfig == null) {
+      /*
+       * Return empty addresses in {@link SecureSessionAgentConfig} if endpoint doesn't return anything.
+       */
+      return SecureSessionAgentConfig.createBuilder().build();
+    }
     try {
       plaintextS2AAddress =
-          validateString(responseData, S2A_PLAINTEXT_ADDRESS_JSON_KEY, PARSE_ERROR_S2A);
+          OAuth2Utils.validateString(
+              (Map<String, Object>) s2aAddressConfig,
+              S2A_PLAINTEXT_ADDRESS_JSON_KEY,
+              PARSE_ERROR_S2A);
     } catch (IOException ignore) {
       /*
        * Do not throw error because of parsing error, just leave the address as empty in {@link SecureSessionAgentConfig}.
        */
     }
     try {
-      mtlsS2AAddress = validateString(responseData, S2A_MTLS_ADDRESS_JSON_KEY, PARSE_ERROR_S2A);
+      mtlsS2AAddress =
+          OAuth2Utils.validateString(
+              (Map<String, Object>) s2aAddressConfig, S2A_MTLS_ADDRESS_JSON_KEY, PARSE_ERROR_S2A);
     } catch (IOException ignore) {
       /*
        * Do not throw error because of parsing error, just leave the address as empty in {@link SecureSessionAgentConfig}.
@@ -210,24 +222,5 @@ public class SecureSessionAgent {
         .setPlaintextAddress(plaintextS2AAddress)
         .setMtlsAddress(mtlsS2AAddress)
         .build();
-  }
-
-  private static String validateString(Map<String, Object> map, String key, String errorPrefix)
-      throws IOException {
-    Object value = map.get(S2A_JSON_KEY);
-    if (value == null) {
-      throw new IOException(
-          String.format(OAuth2Utils.VALUE_NOT_FOUND_MESSAGE, errorPrefix, S2A_JSON_KEY));
-    }
-    if (!(value instanceof Map)) {
-      throw new IOException(
-          String.format(OAuth2Utils.VALUE_WRONG_TYPE_MESSAGE, errorPrefix, "Map", S2A_JSON_KEY));
-    }
-    Object address = ((Map<String, Object>) value).get(key);
-    if (!(address instanceof String)) {
-      throw new IOException(
-          String.format(OAuth2Utils.VALUE_WRONG_TYPE_MESSAGE, errorPrefix, "string", key));
-    }
-    return (String) address;
   }
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -300,7 +300,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
         GenericJson content = new GenericJson();
         content.setFactory(OAuth2Utils.JSON_FACTORY);
         if (requestStatusCode == 200) {
-          content.put("s2a", s2aContentMap);
+          content.put(SecureSessionAgent.S2A_JSON_KEY, s2aContentMap);
         }
         String contentText = content.toPrettyString();
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockMetadataServerTransport.java
@@ -300,9 +300,7 @@ public class MockMetadataServerTransport extends MockHttpTransport {
         GenericJson content = new GenericJson();
         content.setFactory(OAuth2Utils.JSON_FACTORY);
         if (requestStatusCode == 200) {
-          for (Map.Entry<String, String> entrySet : s2aContentMap.entrySet()) {
-            content.put(entrySet.getKey(), entrySet.getValue());
-          }
+          content.put("s2a", s2aContentMap);
         }
         String contentText = content.toPrettyString();
 


### PR DESCRIPTION
Autoconfig endpoint returns
```
{
  s2a:
  {
    plaintext_address: ""
    mtls_address: "" 
  }
}
```

not 
```
{
  plaintext_address: ""
  mtls_address: "" 
}
```