### PR TITLE
chore: replace googleapis-auth with cloud-sdk-auth-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
 # The @googleapis/cloud-sdk-java-team is the default owner for changes in this repo
-*                                   @googleapis/cloud-sdk-java-team @googleapis/googleapis-auth
+*                                   @googleapis/cloud-sdk-java-team @googleapis/cloud-sdk-auth-team
 
 # The java-samples-reviewers team is the default owner for samples changes
 samples/**/*.java                   @googleapis/java-samples-reviewers
@@ -13,58 +13,58 @@ samples/**/*.java                   @googleapis/java-samples-reviewers
 # Generated snippets should not be owned by samples reviewers
 samples/snippets/generated/         @googleapis/cloud-sdk-java-team
 
-# 3PI-related files and related base classes - joint ownership between googleapis-auth, aion-team, and cloud-java-team
-oauth2_http/java/com/google/auth/oauth2/ActingParty.java                      		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java                   		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/AwsSecurityCredentialsSupplier.java   		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/AwsDates.java                         		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/AwsRequestSignature.java              		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/AwsRequestSigner.java                 		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/AwsSecurityCredentials.java           		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java         		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java       		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java            		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/EnvironmentProvider.java              		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/ExecutableHandler.java                		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/ExecutableResponse.java               		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java       		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/FileIdentityPoolSubjectTokenSupplier.java 	    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java                		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java          		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/IdentityPoolSubjectTokenSupplier.java		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java          		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/InternalAwsSecurityCredentialsSupplier.java	    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java                		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java     		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/OAuthException.java                   		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java         		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/PluggableAuthException.java           		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/PluggableAuthHandler.java             		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java                		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeRequest.java          		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeResponse.java         		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/SystemEnvironmentProvider.java        		    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/java/com/google/auth/oauth2/UrlIdentityPoolSubjectTokenSupplier.java	    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/AwsCredentialsTest.java                           @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/AwsRequestSignerTest.java                         @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/CredentialAccessBoundaryTest.java                 @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/DefaultCredentialsProviderTest.java               @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/DownscopedCredentialsTest.java                    @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/ExecutableResponseTest.java                       @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/ExternalAccountCredentialsTest.java               @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/ITDownscopingTest.java                            @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/ITWorkloadIdentityFederationTest.java             @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/IdentityPoolCredentialsTest.java                  @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/ImpersonatedCredentialsTest.java                  @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/InternalAwsSecurityCredentialsSupplierTest.java	@googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/MockExternalAccountCredentialsTransport.java      @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/MockStsTransport.java                             @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/OAuth2CredentialsTest.java                        @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/OAuth2CredentialsWithRefreshTest.java             @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/OAuthExceptionTest.java                           @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/PluggableAuthCredentialsTest.java                 @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/PluggableAuthExceptionTest.java                   @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/PluggableAuthHandlerTest.java                     @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/StsRequestHandlerTest.java                        @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-oauth2_http/javatests/com/google/auth/TestEnvironmentProvider.java                      @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
-README.md                                                                               @googleapis/googleapis-auth @googleapis/aion-team @googleapis/cloud-sdk-java-team
+# 3PI-related files and related base classes - joint ownership between cloud-sdk-auth-team, aion-team, and cloud-java-team
+oauth2_http/java/com/google/auth/oauth2/ActingParty.java                      		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/AwsCredentials.java                   		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/AwsSecurityCredentialsSupplier.java   		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/AwsDates.java                         		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/AwsRequestSignature.java              		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/AwsRequestSigner.java                 		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/AwsSecurityCredentials.java           		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/CredentialAccessBoundary.java         		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java       		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/DownscopedCredentials.java            		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/EnvironmentProvider.java              		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/ExecutableHandler.java                		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/ExecutableResponse.java               		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/ExternalAccountCredentials.java       		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/FileIdentityPoolSubjectTokenSupplier.java 	    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/GoogleCredentials.java                		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/IdentityPoolCredentials.java          		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/IdentityPoolSubjectTokenSupplier.java		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/ImpersonatedCredentials.java          		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/InternalAwsSecurityCredentialsSupplier.java	    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/OAuth2Credentials.java                		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/OAuth2CredentialsWithRefresh.java     		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/OAuthException.java                   		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/PluggableAuthCredentials.java         		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/PluggableAuthException.java           		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/PluggableAuthHandler.java             		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/StsRequestHandler.java                		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeRequest.java          		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/StsTokenExchangeResponse.java         		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/SystemEnvironmentProvider.java        		    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/java/com/google/auth/oauth2/UrlIdentityPoolSubjectTokenSupplier.java	    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/AwsCredentialsTest.java                           @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/AwsRequestSignerTest.java                         @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/CredentialAccessBoundaryTest.java                 @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/DefaultCredentialsProviderTest.java               @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/DownscopedCredentialsTest.java                    @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/ExecutableResponseTest.java                       @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/ExternalAccountCredentialsTest.java               @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/ITDownscopingTest.java                            @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/ITWorkloadIdentityFederationTest.java             @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/IdentityPoolCredentialsTest.java                  @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/ImpersonatedCredentialsTest.java                  @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/InternalAwsSecurityCredentialsSupplierTest.java	@googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/MockExternalAccountCredentialsTransport.java      @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/MockStsTransport.java                             @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/OAuth2CredentialsTest.java                        @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/OAuth2CredentialsWithRefreshTest.java             @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/OAuthExceptionTest.java                           @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/PluggableAuthCredentialsTest.java                 @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/PluggableAuthExceptionTest.java                   @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/PluggableAuthHandlerTest.java                     @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/StsRequestHandlerTest.java                        @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+oauth2_http/javatests/com/google/auth/TestEnvironmentProvider.java                      @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team
+README.md                                                                               @googleapis/cloud-sdk-auth-team @googleapis/aion-team @googleapis/cloud-sdk-java-team

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -164,7 +164,7 @@ permissionRules:
     permission: admin
   - team: yoshi-admins
     permission: admin
-  - team: googleapis-auth
+  - team: cloud-sdk-auth-team
     permission: admin
   - team: aion-team
     permission: push

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,5 @@
   "repo_short": "google-auth-library-java",
   "library_type": "AUTH",
   "distribution_name": "com.google.auth:google-auth-library",
-  "codeowner_team": "@googleapis/googleapis-auth"
+  "codeowner_team": "@googleapis/cloud-sdk-auth-team"
 }


### PR DESCRIPTION
This PR replaces the old googleapis-auth team with the new cloud-sdk-auth-team.

b/478003109