### PR TITLE
fix: Do not add padding in Client-Side CAB tokens.

### DIFF
--- a/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -207,9 +207,12 @@ public class ClientSideCredentialAccessBoundaryFactory {
     byte[] encryptedRestrictions = this.encryptRestrictions(rawRestrictions, sessionKey);
 
     // withoutPadding() is used to stay consistent with server-side CAB
-    // withoutPadding() avoids additional URL encoded token issues (i.e. extra equal signs `=` in the path)
+    // withoutPadding() avoids additional URL encoded token issues (i.e. extra equal signs `=` in
+    // the path)
     String tokenValue =
-        intermediateToken + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(encryptedRestrictions);
+        intermediateToken
+            + "."
+            + Base64.getUrlEncoder().withoutPadding().encodeToString(encryptedRestrictions);
 
     return new AccessToken(tokenValue, intermediateTokenExpirationTime);
   }

--- a/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -206,6 +206,8 @@ public class ClientSideCredentialAccessBoundaryFactory {
 
     byte[] encryptedRestrictions = this.encryptRestrictions(rawRestrictions, sessionKey);
 
+    // withoutPadding() is used to stay consistent with server-side CAB
+    // withoutPadding() avoids additional URL encoded token issues (i.e. extra equal signs `=` in the path)
     String tokenValue =
         intermediateToken + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(encryptedRestrictions);
 

--- a/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
+++ b/cab-token-generator/java/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactory.java
@@ -207,7 +207,7 @@ public class ClientSideCredentialAccessBoundaryFactory {
     byte[] encryptedRestrictions = this.encryptRestrictions(rawRestrictions, sessionKey);
 
     String tokenValue =
-        intermediateToken + "." + Base64.getUrlEncoder().encodeToString(encryptedRestrictions);
+        intermediateToken + "." + Base64.getUrlEncoder().withoutPadding().encodeToString(encryptedRestrictions);
 
     return new AccessToken(tokenValue, intermediateTokenExpirationTime);
   }

--- a/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
+++ b/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
@@ -745,7 +745,9 @@ public class ClientSideCredentialAccessBoundaryFactoryTest {
     CabToken cabToken = parseCabToken(token);
     assertEquals("accessToken", cabToken.intermediateToken);
 
-    // Verifies the encrypted restriction has no padding
+    // Base64 encoding output by default has `=` padding at the end if the input length
+    // is not a multiple of 3. Here we verify the use of `withoutPadding` that removes
+    // this padding.
     assertFalse(cabToken.encryptedRestriction.contains(String.valueOf("=")));
 
     // Checks the encrypted restriction is the correct proto format of the CredentialAccessBoundary.
@@ -798,7 +800,9 @@ public class ClientSideCredentialAccessBoundaryFactoryTest {
     CabToken cabToken = parseCabToken(token);
     assertEquals("accessToken", cabToken.intermediateToken);
 
-    // Verifies the encrypted restriction has no padding
+    // Base64 encoding output by default has `=` padding at the end if the input length
+    // is not a multiple of 3. Here we verify the use of `withoutPadding` that removes
+    // this padding.
     assertFalse(cabToken.encryptedRestriction.contains(String.valueOf("=")));
 
     // Checks the encrypted restriction is the correct proto format of the CredentialAccessBoundary.

--- a/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
+++ b/cab-token-generator/javatests/com/google/auth/credentialaccessboundary/ClientSideCredentialAccessBoundaryFactoryTest.java
@@ -745,6 +745,9 @@ public class ClientSideCredentialAccessBoundaryFactoryTest {
     CabToken cabToken = parseCabToken(token);
     assertEquals("accessToken", cabToken.intermediateToken);
 
+    // Verifies the encrypted restriction has no padding
+    assertFalse(cabToken.encryptedRestriction.contains(String.valueOf("=")));
+
     // Checks the encrypted restriction is the correct proto format of the CredentialAccessBoundary.
     ClientSideAccessBoundary clientSideAccessBoundary =
         decryptRestriction(
@@ -794,6 +797,9 @@ public class ClientSideCredentialAccessBoundaryFactoryTest {
 
     CabToken cabToken = parseCabToken(token);
     assertEquals("accessToken", cabToken.intermediateToken);
+
+    // Verifies the encrypted restriction has no padding
+    assertFalse(cabToken.encryptedRestriction.contains(String.valueOf("=")));
 
     // Checks the encrypted restriction is the correct proto format of the CredentialAccessBoundary.
     ClientSideAccessBoundary clientSideAccessBoundary =


### PR DESCRIPTION
There are early adopters reporting that the padding at the end of the Client-Side CAB tokens can break some use cases including using URL-encoded token in URL. While we have other solutions to resolve this issue, we think it's better to remove the padding in the client library to stay consistent with other types of tokens.

