### PR TITLE
build: add protobuf-4.x-rc configuration to release please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -46,3 +46,4 @@ branches:
     handleGHRelease: true
     releaseType: java-yoshi
     branch: protobuf-4.x-rc
+    manifest: true


### PR DESCRIPTION
Configured in https://github.com/googleapis/google-auth-library-java/blob/protobuf-4.x-rc/release-please-config.json