### PR TITLE
Fixes duplicate "the" in Javadoc comments

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/JwtCredentials.java
@@ -140,7 +140,7 @@ public class JwtCredentials extends Credentials implements JwtProvider {
   /**
    * Returns a copy of these credentials with modified claims.
    *
-   * @param newClaims new claims. Any unspecified claim fields default to the the current values.
+   * @param newClaims new claims. Any unspecified claim fields default to the current values.
    * @return new credentials
    */
   @Override

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -574,7 +574,7 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Result from {@link com.google.auth.oauth2.OAuth2Credentials#getOrCreateRefreshTask()}.
    *
-   * <p>Contains the the refresh task and a flag indicating if the task is newly created. If the
+   * <p>Contains the refresh task and a flag indicating if the task is newly created. If the
    * task is newly created, it is the caller's responsibility to execute it.
    */
   static class AsyncRefreshResult {

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountJwtAccessCredentials.java
@@ -336,7 +336,7 @@ public class ServiceAccountJwtAccessCredentials extends Credentials
   /**
    * Returns a new JwtCredentials instance with modified claims.
    *
-   * @param newClaims new claims. Any unspecified claim fields will default to the the current
+   * @param newClaims new claims. Any unspecified claim fields will default to the current
    *     values.
    * @return new credentials
    */


### PR DESCRIPTION
Removes occurrences of "the the" in Javadoc comments in the following files:
- OAuth2Credentials.java
- ServiceAccountJwtAccessCredentials.java
- JwtCredentials.java


