### PR TITLE
docs: Update Javadoc reference in ExternalAccountCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -763,7 +763,7 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     @Nullable protected ServiceAccountImpersonationOptions serviceAccountImpersonationOptions;
 
     /* The field is not being used and value not set. Superseded by the same field in the
-    {@link GoogleCredential.Builder}.
+    {@link GoogleCredentials.Builder}.
     */
     @Nullable @Deprecated protected String universeDomain;
 


### PR DESCRIPTION
The Javadoc for ExternalAccountCredentials.java incorrectly referred to `GoogleCredential.Builder`. This commit corrects the reference to `GoogleCredentials.Builder`.
