### PR TITLE
chore: Only enable renovate bot for CVE PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,12 @@
   "ignorePaths": [
     ".kokoro/requirements.txt"
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "maven": {
+    "enabled": false
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Attempt to help cut down the number of existing renovate bot PRs and only create PRs that we need to action on.

Manual bumps are required for shared-configs, guava, etc.