### PR TITLE
chore: Remmove class cass for getProjectId in GDCHCredentials

### DIFF
--- a/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
+++ b/oauth2_http/javatests/com/google/auth/oauth2/DefaultCredentialsProviderTest.java
@@ -410,7 +410,7 @@ public class DefaultCredentialsProviderTest {
 
     assertNotNull(defaultCredentials);
     assertTrue(defaultCredentials instanceof GdchCredentials);
-    assertEquals(GDCH_SA_PROJECT_ID, ((GdchCredentials) defaultCredentials).getProjectId());
+    assertEquals(GDCH_SA_PROJECT_ID, defaultCredentials.getProjectId());
     assertEquals(
         GDCH_SA_SERVICE_IDENTITY_NAME,
         ((GdchCredentials) defaultCredentials).getServiceIdentityName());
@@ -423,7 +423,7 @@ public class DefaultCredentialsProviderTest {
         ((GdchCredentials) defaultCredentials).createWithGdchAudience(GDCH_SA_API_AUDIENCE);
     assertNotNull(defaultCredentials);
     assertTrue(defaultCredentials instanceof GdchCredentials);
-    assertEquals(GDCH_SA_PROJECT_ID, ((GdchCredentials) defaultCredentials).getProjectId());
+    assertEquals(GDCH_SA_PROJECT_ID, defaultCredentials.getProjectId());
     assertEquals(
         GDCH_SA_SERVICE_IDENTITY_NAME,
         ((GdchCredentials) defaultCredentials).getServiceIdentityName());


### PR DESCRIPTION
From: https://github.com/googleapis/google-auth-library-java/pull/1813#pullrequestreview-3320455193