### PR TITLE
ci: Disable Sonar if PR comes from a fork

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
+    # Sonar Token can't be passed to PRs from forks. Disable Sonar workflow unless PR is from a branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Context:

PRs from Forks do not have access to secrets which will cause the Sonar CI job to consistently fail. Disable the Sonar CI workflow from Forks.