### PR TITLE
chore: redirect users to google-cloud-java

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**_THIS REPOSITORY IS DEPRECATED. ALL OF ITS CONTENT AND HISTORY HAS BEEN MOVED TO [GOOGLE-CLOUD-JAVA](https://github.com/googleapis/google-cloud-java/tree/main/google-auth-library-java)_**
+
 # Google Auth Library
 
 Open source authentication client library for Java.


### PR DESCRIPTION
Added deprecation notice and redirect to new repository.