### PR TITLE
chore: add jdk 24 to test matrixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [11, 17, 21, 24]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 17, 21]
+        java: [11, 17, 21, 24]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v4


### PR DESCRIPTION
this is order to support latest graalvm update