### PR TITLE
chore: Remove Code Coverage requirements

### DIFF
--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -234,19 +234,6 @@
           <reportNameSuffix>sponge_log</reportNameSuffix>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
-        <executions>
-          <execution>
-            <id>jacoco-check</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
91% code coverage is quite high. We'll rely on maintainers and developers for best effort of coverage on implementations instead of an arbitrary metric.

This also removes issues from local development:
```
[WARNING] Rule violated for bundle google-auth-library-oauth2-http: lines covered ratio is 0.881, but expected minimum is 0.910
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Google Auth Library for Java 1.43.1-SNAPSHOT:
[INFO]
[INFO] Google Auth Library for Java ....................... SUCCESS [  1.582 s]
[INFO] Google Auth Library for Java - Credentials ......... SUCCESS [  1.814 s]
[INFO] Google Auth Library for Java - OAuth2 HTTP ......... FAILURE [01:05 min]
[INFO] Google Auth Library for Java - Google App Engine ... SKIPPED
[INFO] Google Auth Library for Java BOM ................... SUCCESS [  0.082 s]
[INFO] Google Auth Library for Java - Cab Token Generator . SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:09 min (Wall Clock)
[INFO] Finished at: 2026-03-19T17:12:36-04:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.jacoco:jacoco-maven-plugin:0.8.12:check (jacoco-check) on project google-auth-library-oauth2-http: Coverage checks have not been met. See log for details. -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :google-auth-library-oauth2-http
```