### PR TITLE
feat: Add getProjectId getter for ComputeEngineCredentials

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
+++ b/oauth2_http/java/com/google/auth/oauth2/ComputeEngineCredentials.java
@@ -635,6 +635,11 @@ public class ComputeEngineCredentials extends GoogleCredentials
     return false;
   }
 
+  @VisibleForTesting
+  void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
   private static boolean pingComputeEngineMetadata(
       HttpTransportFactory transportFactory, DefaultCredentialsProvider provider) {
     GenericUrl tokenUrl = new GenericUrl(getMetadataServerUrl(provider));


### PR DESCRIPTION
This PR adds a project ID getter for `ComputeEngineCredentials`.

This is a follow-up to work done in #1813 

