### PR TITLE
chore: demonstration of null calendar after reserialization of `ImpersonatedCredentials`

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -522,6 +522,29 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
   }
 
   @Test()
+  public void refreshAccessToken_reserialized_success() throws IOException, IllegalStateException, ClassNotFoundException {
+    mockTransportFactory.getTransport().setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+    mockTransportFactory.getTransport().setAccessToken(ACCESS_TOKEN);
+    mockTransportFactory.getTransport().setExpireTime(getDefaultExpireTime());
+    mockTransportFactory.getTransport().addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "", true);
+    ImpersonatedCredentials targetCredentials =
+        ImpersonatedCredentials.create(
+            sourceCredentials,
+            IMPERSONATED_CLIENT_EMAIL,
+            null,
+            IMMUTABLE_SCOPES_LIST,
+            VALID_LIFETIME,
+            mockTransportFactory);
+
+    targetCredentials.refreshAccessToken();
+    targetCredentials.refreshAccessToken();
+    targetCredentials.refreshAccessToken();
+    ImpersonatedCredentials reserializedCredentials = serializeAndDeserialize(targetCredentials);
+    reserializedCredentials.setTransportFactory(mockTransportFactory);
+    reserializedCredentials.refreshAccessToken();
+  }
+
+  @Test()
   public void refreshAccessToken_success_SSJflow() throws IOException, IllegalStateException {
     mockTransportFactory.getTransport().setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
     mockTransportFactory.getTransport().setAccessToken(ACCESS_TOKEN);


### PR DESCRIPTION
b/416096444

This test fails with:
```
java.lang.NullPointerException: Cannot invoke "java.util.Calendar.getDisplayNames(int, int, java.util.Locale)" because "this.calendar" is null

	at java.base/java.text.SimpleDateFormat.subParse(SimpleDateFormat.java:1980)
	at java.base/java.text.SimpleDateFormat.parse(SimpleDateFormat.java:1545)
	at java.base/java.text.DateFormat.parse(DateFormat.java:397)
	at com.google.auth.oauth2.ImpersonatedCredentials.refreshAccessToken(ImpersonatedCredentials.java:579)
	at com.google.auth.oauth2.ImpersonatedCredentialsTest.refreshAccessToken_reserialized_success(ImpersonatedCredentialsTest.java:544)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

This is due to `this.calendar` marked as `transient`:
https://github.com/googleapis/google-auth-library-java/blob/d02ab85ae8d29402650d3cbf00e00363a903fe31/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java#L118

We must understand the reasons for:
 - Including the calendar in the credentials object (instead of maybe using UTC, as pointed out by @lqiu96)
 - Marking the calendar as `transient`