### PR TITLE
feat: Add trust boundary support for service account

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -380,8 +380,11 @@ public class ComputeEngineCredentials extends GoogleCredentials
     int expiresInSeconds =
         OAuth2Utils.validateInt32(responseData, "expires_in", PARSE_ERROR_PREFIX);
     long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000;
+    AccessToken newAccessToken = new AccessToken(accessToken, new Date(expiresAtMilliseconds));
 
-    return new AccessToken(accessToken, new Date(expiresAtMilliseconds));
+    refreshTrustBoundaries(newAccessToken);
+
+    return newAccessToken;
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -82,7 +82,7 @@ import java.util.logging.Logger;
  * <p>These credentials use the IAM API to sign data. See {@link #sign(byte[])} for more details.
  */
 public class ComputeEngineCredentials extends GoogleCredentials
-    implements ServiceAccountSigner, IdTokenProvider {
+    implements ServiceAccountSigner, IdTokenProvider, TrustBoundaryCredentials {
 
   static final String METADATA_RESPONSE_EMPTY_CONTENT_ERROR_MESSAGE =
       "Empty content from metadata token server request.";
@@ -187,6 +187,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
 
   private final GoogleAuthTransport transport;
   private final BindingEnforcement bindingEnforcement;
+  private final boolean trustBoundaryEnabled;
 
   private transient HttpTransportFactory transportFactory;
   private transient String serviceAccountEmail;
@@ -220,6 +221,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
     }
     this.transport = builder.getGoogleAuthTransport();
     this.bindingEnforcement = builder.getBindingEnforcement();
+    this.trustBoundaryEnabled = builder.isTrustBoundaryEnabled();
   }
 
   @Override
@@ -698,6 +700,16 @@ public class ComputeEngineCredentials extends GoogleCredentials
     return serviceAccountEmail;
   }
 
