### PR TITLE
docs: Update README with client-side CAB instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -995,14 +995,19 @@ resources.
 There are two ways to generate downscoped tokens using a
 CredentialAccessBoundary:
 
-* Server-side: Uses the `DownscopedCredentials` class. Each time a
-  downscoped token is needed, the client makes a call to the Security Token Service (STS).
-  This is suitable for applications that require downscoped tokens infrequently, or applications that reuse a single downscoped credential many times.
-* Client-side: Uses the `ClientSideCredentialAccessBoundaryFactory` class. This
-  approach minimizes calls to STS. The client retrieves necessary cryptographic
-  material once and then generates multiple downscoped tokens locally. This is
-  more efficient for applications that need to generate many unique downscoped tokens.
+* **Server-side (using `DownscopedCredentials`):** The client calls the Security
+Token Service (STS) each time a downscoped token is needed. This is suitable for
+applications where the Credential Access Boundary rules change infrequently or 
+when a single downscoped credential is reused many times.  A key consideration 
+is that every rule change requires a new call to the STS.
 
+
+* **Client-side (using `ClientSideCredentialAccessBoundaryFactory`):** The client 
+retrieves cryptographic material once and then generates multiple downscoped 
+tokens locally. This minimizes calls to the STS and is more efficient when 
+Credential Access Boundary rules change frequently, as the client doesn't need 
+to contact the STS for each rule change.  This is also more efficient for 
+applications that need to generate many *unique* downscoped tokens.
 #### Server-side CAB
 
 The `DownscopedCredentials` class can be used to produce a downscoped access

--- a/README.md
+++ b/README.md
@@ -998,7 +998,7 @@ CredentialAccessBoundary:
 * **Server-side (using `DownscopedCredentials`):** The client calls the Security
 Token Service (STS) each time a downscoped token is needed. This is suitable for
 applications where the Credential Access Boundary rules change infrequently or 
-when a single downscoped credential is reused many times.  A key consideration 
+when a single downscoped credential is reused many times. A key consideration 
 is that every rule change requires a new call to the STS.
 
 
@@ -1006,8 +1006,9 @@ is that every rule change requires a new call to the STS.
 retrieves cryptographic material once and then generates multiple downscoped 
 tokens locally. This minimizes calls to the STS and is more efficient when 
 Credential Access Boundary rules change frequently, as the client doesn't need 
-to contact the STS for each rule change.  This is also more efficient for 
+to contact the STS for each rule change. This is also more efficient for 
 applications that need to generate many *unique* downscoped tokens.
+
 #### Server-side CAB
 
 The `DownscopedCredentials` class can be used to produce a downscoped access

--- a/README.md
+++ b/README.md
@@ -953,7 +953,7 @@ enables restricting the Identity and Access Management (IAM) permissions that a
 short-lived credential can use for Cloud Storage. This involves creating a
 `CredentialAccessBoundary` that defines the restrictions applied to the
 downscoped token. Using downscoped credentials ensures tokens in flight always
-have the least privileges (Principle of Least Privilege).
+have the least privileges ([Principle of Least Privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)).
 
 #### Creating a CredentialAccessBoundary
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,18 @@ Open source authentication client library for Java.
 
 -  [API Documentation](https://googleapis.dev/java/google-auth-library/latest)
 
-This project consists of 3 artifacts:
+This project consists of 4 artifacts:
 
 - [*google-auth-library-credentials*](#google-auth-library-credentials): contains base classes and
 interfaces for Google credentials
 - [*google-auth-library-appengine*](#google-auth-library-appengine): contains App Engine
 credentials. This artifact depends on the App Engine SDK.
-- [*google-auth-library-oauth2-http*](#google-auth-library-oauth2-http): contains a wide variety of
-credentials as well as utility methods to create them and to get Application Default Credentials
+- [*google-auth-library-oauth2-http*](#google-auth-library-oauth2-http): contains 
+a wide variety of credentials and utility methods, including functionality to get 
+Application Default Credentials. Also provides the server-side approach for generating
+downscoped tokens.
+- [*google-auth-library-cab-token-generator*](#google-auth-library-cab-token-generator):
+provides the client-side approach for generating downscoped tokens.
 
 **Table of contents:**
 
@@ -991,23 +995,28 @@ to a token consumer via some secure authenticated channel for limited access to 
 resources.
 
 #### Generating Downscoped Tokens
+There are two ways to generate downscoped tokens using a CredentialAccessBoundary:
 
-There are two ways to generate downscoped tokens using a
-CredentialAccessBoundary:
-
-* **Server-side (using `DownscopedCredentials`):** The client calls the Security
+* **Server-side (using `DownscopedCredentials`):** The client calls the Security 
 Token Service (STS) each time a downscoped token is needed. This is suitable for
 applications where the Credential Access Boundary rules change infrequently or 
-when a single downscoped credential is reused many times. A key consideration 
-is that every rule change requires a new call to the STS.
+when a single downscoped credential is reused many times.  A key consideration
+is that every rule change requires a new call to the STS. This approach is available 
+within the `google-auth-library-oauth2-http` library and does not require any additional 
+dependencies, making it simpler to integrate.  It's a good choice if your use case 
+doesn't demand the specific benefits of the client-side approach.
 
 
 * **Client-side (using `ClientSideCredentialAccessBoundaryFactory`):** The client 
-retrieves cryptographic material once and then generates multiple downscoped 
-tokens locally. This minimizes calls to the STS and is more efficient when 
-Credential Access Boundary rules change frequently, as the client doesn't need 
-to contact the STS for each rule change. This is also more efficient for 
-applications that need to generate many *unique* downscoped tokens.
+retrieves cryptographic material once and then generates multiple downscoped tokens 
+locally. This minimizes calls to the STS and is more efficient when Credential Access 
+Boundary rules change frequently, as the client doesn't need to contact the STS 
+for each rule change. This is also more efficient for applications that need to 
+generate many *unique* downscoped tokens.  This approach is available in the 
+`google-auth-library-cab-token-generator` module.  However, this module comes with 
+its own set of dependencies, which can add complexity to your project.  Consider
+this approach if minimizing STS calls and generating numerous unique tokens are 
+primary concerns and you are willing to manage the additional dependencies.
 
 #### Server-side CAB
 
@@ -1310,6 +1319,19 @@ Credentials credentials =
 
 **Important: `com.google.auth.appengine.AppEngineCredentials` is a separate class from
 `com.google.auth.oauth2.AppEngineCredentials`.**
+
+## google-auth-library-cab-token-generator
+
+This module provides the `ClientSideCredentialAccessBoundaryFactory` class, 
+enabling client-side generation of downscoped tokens for Cloud Storage using 
+Credential Access Boundaries. This approach is particularly useful for applications 
+requiring frequent changes to Credential Access Boundary rules or the generation 
+of many unique downscoped tokens, as it minimizes calls to the Security Token 
+Service (STS). For more details on when to consider this approach and how it 
+compares to the server-side method, see [Downscoping with Credential Access Boundaries](#downscoping-with-credential-access-boundaries). 
+For usage examples, see the [Client-side CAB](#client-side-cab) section. 
+This module comes with its own set of dependencies, so evaluate whether the 
+benefits of client-side downscoping outweigh the added complexity for your specific use case.
 
 ## CI Status
 


### PR DESCRIPTION
This commit updates the README file to include instructions for setting up and using the client-side CAB feature.

Design doc: [go/client-side-cab-client-library-java](http://goto.google.com/client-side-cab-client-library-java)