### PR TITLE
fix: Override toBuilder() for ExternalAccountCredential and subclasses

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java
@@ -233,6 +233,11 @@ public class AwsCredentials extends ExternalAccountCredentials {
     return new AwsCredentials.Builder(awsCredentials);
   }
 
+  @Override
+  public AwsCredentials.Builder toBuilder() {
+    return new AwsCredentials.Builder(this);
+  }
+
   public static class Builder extends ExternalAccountCredentials.Builder {
 
     private AwsSecurityCredentialsSupplier awsSecurityCredentialsSupplier;

--- a/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java
@@ -682,6 +682,9 @@ public abstract class ExternalAccountCredentials extends GoogleCredentials {
     return true;
   }
 
+  @Override
+  public abstract ExternalAccountCredentials.Builder toBuilder();
+
   /**
    * Encapsulates the service account impersonation options portion of the configuration for
    * ExternalAccountCredentials.

--- a/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java
@@ -153,6 +153,11 @@ public class IdentityPoolCredentials extends ExternalAccountCredentials {
     return new Builder(identityPoolCredentials);
   }
 
+  @Override
+  public IdentityPoolCredentials.Builder toBuilder() {
+    return new IdentityPoolCredentials.Builder(this);
+  }
+
   private IdentityPoolSubjectTokenSupplier createCertificateSubjectTokenSupplier(
       Builder builder, IdentityPoolCredentialSource credentialSource) throws IOException {
     // Configure the mTLS transport with the x509 keystore.

--- a/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java
@@ -203,6 +203,11 @@ public class PluggableAuthCredentials extends ExternalAccountCredentials {
     return new Builder(pluggableAuthCredentials);
   }
 
+  @Override
+  public PluggableAuthCredentials.Builder toBuilder() {
+    return new PluggableAuthCredentials.Builder(this);
+  }
+
   @VisibleForTesting
   @Nullable
   ExecutableHandler getExecutableHandler() {


### PR DESCRIPTION
See b/393551276 for more information

Note: This does add `public abstract ExternalAccountCredentials.Builder toBuilder();` to a public class which will fail the CLIRR checks.