### PR TITLE
deps: Update google-http-client to v2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.google.http.version>1.47.0</project.google.http.version>
+    <project.google.http.version>2.0.0</project.google.http.version>
     <project.junit.version>4.13.2</project.junit.version>
     <project.guava.version>33.4.0-android</project.guava.version>
     <project.appengine.version>2.0.33</project.appengine.version>


### PR DESCRIPTION
Manually creating this PR because renovate is slow

Auth also uses http-client:
```
Error:  +-com.google.cloud:google-cloud-core-http:2.60.1-SNAPSHOT
Error:    +-com.google.api-client:google-api-client:2.8.1
Error:      +-com.google.http-client:google-http-client-apache-v2:1.47.1 (managed) <-- com.google.http-client:google-http-client-apache-v2:2.0.0
Error:  , 
Error:  Require upper bound dependencies error for com.google.http-client:google-http-client:1.47.1 paths to dependency are:
Error:  +-com.google.cloud:google-cloud-core-http:2.60.1-SNAPSHOT
Error:    +-com.google.http-client:google-http-client:1.47.1
Error:  and
Error:  +-com.google.cloud:google-cloud-core-http:2.60.1-SNAPSHOT
Error:    +-com.google.cloud:google-cloud-core:2.60.1-SNAPSHOT
Error:      +-com.google.http-client:google-http-client:1.47.1 (managed) <-- com.google.http-client:google-http-client:1.47.1
Error:  and
Error:  +-com.google.cloud:google-cloud-core-http:2.60.1-SNAPSHOT
Error:    +-com.google.auth:google-auth-library-oauth2-http:1.37.1
Error:      +-com.google.http-client:google-http-client:1.47.1 (managed) <-- com.google.http-client:google-http-client:1.47.0
```

From https://github.com/googleapis/sdk-platform-java/actions/runs/17109334878/job/48526565817?pr=3888