### PR TITLE
chore: Revert "chore: add step to download members.json"

### DIFF
--- a/.github/workflows/multi_approvers.yaml
+++ b/.github/workflows/multi_approvers.yaml
@@ -26,12 +26,6 @@ concurrency:
 
 jobs:
   multi-approvers:
-    steps:
-      - name: Download members.json
-        run: |
-          mkdir -p .github/workflows
-          wget https://raw.githubusercontent.com/googleapis/google-auth-library-java/refs/heads/main/.github/workflows/members.json -O .github/workflows/members.json
-
-      - uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
-        with:
-          org-members-path: '.github/workflows/members.json'
+    uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
+    with:
+      org-members-path: '.github/workflows/members.json'


### PR DESCRIPTION
Reverts googleapis/google-auth-library-java#1633

Reason: "reusable workflows should be referenced at the top-level `jobs.*.uses' key, not within steps"