### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/scripts/downscoping-with-cab-setup.sh
+++ b/scripts/downscoping-with-cab-setup.sh
@@ -74,18 +74,18 @@ service_account_email=""
 gcloud config set project ${project_id}
 
 # Create the GCS bucket.
-gsutil mb -b on -l us-east1 gs://${bucket_id}
+gcloud storage buckets create gs://${bucket_id} --uniform-bucket-level-access --location us-east1
 
 # Give the specified service account the objectAdmin role for this bucket.
-gsutil iam ch serviceAccount:${service_account_email}:objectAdmin gs://${bucket_id}
+gcloud storage buckets add-iam-policy-binding gs://${bucket_id} --member=serviceAccount:${service_account_email} --role=roles/storage.objectAdmin
 
 # Create both objects.
 echo "first" >> ${first_object}
 echo "second" >> ${second_object}
 
 # Upload the created objects to the bucket.
-gsutil cp ${first_object} gs://${bucket_id}
-gsutil cp ${second_object} gs://${bucket_id}
+gcloud storage cp ${first_object} gs://${bucket_id}
+gcloud storage cp ${second_object} gs://${bucket_id}
 
 echo "Bucket ID: "${bucket_id}
 echo "First object ID: "${first_object}


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
