### PR TITLE
fix: Add cab-token-generator module to Auth BOM

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -64,6 +64,11 @@
         <artifactId>google-auth-library-appengine</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>com.google.auth</groupId>
+        <artifactId>google-auth-library-cab-token-generator</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
We missed this as part of the CAB Token Generator PR  CC: @nbayati 