### PR TITLE
ci: GraalVM CI uses existing Truststore if configured

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -81,13 +81,17 @@ graalvm)
     bash .kokoro/populate-secrets.sh
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
     
-    # Extract trustStore if present in JAVA_TOOL_OPTIONS
+    # GraalVM Native Image ignores JAVA_TOOL_OPTIONS at runtime. If the CI environment
+    # injects a custom truststore (e.g., for a proxy) via JAVA_TOOL_OPTIONS, we need to
+    # extract it and pass it explicitly to the native executable.
     TRUST_STORE=""
     if [[ "${JAVA_TOOL_OPTIONS}" =~ -Djavax.net.ssl.trustStore=([^ ]+) ]]; then
         TRUST_STORE="${BASH_REMATCH[1]}"
     fi
     
-    # Build the native tests (stops at package phase, avoiding automatic test execution)
+    # We use 'package' instead of 'test' to build the native image without automatically
+    # running it via the Maven plugin. This allows us to run it manually with the
+    # extracted truststore argument in the next step, avoiding complex Maven XML overrides.
     mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x package -pl 'oauth2_http'
     
     # Run the native tests manually with the truststore

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -80,7 +80,7 @@ graalvm)
     # Run Unit and Integration Tests with Native Image
     bash .kokoro/populate-secrets.sh
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -Djavax.net.debug=all
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -Dnative.image.args="-Djavax.net.debug=all"
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -80,7 +80,7 @@ graalvm)
     # Run Unit and Integration Tests with Native Image
     bash .kokoro/populate-secrets.sh
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http'
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -Djavax.net.debug=all
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -80,7 +80,14 @@ graalvm)
     # Run Unit and Integration Tests with Native Image
     bash .kokoro/populate-secrets.sh
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -Dnative.image.args="-Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts"
+    
+    # Extract trustStore if present in JAVA_TOOL_OPTIONS
+    NATIVE_TEST_RUNTIME_ARGS=""
+    if [[ "${JAVA_TOOL_OPTIONS}" =~ -Djavax.net.ssl.trustStore=([^ ]+) ]]; then
+        NATIVE_TEST_RUNTIME_ARGS="-Djavax.net.ssl.trustStore=${BASH_REMATCH[1]}"
+    fi
+    
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -DnativeTestRuntimeArgs="${NATIVE_TEST_RUNTIME_ARGS}"
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -77,11 +77,10 @@ integration)
     RETURN_CODE=$?
     ;;
 graalvm)
-    unset JAVA_TOOL_OPTIONS
     # Run Unit and Integration Tests with Native Image
     bash .kokoro/populate-secrets.sh
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http'
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -Dnative.image.args="-Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts"
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -77,10 +77,11 @@ integration)
     RETURN_CODE=$?
     ;;
 graalvm)
+    unset JAVA_TOOL_OPTIONS
     # Run Unit and Integration Tests with Native Image
     bash .kokoro/populate-secrets.sh
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -Dnative.image.args="-Djavax.net.debug=all"
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http'
     RETURN_CODE=$?
     ;;
 samples)

--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -82,12 +82,22 @@ graalvm)
     export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/secret_manager/java-it-service-account"
     
     # Extract trustStore if present in JAVA_TOOL_OPTIONS
-    NATIVE_TEST_RUNTIME_ARGS=""
+    TRUST_STORE=""
     if [[ "${JAVA_TOOL_OPTIONS}" =~ -Djavax.net.ssl.trustStore=([^ ]+) ]]; then
-        NATIVE_TEST_RUNTIME_ARGS="-Djavax.net.ssl.trustStore=${BASH_REMATCH[1]}"
+        TRUST_STORE="${BASH_REMATCH[1]}"
     fi
     
-    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x test -pl 'oauth2_http' -DnativeTestRuntimeArgs="${NATIVE_TEST_RUNTIME_ARGS}"
+    # Build the native tests (stops at package phase, avoiding automatic test execution)
+    mvn -B ${INTEGRATION_TEST_ARGS} -ntp -Pnative -Pnative-test -Pslf4j2x package -pl 'oauth2_http'
+    
+    # Run the native tests manually with the truststore
+    CMD="./oauth2_http/target/native-tests --xml-output-dir ./oauth2_http/target/native-test-reports"
+    if [ -n "$TRUST_STORE" ]; then
+        CMD="$CMD -Djavax.net.ssl.trustStore=$TRUST_STORE"
+    fi
+    
+    echo "Executing: $CMD"
+    $CMD
     RETURN_CODE=$?
     ;;
 samples)

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -21,6 +21,10 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <properties>
+    <nativeTestRuntimeArgs></nativeTestRuntimeArgs>
+  </properties>
+
   <profiles>
     <profile>
       <id>native-test</id>
@@ -36,6 +40,15 @@
                 <include>**/IT*.java</include>
                 <include>**/functional/*.java</include>
             </includes>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+            <configuration>
+              <runtimeArgs>
+                <runtimeArg>${nativeTestRuntimeArgs}</runtimeArg>
+              </runtimeArgs>
             </configuration>
           </plugin>
           <plugin>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -21,10 +21,6 @@
     </snapshotRepository>
   </distributionManagement>
 
-  <properties>
-    <nativeTestRuntimeArgs></nativeTestRuntimeArgs>
-  </properties>
-
   <profiles>
     <profile>
       <id>native-test</id>
@@ -41,20 +37,6 @@
                 <include>**/functional/*.java</include>
             </includes>
             </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.graalvm.buildtools</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>test-native</id>
-                <configuration>
-                  <runtimeArgs>
-                    <runtimeArg>${nativeTestRuntimeArgs}</runtimeArg>
-                  </runtimeArgs>
-                </configuration>
-              </execution>
-            </executions>
           </plugin>
           <plugin>
             <artifactId>maven-compiler-plugin</artifactId>

--- a/oauth2_http/pom.xml
+++ b/oauth2_http/pom.xml
@@ -45,11 +45,16 @@
           <plugin>
             <groupId>org.graalvm.buildtools</groupId>
             <artifactId>native-maven-plugin</artifactId>
-            <configuration>
-              <runtimeArgs>
-                <runtimeArg>${nativeTestRuntimeArgs}</runtimeArg>
-              </runtimeArgs>
-            </configuration>
+            <executions>
+              <execution>
+                <id>test-native</id>
+                <configuration>
+                  <runtimeArgs>
+                    <runtimeArg>${nativeTestRuntimeArgs}</runtimeArg>
+                  </runtimeArgs>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
Temporary fix for the new Truststore that is being passed in and breaking the GraalVM checks.