### PR TITLE
Revert "feat: next release from main branch is 1.34.0 (#1698)"

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -34,7 +34,3 @@ branches:
     handleGHRelease: true
     releaseType: java-backport
     branch: 1.23.x
-  - bumpMinorPreMajor: true
-    handleGHRelease: true
-    releaseType: java-backport
-    branch: 1.33.x-LTS8

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -117,18 +117,6 @@ branchProtectionRules:
     requiredApprovingReviewCount: 1
     requiresCodeOwnerReviews: true
     requiresStrictStatusChecks: true
-  - pattern: 1.33.x-LTS8
-    isAdminEnforced: true
-    requiredStatusCheckContexts:
-      - dependencies (17)
-      - lint
-      - clirr
-      - units (8)
-      - units (11)
-      - cla/google
-    requiredApprovingReviewCount: 1
-    requiresCodeOwnerReviews: true
-    requiresStrictStatusChecks: true
 permissionRules:
   - team: Googlers
     permission: pull


### PR DESCRIPTION
This reverts commit fe4381513db1340190c4309a53c6265718682dde.

kokoro is only configured to run presubmit checks on branches end in .x
