### PR TITLE
chore: add renovate-bot and release-please to members

### DIFF
--- a/.github/workflows/members.json
+++ b/.github/workflows/members.json
@@ -1,4 +1,6 @@
 [
+{"login":"renovate-bot"},
+{"login":"release-please"},
 {"login":"suztomo"},
 {"login":"dangazineu"},
 {"login":"ldetmer"},


### PR DESCRIPTION
The multi-approvers check will not require and additional human for these bot PRs.