### PR TITLE
RFC: Make DefaultCredentialsProvider public.

### DIFF
--- a/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
+++ b/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
  * <p>An instance represents the per-process state used to get and cache the credential and allows
  * overriding the state and environment for testing purposes.
  */
-class DefaultCredentialsProvider {
+public class DefaultCredentialsProvider {
   static final DefaultCredentialsProvider DEFAULT = new DefaultCredentialsProvider();
   static final String CREDENTIAL_ENV_VAR = "GOOGLE_APPLICATION_CREDENTIALS";
   static final String QUOTA_PROJECT_ENV_VAR = "GOOGLE_CLOUD_QUOTA_PROJECT";
@@ -89,7 +89,7 @@ class DefaultCredentialsProvider {
   private boolean checkedAppEngine = false;
   private boolean checkedComputeEngine = false;
 
-  DefaultCredentialsProvider() {}
+  public DefaultCredentialsProvider() {}
 
   /**
    * Returns the Application Default Credentials.
@@ -113,7 +113,7 @@ class DefaultCredentialsProvider {
    * @return the credentials instance.
    * @throws IOException if the credentials cannot be created in the current environment.
    */
-  final GoogleCredentials getDefaultCredentials(HttpTransportFactory transportFactory)
+  public final GoogleCredentials getDefaultCredentials(HttpTransportFactory transportFactory)
       throws IOException {
     synchronized (this) {
       if (cachedCredentials == null) {


### PR DESCRIPTION
Motivation: Bazel uses GoogleCredentials.getApplicationDefault() to locate and load Application Default Credentials. Because this method calls through to a DefaultCredentialsProvider singleton instance which caches the credentials, they can never be reloaded; the only way to force a reload is to restart the Bazel server (see https://github.com/bazelbuild/bazel/issues/23368). With this change, Bazel could instantiate a fresh DefaultCredentialsProvider and call getDefaultCredentials() on it directly.

I'd also accept any alternative that has the effect of forcing a reload (e.g., a GoogleCredentials.getApplicationDefaultUncached() method; or a reload argument to the existing method; or a cache reset method). All I want is to avoid duplicating the DefaultCredentialsProvider logic in Bazel.