+  @Override
+  public boolean isTrustBoundaryEnabled() {
+    return trustBoundaryEnabled;
+  }
+
+  @Override
+  public HttpTransportFactory getTransportFactory() {
+    return transportFactory;
+  }
+
   /**
    * Signs the provided bytes using the private key associated with the service account.
    *
@@ -781,6 +793,7 @@ public class ComputeEngineCredentials extends GoogleCredentials
       super(credentials);
       this.transportFactory = credentials.transportFactory;
       this.scopes = credentials.scopes;
+      // trustBoundaryEnabled is handled by super(credentials)
     }
 
     @CanIgnoreReturnValue
@@ -798,6 +811,18 @@ public class ComputeEngineCredentials extends GoogleCredentials
     @CanIgnoreReturnValue
     public Builder setDefaultScopes(Collection<String> defaultScopes) {
       this.defaultScopes = defaultScopes;
+      return this;
+    }
+
+    /**
+     * Sets whether trust boundary is enabled. This is an experimental feature.
+     *
+     * @param trustBoundaryEnabled whether trust boundary is enabled
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public Builder setTrustBoundaryEnabled(boolean trustBoundaryEnabled) {
+      super.setTrustBoundaryEnabled(trustBoundaryEnabled);
       return this;
     }
 

--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -115,6 +115,7 @@ class DefaultCredentialsProvider {
    */
   final GoogleCredentials getDefaultCredentials(HttpTransportFactory transportFactory)
       throws IOException {
+    LOGGER.log(Level.FINE, "ajbhdabjh");
     synchronized (this) {
       if (cachedCredentials == null) {
         cachedCredentials = getDefaultCredentialsUnsynchronized(transportFactory);

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -308,7 +308,10 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     return Collections.unmodifiableMap(newRequestMetadata);
   }
 
-  private void refreshTrustBoundaries(AccessToken newAccessToken) throws IOException {
+  protected void refreshTrustBoundaries(AccessToken newAccessToken) throws IOException {
+    if (!(this instanceof TrustBoundaryProvider)) {
+      return;
+    }
     if (!TrustBoundary.isTrustBoundaryEnabled() || !isDefaultUniverseDomain()) {
       return;
     }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 
@@ -257,6 +256,10 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
     return this.toBuilder().setQuotaProjectId(quotaProject).build();
   }
 
+  public TrustBoundary getTrustBoundary() {
+    return trustBoundary;
+  }
+
   /**
    * Gets the universe domain for the credential.
    *
@@ -321,12 +324,11 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
       // Refresh trust boundaries only if the cached value is not NO_OP.
       if (this.trustBoundary == null || !this.trustBoundary.isNoOp()) {
         try {
-          this.trustBoundary =
-              TrustBoundary.refresh(
-                  provider.getTransportFactory(),
-                  provider.getTrustBoundaryUrl(),
-                  newAccessToken,
-                  this.trustBoundary);
+          this.trustBoundary = TrustBoundary.refresh(
+              provider.getTransportFactory(),
+              provider.getTrustBoundaryUrl(),
+              newAccessToken,
+              this.trustBoundary);
         } catch (IOException e) {
           // If refresh fails, check for cached value.
           if (this.trustBoundary == null) {
@@ -334,11 +336,6 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
             throw new IOException(
                 "Failed to refresh trust boundary and no cached value is available.", e);
           }
-          LoggingUtils.log(
-              LOGGER_PROVIDER,
-              Level.WARNING,
-              Collections.singletonMap("cause", e.toString()),
-              "TrustBoundary: Failure while getting trust boundaries. Using cached value.");
         }
       }
     }

--- a/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java
@@ -346,19 +346,11 @@ public class GoogleCredentials extends OAuth2Credentials implements QuotaProject
 
  @Override
   protected Map<String, List<String>> getAdditionalHeaders() {
-    Map<String, List<String>> headers = super.getAdditionalHeaders();
+    Map<String, List<String>> headers = new HashMap<>(super.getAdditionalHeaders());
     String quotaProjectId = this.getQuotaProjectId();
     if (quotaProjectId != null) {
-      return addQuotaProjectIdToRequestMetadata(quotaProjectId, headers);
+      headers.put(QUOTA_PROJECT_ID_HEADER_KEY, Collections.singletonList(quotaProjectId));
     }
-    return headers;
-  }
-
-@Override
-  protected Map<String, List<String>> refreshTrustBoundaryAndGetAdditionalHeaders(AccessToken newAccessToken) throws IOException{
-    Map<String, List<String>> headers = new HashMap<>(getAdditionalHeaders());
-
-    refreshTrustBoundaries(newAccessToken);
 
     if (this.trustBoundary != null) {
       String headerValue = trustBoundary.isNoOp() ? "" : trustBoundary.getEncodedLocations();

--- a/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java
@@ -589,7 +589,11 @@ public class ImpersonatedCredentials extends GoogleCredentials
     format.setCalendar(calendar);
     try {
       Date date = format.parse(expireTime);
-      return new AccessToken(accessToken, date);
+      AccessToken newAccessToken = new AccessToken(accessToken, date);
+
+      refreshTrustBoundaries(newAccessToken);
+
+      return newAccessToken;
     } catch (ParseException pe) {
       throw new IOException("Error parsing expireTime: " + pe.getMessage());
     }

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -31,6 +31,22 @@
 
 package com.google.auth.oauth2;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+
+import javax.annotation.Nullable;
+
 import com.google.api.client.util.Clock;
 import com.google.auth.Credentials;
 import com.google.auth.RequestMetadataCallback;
@@ -48,21 +64,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.Serializable;
-import java.net.URI;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.ServiceLoader;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import javax.annotation.Nullable;
 
 /** Base type for Credentials using OAuth2. */
 public class OAuth2Credentials extends Credentials {
@@ -264,11 +265,8 @@ public class OAuth2Credentials extends Credentials {
 
       final ListenableFutureTask<OAuthValue> task =
           ListenableFutureTask.create(
-              new Callable<OAuthValue>() {
-                @Override
-                public OAuthValue call() throws Exception {
-                  return OAuthValue.create(refreshAccessToken(), getAdditionalHeaders());
-                }
+              () -> {
+                return OAuthValue.create(refreshAccessToken(), refreshAndGetAdditionalHeaders());
               });
 
       refreshTask = new RefreshTask(task, new RefreshTaskListener(task));
@@ -377,6 +375,11 @@ public class OAuth2Credentials extends Credentials {
    */
   protected Map<String, List<String>> getAdditionalHeaders() {
     return EMPTY_EXTRA_HEADERS;
+  }
+
+  /** Refresh additional headers. By default, it calls {@link #getAdditionalHeaders()}. */
+  protected Map<String, List<String>> refreshAndGetAdditionalHeaders() throws IOException {
+    return getAdditionalHeaders();
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -266,14 +266,7 @@ public class OAuth2Credentials extends Credentials {
       final ListenableFutureTask<OAuthValue> task =
           ListenableFutureTask.create(
               () -> {
-                AccessToken newAccessToken = refreshAccessToken();
-                Map<String, List<String>> newHeaders;
-                if(this instanceof TrustBoundaryProvider) {
-                  newHeaders = refreshTrustBoundaryAndGetAdditionalHeaders(newAccessToken);
-                } else{
-                  newHeaders = getAdditionalHeaders();
-                }
-                return OAuthValue.create(newAccessToken, newHeaders);
+                return OAuthValue.create(refreshAccessToken(), getAdditionalHeaders());
               });
 
       refreshTask = new RefreshTask(task, new RefreshTaskListener(task));
@@ -383,16 +376,6 @@ public class OAuth2Credentials extends Credentials {
   protected Map<String, List<String>> getAdditionalHeaders() {
     return EMPTY_EXTRA_HEADERS;
   }
-
-  /**
-   * Refresh trust boundary and get additional headers to return as request metadata.
-   *
-   * @return additional headers.
-   */
-  protected Map<String, List<String>> refreshTrustBoundaryAndGetAdditionalHeaders(AccessToken newAccessToken) throws IOException {
-    return EMPTY_EXTRA_HEADERS;
-  }
-
 
   /**
    * Adds a listener that is notified when the Credentials data changes.

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -266,7 +266,9 @@ public class OAuth2Credentials extends Credentials {
       final ListenableFutureTask<OAuthValue> task =
           ListenableFutureTask.create(
               () -> {
-                return OAuthValue.create(refreshAccessToken(), refreshAndGetAdditionalHeaders());
+                AccessToken newAccessToken = refreshAccessToken();
+                Map<String, List<String>> newHeaders = refreshAndGetAdditionalHeaders(newAccessToken);
+                return OAuthValue.create(newAccessToken, newHeaders);
               });
 
       refreshTask = new RefreshTask(task, new RefreshTaskListener(task));
@@ -371,16 +373,27 @@ public class OAuth2Credentials extends Credentials {
   /**
    * Provide additional headers to return as request metadata.
    *
-   * @return additional headers
+   * @return additional headers.
+   * @deprecated This method is no longer used for refreshing headers. Override {@link
+   *     #refreshAndGetAdditionalHeaders(AccessToken)} instead. This method will be removed in a
+   *     future major version.
    */
+  @Deprecated
   protected Map<String, List<String>> getAdditionalHeaders() {
     return EMPTY_EXTRA_HEADERS;
   }
 
-  /** Refresh additional headers. By default, it calls {@link #getAdditionalHeaders()}. */
-  protected Map<String, List<String>> refreshAndGetAdditionalHeaders() throws IOException {
+  /**
+   * Refresh additional headers.
+   *
+   * @deprecated This method is no longer used for refreshing headers. Override {@link
+   *     #refreshAndGetAdditionalHeaders(AccessToken)} instead. This method will be removed in a
+   *     future major version.
+   */
+  protected Map<String, List<String>> refreshAndGetAdditionalHeaders(AccessToken newAccessToken) throws IOException {
     return getAdditionalHeaders();
   }
+
 
   /**
    * Adds a listener that is notified when the Credentials data changes.

--- a/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java
@@ -267,7 +267,12 @@ public class OAuth2Credentials extends Credentials {
           ListenableFutureTask.create(
               () -> {
                 AccessToken newAccessToken = refreshAccessToken();
-                Map<String, List<String>> newHeaders = refreshAndGetAdditionalHeaders(newAccessToken);
+                Map<String, List<String>> newHeaders;
+                if(this instanceof TrustBoundaryProvider) {
+                  newHeaders = refreshTrustBoundaryAndGetAdditionalHeaders(newAccessToken);
+                } else{
+                  newHeaders = getAdditionalHeaders();
+                }
                 return OAuthValue.create(newAccessToken, newHeaders);
               });
 
@@ -374,24 +379,18 @@ public class OAuth2Credentials extends Credentials {
    * Provide additional headers to return as request metadata.
    *
    * @return additional headers.
-   * @deprecated This method is no longer used for refreshing headers. Override {@link
-   *     #refreshAndGetAdditionalHeaders(AccessToken)} instead. This method will be removed in a
-   *     future major version.
    */
-  @Deprecated
   protected Map<String, List<String>> getAdditionalHeaders() {
     return EMPTY_EXTRA_HEADERS;
   }
 
   /**
-   * Refresh additional headers.
+   * Refresh trust boundary and get additional headers to return as request metadata.
    *
-   * @deprecated This method is no longer used for refreshing headers. Override {@link
-   *     #refreshAndGetAdditionalHeaders(AccessToken)} instead. This method will be removed in a
-   *     future major version.
+   * @return additional headers.
    */
-  protected Map<String, List<String>> refreshAndGetAdditionalHeaders(AccessToken newAccessToken) throws IOException {
-    return getAdditionalHeaders();
+  protected Map<String, List<String>> refreshTrustBoundaryAndGetAdditionalHeaders(AccessToken newAccessToken) throws IOException {
+    return EMPTY_EXTRA_HEADERS;
   }
 
 

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -89,7 +89,7 @@ import java.util.concurrent.Executor;
  * <p>By default uses a JSON Web Token (JWT) to fetch access tokens.
  */
 public class ServiceAccountCredentials extends GoogleCredentials
-    implements ServiceAccountSigner, IdTokenProvider, JwtProvider {
+    implements ServiceAccountSigner, IdTokenProvider, JwtProvider, TrustBoundaryCredentials {
 
   private static final long serialVersionUID = 7807543542681217978L;
   private static final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
@@ -112,6 +112,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
   private final int lifetime;
   private final boolean useJwtAccessWithScope;
   private final boolean defaultRetriesEnabled;
+  private final boolean trustBoundaryEnabled;
 
   private transient HttpTransportFactory transportFactory;
 
@@ -150,6 +151,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     this.lifetime = builder.lifetime;
     this.useJwtAccessWithScope = builder.useJwtAccessWithScope;
     this.defaultRetriesEnabled = builder.defaultRetriesEnabled;
+    this.trustBoundaryEnabled = builder.trustBoundaryEnabled;
   }
 
   /**
@@ -817,6 +819,16 @@ public class ServiceAccountCredentials extends GoogleCredentials
     return useJwtAccessWithScope;
   }
 
+  @Override
+  public boolean isTrustBoundaryEnabled() {
+    return trustBoundaryEnabled;
+  }
+
+  @Override
+  public HttpTransportFactory getTransportFactory() {
+    return transportFactory;
+  }
+
   @VisibleForTesting
   JwtCredentials getSelfSignedJwtCredentialsWithScope() {
     return selfSignedJwtCredentialsWithScope;
@@ -871,6 +883,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
         lifetime,
         useJwtAccessWithScope,
         defaultRetriesEnabled,
+        trustBoundaryEnabled,
         super.hashCode());
   }
 
@@ -887,7 +900,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
         .add("serviceAccountUser", serviceAccountUser)
         .add("lifetime", lifetime)
         .add("useJwtAccessWithScope", useJwtAccessWithScope)
-        .add("defaultRetriesEnabled", defaultRetriesEnabled);
+        .add("defaultRetriesEnabled", defaultRetriesEnabled)
+        .add("trustBoundaryEnabled", trustBoundaryEnabled);
   }
 
   @Override
@@ -910,7 +924,8 @@ public class ServiceAccountCredentials extends GoogleCredentials
         && Objects.equals(this.defaultScopes, other.defaultScopes)
         && Objects.equals(this.lifetime, other.lifetime)
         && Objects.equals(this.useJwtAccessWithScope, other.useJwtAccessWithScope)
-        && Objects.equals(this.defaultRetriesEnabled, other.defaultRetriesEnabled);
+        && Objects.equals(this.defaultRetriesEnabled, other.defaultRetriesEnabled)
+        && Objects.equals(this.trustBoundaryEnabled, other.trustBoundaryEnabled);
   }
 
   String createAssertion(JsonFactory jsonFactory, long currentTime) throws IOException {
@@ -1142,6 +1157,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
     private boolean useJwtAccessWithScope = false;
     private boolean defaultRetriesEnabled = true;
+    private boolean trustBoundaryEnabled = false;
 
     protected Builder() {}
 
@@ -1160,6 +1176,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
       this.lifetime = credentials.lifetime;
       this.useJwtAccessWithScope = credentials.useJwtAccessWithScope;
       this.defaultRetriesEnabled = credentials.defaultRetriesEnabled;
+      this.trustBoundaryEnabled = credentials.trustBoundaryEnabled;
     }
 
     @CanIgnoreReturnValue
@@ -1259,6 +1276,18 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return this;
     }
 
+    /**
+     * Sets whether trust boundary is enabled. This is an experimental feature.
+     *
+     * @param trustBoundaryEnabled whether trust boundary is enabled
+     * @return this {@code Builder} object
+     */
+    @CanIgnoreReturnValue
+    public Builder setTrustBoundaryEnabled(boolean trustBoundaryEnabled) {
+      this.trustBoundaryEnabled = trustBoundaryEnabled;
+      return this;
+    }
+
     public Builder setUniverseDomain(String universeDomain) {
       super.universeDomain = universeDomain;
       return this;
@@ -1314,6 +1343,10 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
     public boolean isDefaultRetriesEnabled() {
       return defaultRetriesEnabled;
+    }
+
+    public boolean isTrustBoundaryEnabled() {
+      return trustBoundaryEnabled;
     }
 
     @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -578,7 +578,11 @@ public class ServiceAccountCredentials extends GoogleCredentials
     int expiresInSeconds =
         OAuth2Utils.validateInt32(responseData, "expires_in", PARSE_ERROR_PREFIX);
     long expiresAtMilliseconds = clock.currentTimeMillis() + expiresInSeconds * 1000L;
-    return new AccessToken(accessToken, new Date(expiresAtMilliseconds));
+    AccessToken newAccessToken = new AccessToken(accessToken, new Date(expiresAtMilliseconds));
+
+    refreshTrustBoundaries(newAccessToken);
+
+    return newAccessToken;
   }
 
   /**

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -31,7 +31,24 @@
 
 package com.google.auth.oauth2;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
 
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpBackOffIOExceptionHandler;
@@ -60,28 +77,11 @@ import com.google.auth.http.HttpTransportFactory;
 import com.google.auth.oauth2.MetricsUtils.RequestType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects.ToStringHelper;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.Signature;
-import java.security.SignatureException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.Executor;
 
 /**
  * OAuth2 credentials representing a Service Account for calling Google APIs.
@@ -89,7 +89,7 @@ import java.util.concurrent.Executor;
  * <p>By default uses a JSON Web Token (JWT) to fetch access tokens.
  */
 public class ServiceAccountCredentials extends GoogleCredentials
-    implements ServiceAccountSigner, IdTokenProvider, JwtProvider, TrustBoundaryCredentials {
+    implements ServiceAccountSigner, IdTokenProvider, JwtProvider, TrustBoundaryProvider {
 
   private static final long serialVersionUID = 7807543542681217978L;
   private static final String GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
@@ -112,7 +112,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
   private final int lifetime;
   private final boolean useJwtAccessWithScope;
   private final boolean defaultRetriesEnabled;
-  private final boolean trustBoundaryEnabled;
 
   private transient HttpTransportFactory transportFactory;
 
@@ -151,7 +150,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
     this.lifetime = builder.lifetime;
     this.useJwtAccessWithScope = builder.useJwtAccessWithScope;
     this.defaultRetriesEnabled = builder.defaultRetriesEnabled;
-    this.trustBoundaryEnabled = builder.trustBoundaryEnabled;
   }
 
   /**
@@ -820,13 +818,15 @@ public class ServiceAccountCredentials extends GoogleCredentials
   }
 
   @Override
-  public boolean isTrustBoundaryEnabled() {
-    return trustBoundaryEnabled;
+  public HttpTransportFactory getTransportFactory() {
+    return transportFactory;
   }
 
   @Override
-  public HttpTransportFactory getTransportFactory() {
-    return transportFactory;
+  public String getTrustBoundaryUrl() throws IOException {
+    return String.format(
+        "https://iamcredentials.%s/v1/projects/-/serviceAccounts/%s/allowedLocations",
+        getUniverseDomain(), getClientEmail());
   }
 
   @VisibleForTesting
@@ -883,7 +883,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
         lifetime,
         useJwtAccessWithScope,
         defaultRetriesEnabled,
-        trustBoundaryEnabled,
         super.hashCode());
   }
 
@@ -900,8 +899,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
         .add("serviceAccountUser", serviceAccountUser)
         .add("lifetime", lifetime)
         .add("useJwtAccessWithScope", useJwtAccessWithScope)
-        .add("defaultRetriesEnabled", defaultRetriesEnabled)
-        .add("trustBoundaryEnabled", trustBoundaryEnabled);
+        .add("defaultRetriesEnabled", defaultRetriesEnabled);
   }
 
   @Override
@@ -924,8 +922,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
         && Objects.equals(this.defaultScopes, other.defaultScopes)
         && Objects.equals(this.lifetime, other.lifetime)
         && Objects.equals(this.useJwtAccessWithScope, other.useJwtAccessWithScope)
-        && Objects.equals(this.defaultRetriesEnabled, other.defaultRetriesEnabled)
-        && Objects.equals(this.trustBoundaryEnabled, other.trustBoundaryEnabled);
+        && Objects.equals(this.defaultRetriesEnabled, other.defaultRetriesEnabled);
   }
 
   String createAssertion(JsonFactory jsonFactory, long currentTime) throws IOException {
@@ -1157,7 +1154,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
     private boolean useJwtAccessWithScope = false;
     private boolean defaultRetriesEnabled = true;
-    private boolean trustBoundaryEnabled = false;
 
     protected Builder() {}
 
@@ -1176,7 +1172,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
       this.lifetime = credentials.lifetime;
       this.useJwtAccessWithScope = credentials.useJwtAccessWithScope;
       this.defaultRetriesEnabled = credentials.defaultRetriesEnabled;
-      this.trustBoundaryEnabled = credentials.trustBoundaryEnabled;
     }
 
     @CanIgnoreReturnValue
@@ -1276,18 +1271,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
       return this;
     }
 
-    /**
-     * Sets whether trust boundary is enabled. This is an experimental feature.
-     *
-     * @param trustBoundaryEnabled whether trust boundary is enabled
-     * @return this {@code Builder} object
-     */
-    @CanIgnoreReturnValue
-    public Builder setTrustBoundaryEnabled(boolean trustBoundaryEnabled) {
-      this.trustBoundaryEnabled = trustBoundaryEnabled;
-      return this;
-    }
-
     public Builder setUniverseDomain(String universeDomain) {
       super.universeDomain = universeDomain;
       return this;
@@ -1343,10 +1326,6 @@ public class ServiceAccountCredentials extends GoogleCredentials
 
     public boolean isDefaultRetriesEnabled() {
       return defaultRetriesEnabled;
-    }
-
-    public boolean isTrustBoundaryEnabled() {
-      return trustBoundaryEnabled;
     }
 
     @Override

--- a/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ServiceAccountCredentials.java
@@ -1158,6 +1158,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
     private int lifetime = DEFAULT_LIFETIME_IN_SECONDS;
     private boolean useJwtAccessWithScope = false;
     private boolean defaultRetriesEnabled = true;
+    private TrustBoundary trustBoundary;
 
     protected Builder() {}
 
@@ -1176,6 +1177,7 @@ public class ServiceAccountCredentials extends GoogleCredentials
       this.lifetime = credentials.lifetime;
       this.useJwtAccessWithScope = credentials.useJwtAccessWithScope;
       this.defaultRetriesEnabled = credentials.defaultRetriesEnabled;
+      this.trustBoundary = credentials.getTrustBoundary();
     }
 
     @CanIgnoreReturnValue

--- a/oauth2_http/java/com/google/auth/oauth2/TrustBoundary.java
+++ b/oauth2_http/java/com/google/auth/oauth2/TrustBoundary.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024, Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import java.io.IOException;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.auth.http.HttpTransportFactory;
+
+/**
+ * Represents a trust boundary that can be used to restrict access to resources. This is an
+ * experimental feature.
+ */
+public final class TrustBoundary {
+
+  static final String TRUST_BOUNDARY_KEY = "x-goog-trust-boundary";
+  private static final String TRUST_BOUNDARY_ENDPOINT = "https://sts.googleapis.com/v1/trustBoundary";
+
+  private final boolean enabled;
+  private final String value;
+
+  private TrustBoundary(boolean enabled, String value) {
+    this.enabled = enabled;
+    this.value = value;
+  }
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static TrustBoundary refresh(HttpTransportFactory transportFactory) throws IOException {
+    HttpRequestFactory requestFactory = transportFactory.create().createRequestFactory();
+    HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(TRUST_BOUNDARY_ENDPOINT));
+    request.setParser(new JsonObjectParser(OAuth2Utils.JSON_FACTORY));
+    HttpResponse response = request.execute();
+    GenericJson json = response.parseAs(GenericJson.class);
+    boolean enabled = (boolean) json.get("enabled");
+    String value = (String) json.get("value");
+    return new TrustBoundary(enabled, value);
+  }
+}

--- a/oauth2_http/java/com/google/auth/oauth2/TrustBoundary.java
+++ b/oauth2_http/java/com/google/auth/oauth2/TrustBoundary.java
@@ -147,22 +147,20 @@ static final String TRUST_BOUNDARY_KEY = "x-allowed-locations";
 
     HttpRequestFactory requestFactory = transportFactory.create().createRequestFactory();
     HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
-    // request.getHeaders().setAuthorization("Bearer " + accessToken.getTokenValue());
+    request.getHeaders().setAuthorization("Bearer " + accessToken.getTokenValue());
 
     // Add the cached trust boundary header, if available.
     if (cachedTrustBoundary != null) {
       String headerValue =
           cachedTrustBoundary.isNoOp() ? "" : cachedTrustBoundary.getEncodedLocations();
-      // request.getHeaders().set(TRUST_BOUNDARY_KEY, headerValue);
+      request.getHeaders().set(TRUST_BOUNDARY_KEY, headerValue);
     }
         TrustBoundaryResponse json;
     try {
       HttpResponse response = request.execute();
       String responseString = response.parseAsString();
-      System.out.println("TrustBoundary lookup endpoint response: " + responseString);
       JsonParser parser = OAuth2Utils.JSON_FACTORY.createJsonParser(responseString);
       json = parser.parseAndClose(TrustBoundaryResponse.class);
-      System.out.println("TrustBoundary lookup endpoint json response: " + json.toString());
 
     } catch (HttpResponseException e) {
       throw new IOException(

--- a/oauth2_http/java/com/google/auth/oauth2/TrustBoundaryCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/TrustBoundaryCredentials.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024, Google LLC
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google LLC nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.google.auth.oauth2;
+
+import com.google.auth.http.HttpTransportFactory;
+
+/**
+ * An interface for credentials that support trust boundaries. This is an experimental feature.
+ */
+public interface TrustBoundaryCredentials {
+
+  /** Returns whether trust boundary is enabled. */
+  boolean isTrustBoundaryEnabled();
+
+  /** Returns the transport factory. */
+  HttpTransportFactory getTransportFactory();
+}

--- a/oauth2_http/java/com/google/auth/oauth2/TrustBoundaryProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/TrustBoundaryProvider.java
@@ -31,16 +31,18 @@
 
 package com.google.auth.oauth2;
 
+import java.io.IOException;
+
 import com.google.auth.http.HttpTransportFactory;
 
 /**
  * An interface for credentials that support trust boundaries. This is an experimental feature.
  */
-public interface TrustBoundaryCredentials {
-
-  /** Returns whether trust boundary is enabled. */
-  boolean isTrustBoundaryEnabled();
+public interface TrustBoundaryProvider {
 
   /** Returns the transport factory. */
   HttpTransportFactory getTransportFactory();
+
+  /** Returns the trust boundary lookup URL. */
+  String getTrustBoundaryUrl() throws IOException;
 }

--- a/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ComputeEngineCredentialsTest.java
@@ -68,6 +68,7 @@ import java.util.Queue;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -417,6 +418,11 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
         scopedCredentialCopy.getRequestMetadata(CALL_URI);
     TestUtils.assertContainsBearerToken(metadataForCopiedCredentials, ACCESS_TOKEN_WITH_SCOPES);
     TestUtils.assertNotContainsBearerToken(metadataForCopiedCredentials, ACCESS_TOKEN);
+  }
+
+  @After
+  public void tearDown() {
+    TrustBoundary.setEnvironmentProviderForTest(null);
   }
 
   @Test
@@ -1140,6 +1146,43 @@ public class ComputeEngineCredentialsTest extends BaseSerializationTest {
     assertThrows(
         GoogleAuthException.class, () -> credentials.idTokenWithAudience("Audience", null));
   }
+
+    @Test
+    public void refresh_trustBoundarySuccess() throws IOException {
+       TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+        TrustBoundary.setEnvironmentProviderForTest(environmentProvider);
+        environmentProvider.setEnv("GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT", "1");
+        String defaultAccountEmail = "default@email.com";
+        MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+        TrustBoundary trustBoundary = new TrustBoundary("0x80000", Collections.singletonList("us-central1"));
+        transportFactory.transport.setTrustBoundary(trustBoundary);
+        transportFactory.transport.setServiceAccountEmail(defaultAccountEmail);
+
+        ComputeEngineCredentials credentials =
+                ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+        Map<String, List<String>> headers = credentials.getRequestMetadata();
+        assertEquals(headers.get("x-allowed-locations"), Arrays.asList("0x80000"));
+    }
+
+    @Test
+    public void refresh_trustBoundaryFails_throwsIOException() throws IOException {
+        TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+        TrustBoundary.setEnvironmentProviderForTest(environmentProvider);
+        environmentProvider.setEnv("GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT", "1");
+
+        MockMetadataServerTransportFactory transportFactory = new MockMetadataServerTransportFactory();
+
+        ComputeEngineCredentials credentials =
+                ComputeEngineCredentials.newBuilder().setHttpTransportFactory(transportFactory).build();
+
+        try {
+            credentials.refresh();
+        } catch (IOException e) {
+            assertTrue("The exception message should explain why the refresh failed.",
+                    e.getMessage().contains("Failed to refresh trust boundary and no cached value is available."));
+        }
+    }
 
   static class MockMetadataServerTransportFactory implements HttpTransportFactory {
 

--- a/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/ImpersonatedCredentialsTest.java
@@ -71,6 +71,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -154,6 +156,8 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
   private static final String REFRESH_TOKEN = "dasdfasdffa4ffdfadgyjirasdfadsft";
   public static final List<String> DELEGATES =
       Arrays.asList("sa1@developer.gserviceaccount.com", "sa2@developer.gserviceaccount.com");
+  public static final TrustBoundary TRUST_BOUNDARY =
+      new TrustBoundary("0x80000", Arrays.asList("us-central1"));
 
   private GoogleCredentials sourceCredentials;
   private MockIAMCredentialsServiceTransportFactory mockTransportFactory;
@@ -177,6 +181,7 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
             .setHttpTransportFactory(transportFactory)
             .build();
     transportFactory.transport.addServiceAccount(SA_CLIENT_EMAIL, ACCESS_TOKEN);
+    transportFactory.transport.setTrustBoundary(TRUST_BOUNDARY);
 
     return sourceCredentials;
   }
@@ -1268,6 +1273,72 @@ public class ImpersonatedCredentialsTest extends BaseSerializationTest {
     assertEquals(targetCredentials.hashCode(), deserializedCredentials.hashCode());
     assertEquals(targetCredentials.toString(), deserializedCredentials.toString());
     assertSame(deserializedCredentials.clock, Clock.SYSTEM);
+  }
+
+  @After
+  public void tearDown() {
+    TrustBoundary.setEnvironmentProviderForTest(null);
+  }
+
+  @Test
+  public void refresh_trustBoundarySuccess() throws IOException {
+    TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+    TrustBoundary.setEnvironmentProviderForTest(environmentProvider);
+    environmentProvider.setEnv("GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT", "1");
+
+      // Mock trust boundary response
+      TrustBoundary trustBoundary = TRUST_BOUNDARY;
+
+      mockTransportFactory.getTransport().setTrustBoundary(trustBoundary);
+      mockTransportFactory.getTransport().setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+      mockTransportFactory.getTransport().setAccessToken(ACCESS_TOKEN);
+      mockTransportFactory.getTransport().setExpireTime(getDefaultExpireTime());
+      mockTransportFactory.getTransport().addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "", true);
+
+      ImpersonatedCredentials targetCredentials =
+              ImpersonatedCredentials.create(
+                      sourceCredentials,
+                      IMPERSONATED_CLIENT_EMAIL,
+                      null,
+                      IMMUTABLE_SCOPES_LIST,
+                      VALID_LIFETIME,
+                      mockTransportFactory);
+
+    Map<String, List<String>> headers = targetCredentials.getRequestMetadata();
+    assertEquals(headers.get("x-allowed-locations"), Arrays.asList("0x80000"));
+  }
+
+  @Test
+  public void refresh_trustBoundaryFails_throwsIOException() throws IOException {
+      TestEnvironmentProvider environmentProvider = new TestEnvironmentProvider();
+      TrustBoundary.setEnvironmentProviderForTest(environmentProvider);
+      environmentProvider.setEnv("GOOGLE_AUTH_TRUST_BOUNDARY_ENABLE_EXPERIMENT", "1");
+
+      // Mock trust boundary response
+      TrustBoundary trustBoundary = TRUST_BOUNDARY;
+
+      mockTransportFactory.getTransport().setTargetPrincipal(IMPERSONATED_CLIENT_EMAIL);
+      mockTransportFactory.getTransport().setAccessToken(ACCESS_TOKEN);
+      mockTransportFactory.getTransport().setExpireTime(getDefaultExpireTime());
+      mockTransportFactory.getTransport().addStatusCodeAndMessage(HttpStatusCodes.STATUS_CODE_OK, "", true);
+
+      ImpersonatedCredentials targetCredentials =
+              ImpersonatedCredentials.create(
+                      sourceCredentials,
+
+
+                      IMPERSONATED_CLIENT_EMAIL,
+                      null,
+                      IMMUTABLE_SCOPES_LIST,
+                      VALID_LIFETIME,
+                      mockTransportFactory);
+
+    try {
+        targetCredentials.refresh();
+    } catch (IOException e) {
+      assertTrue("The exception message should explain why the refresh failed.",
+          e.getMessage().contains("Failed to refresh trust boundary and no cached value is available."));
+    }
   }
 
   public static String getDefaultExpireTime() {

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockIAMCredentialsServiceTransport.java
@@ -80,6 +80,8 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
 
   private String universeDomain;
 
+  private TrustBoundary trustBoundary;
+
   private MockLowLevelHttpRequest request;
 
   MockIAMCredentialsServiceTransport(String universeDomain) {
@@ -130,6 +132,10 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
 
   public void setAccessTokenEndpoint(String accessTokenEndpoint) {
     this.iamAccessTokenEndpoint = accessTokenEndpoint;
+  }
+
+  public void setTrustBoundary(TrustBoundary trustBoundary) {
+    this.trustBoundary = trustBoundary;
   }
 
   public MockLowLevelHttpRequest getRequest() {
@@ -221,6 +227,25 @@ public class MockIAMCredentialsServiceTransport extends MockHttpTransport {
                   .setContent(tokenContent);
             }
           };
+    } else if (url.endsWith("/allowedLocations")) {
+      request =
+          new MockLowLevelHttpRequest(url) {
+            @Override
+            public LowLevelHttpResponse execute() throws IOException {
+              if (trustBoundary == null) {
+                return new MockLowLevelHttpResponse().setStatusCode(404);
+              }
+              GenericJson responseJson = new GenericJson();
+              responseJson.setFactory(OAuth2Utils.JSON_FACTORY);
+              responseJson.put("encoded_locations", trustBoundary.getEncodedLocations());
+              responseJson.put("locations", trustBoundary.getLocations());
+              String content = responseJson.toPrettyString();
+              return new MockLowLevelHttpResponse()
+                  .setContentType(Json.MEDIA_TYPE)
+                  .setContent(content);
+            }
+          };
+      return request;
     } else {
       return super.buildRequest(method, url);
     }

--- a/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/MockTokenServerTransport.java
@@ -77,6 +77,11 @@ public class MockTokenServerTransport extends MockHttpTransport {
   private MockLowLevelHttpRequest request;
   private ClientAuthenticationType clientAuthenticationType;
   private PKCEProvider pkceProvider;
+  private TrustBoundary trustBoundary;
+
+  public void setTrustBoundary(TrustBoundary trustBoundary) {
+    this.trustBoundary = trustBoundary;
+  }
 
   public MockTokenServerTransport() {}
 
@@ -318,6 +323,25 @@ public class MockTokenServerTransport extends MockHttpTransport {
               return new MockLowLevelHttpResponse()
                   .setContentType(Json.MEDIA_TYPE)
                   .setContent(refreshText);
+            }
+          };
+      return request;
+    } else if (urlWithoutQuery.endsWith("/allowedLocations")) {
+      request =
+          new MockLowLevelHttpRequest(url) {
+            @Override
+            public LowLevelHttpResponse execute() throws IOException {
+              if (trustBoundary == null) {
+                return new MockLowLevelHttpResponse().setStatusCode(404);
+              }
+              GenericJson responseJson = new GenericJson();
+              responseJson.setFactory(JSON_FACTORY);
+              responseJson.put("encoded_locations", trustBoundary.getEncodedLocations());
+              responseJson.put("locations", trustBoundary.getLocations());
+              String content = responseJson.toPrettyString();
+              return new MockLowLevelHttpResponse()
+                  .setContentType(Json.MEDIA_TYPE)
+                  .setContent(content);
             }
           };
       return request;

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
-      <version>1.35.0</version>
+        <version>1.35.0</version>
     </dependency>
 
 <!--    IAM dependency-->
@@ -80,4 +80,3 @@
   </dependencies>
 
 </project>
-


### PR DESCRIPTION
Introduces trust boundary feature to Java library.

This change covers Service Accounts, Impersonated and GCE Credential flows.

Will add unit tests post initial review.


