### PR TITLE
chore: add step to download members.json

### DIFF
--- a/.github/workflows/multi_approvers.yaml
+++ b/.github/workflows/multi_approvers.yaml
@@ -26,6 +26,12 @@ concurrency:
 
 jobs:
   multi-approvers:
-    uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
-    with:
-      org-members-path: '.github/workflows/members.json'
+    steps:
+      - name: Download members.json
+        run: |
+          mkdir -p .github/workflows
+          wget https://raw.githubusercontent.com/googleapis/google-auth-library-java/refs/heads/main/.github/workflows/members.json -O .github/workflows/members.json
+
+      - uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
+        with:
+          org-members-path: '.github/workflows/members.json'


### PR DESCRIPTION
Download members.json so that the check works on other repos. Otherwise the following failure occurs:
https://github.com/googleapis/java-spanner/actions/runs/12993106224/job/36234542669