### PR TITLE
chore: cleanup release-please config

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -2,24 +2,24 @@ bumpMinorPreMajor: true
 handleGHRelease: true
 releaseType: java-yoshi
 branches:
-    - releaseType: java-lts
-      branch: 0.25.2-sp
+    - branch: 0.25.2-sp
+      releaseType: java-lts
     - branch: java7
-    - releaseType: java-backport
-      branch: 1.2.x
-    - releaseType: java-backport
-      branch: 1.12.x
-    - releaseType: java-backport
-      branch: 1.6.x
-    - releaseType: java-backport
-      branch: 1.19.x
-    - releaseType: java-backport
-      branch: 1.20.x
-    - releaseType: java-backport
-      branch: 1.23.x
-    - releaseType: java-backport
-      branch: 1.33.x
-    - releaseType: java-backport
-      branch: 1.36.x
+    - branch: 1.2.x
+      releaseType: java-backport
+    - branch: 1.12.x
+      releaseType: java-backport
+    - branch: 1.6.x
+      releaseType: java-backport
+    - branch: 1.19.x
+      releaseType: java-backport
+    - branch: 1.20.x
+      releaseType: java-backport
+    - branch: 1.23.x
+      releaseType: java-backport
+    - branch: 1.33.x
+      releaseType: java-backport
+    - branch: 1.36.x
+      releaseType: java-backport
     - branch: protobuf-4.x-rc
       manifest: true


### PR DESCRIPTION
This PR cleans up the .github/release-please.yml file by removing redundant options and the bump-minor-pre-major setting for major releases.