### PR TITLE
Fix: Correct capitalization of GitHub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# Github action job to test core java library features on
+# GitHub action job to test core java library features on
 # downstream client libraries before they are released.
 on:
   push:

--- a/.kokoro/build.bat
+++ b/.kokoro/build.bat
@@ -11,7 +11,7 @@
 :: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 :: See the License for the specific language governing permissions and
 :: limitations under the License.
-:: Github action job to test core java library features on
+:: GitHub action job to test core java library features on
 :: downstream client libraries before they are released.
 :: See documentation in type-shell-output.bat
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -88,7 +88,7 @@ Central](https://repo1.maven.org/maven2/com/google/auth/google-auth-library-pare
     * In our case, `com.google.auth`
   * Click on the repository and check for errors
 * Submit the pull request to bump the version numbers
-* Update Javadoc on Github using `scripts/update_javadoc.sh`.
+* Update Javadoc on GitHub using `scripts/update_javadoc.sh`.
 * Run `releasetool tag` to create the GitHub release.
 * Run `releasetool start` to bump the next snapshot version. Select "snapshot" when prompted for
   the release type. This will bump the artifact versions and create a pull request.


### PR DESCRIPTION
Corrects improper capitalization of "GitHub" in documentation and workflow files.

Changes were made in:
- .github/workflows/ci.yaml
- RELEASE.md
- .kokoro/build.bat
