### PR TITLE
chore: Add test for non-2xx responses from idTokenWithAudience calls

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -988,13 +988,14 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain(universeDomain)
             .build();
 
-    String targetAudience = "differentAudience";
+    String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
         IdTokenCredentials.newBuilder()
             .setIdTokenProvider(credentials)
             .setTargetAudience(targetAudience)
             .build();
 
+    // Ensure that a non 2xx status code returns an exception and doesn't continue execution
     assertThrows(IOException.class, tokenCredential::refresh);
   }
 
@@ -1015,13 +1016,15 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
             .setUniverseDomain(universeDomain)
             .build();
 
-    String targetAudience = "differentAudience";
+    String targetAudience = "audience";
     IdTokenCredentials tokenCredential =
         IdTokenCredentials.newBuilder()
             .setIdTokenProvider(credentials)
             .setTargetAudience(targetAudience)
             .build();
 
+    // Ensure that a non 2xx status code returns an exception and doesn't continue execution
+    // Non 2xx status codes will be returned as HttpResponseException
     assertThrows(IOException.class, tokenCredential::refresh);
   }
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -978,15 +978,10 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
 
   @Test
   public void idTokenWithAudience_oauthEndpoint_non2XXStatusCode() throws IOException {
-    String universeDomain = "test.com";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.setError(new IOException("404 Not Found"));
     ServiceAccountCredentials credentials =
-        createDefaultBuilder()
-            .setScopes(SCOPES)
-            .setHttpTransportFactory(transportFactory)
-            .setUniverseDomain(universeDomain)
-            .build();
+        createDefaultBuilder().setScopes(SCOPES).setHttpTransportFactory(transportFactory).build();
 
     String targetAudience = "audience";
     IdTokenCredentials tokenCredential =

--- a/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ServiceAccountCredentialsTest.java
@@ -977,7 +977,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void idTokenWithAudience_oauthEndpoint_non2XXError() throws IOException {
+  public void idTokenWithAudience_oauthEndpoint_non2XXStatusCode() throws IOException {
     String universeDomain = "test.com";
     MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
     transportFactory.transport.setError(new IOException("404 Not Found"));
@@ -1000,7 +1000,7 @@ public class ServiceAccountCredentialsTest extends BaseSerializationTest {
   }
 
   @Test
-  public void idTokenWithAudience_iamEndpoint_non2XXError() throws IOException {
+  public void idTokenWithAudience_iamEndpoint_non2XXStatusCode() throws IOException {
     String universeDomain = "test.com";
     MockIAMCredentialsServiceTransportFactory transportFactory =
         new MockIAMCredentialsServiceTransportFactory(universeDomain);

--- a/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/UserCredentialsTest.java
@@ -37,6 +37,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -811,6 +812,21 @@ public class UserCredentialsTest extends BaseSerializationTest {
       assertTrue(ex.isRetryable());
       assertEquals(0, ex.getRetryCount());
     }
+  }
+
+  @Test
+  public void idTokenWithAudience_non2xxError() throws IOException {
+    MockTokenServerTransportFactory transportFactory = new MockTokenServerTransportFactory();
+    transportFactory.transport.setError(new IOException("404 Not Found"));
+    String refreshToken = MockTokenServerTransport.REFRESH_TOKEN_WITH_USER_SCOPE;
+    InputStream userStream = writeUserStream(CLIENT_ID, CLIENT_SECRET, refreshToken, QUOTA_PROJECT);
+
+    UserCredentials credentials = UserCredentials.fromStream(userStream, transportFactory);
+
+    IdTokenCredentials tokenCredential =
+        IdTokenCredentials.newBuilder().setIdTokenProvider(credentials).build();
+
+    assertThrows(GoogleAuthException.class, tokenCredential::refresh);
   }
 
   @Test

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.31.0</version>
+      <version>1.32.0</version>
     </dependency>
 
 <!--    IAM dependency-->


### PR DESCRIPTION
I believe the issue that was reported in https://github.com/googleapis/google-auth-library-java/issues/1027 was actually resolved in https://github.com/googleapis/google-auth-library-java/pull/1636.

This PR is to add more tests to ensure that receiving non-2xx status codes back from the `idTokenWithAudience` are correctly caught.

Fixes https://github.com/googleapis/google-auth-library-java/issues/1027

